### PR TITLE
Fix Missing Includes & Enforce C++20 in Example CMake

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Explicitly declare C++20
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Define example directory
 add_executable(example_generator example_generator.cpp)
 add_executable(example_immutable_str example_immutable_str.cpp)

--- a/include/jh/generator.h
+++ b/include/jh/generator.h
@@ -32,6 +32,7 @@
 #include <list>
 #include <optional>
 #include <vector>
+#include <variant>
 
 #include "sequence.h"
 

--- a/include/jh/immutable_str.h
+++ b/include/jh/immutable_str.h
@@ -54,6 +54,7 @@
 #include <unordered_set>    // for std::unordered_set
 #include <string>           // for std::string
 #include <string_view>      // for std::string_view
+#include <cstdint>          // for std::uint64_t
 
 namespace jh {
     /**


### PR DESCRIPTION
This PR addresses the issues mentioned in [Issue #XXX] (replace with actual issue number). The following fixes have been implemented:  

### ✅ Fixes:  
1. **Added `<variant>` to `generator.h`**  
   - Ensures `std::monostate` can be used correctly across all platforms.  

2. **Added `<cstdint>` to `immutable_str.h`**  
   - Prevents issues with `std::uint64_t` on certain platforms.  

3. **Updated `example/` CMake Configuration**  
   - Explicitly sets:  
     ```cmake
     set(CMAKE_CXX_STANDARD 20)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
     ```  
   - Ensures C++20 is correctly enforced, especially for MinGW on Windows.  

### 🔍 Testing:  
- Successfully built and tested on **MinGW (Windows)**.
- Verified that `std::monostate` and `std::uint64_t` now work as expected.  
- Ensured that C++20 features are properly enabled in the `example/` folder.  

Please review and let me know if any changes are needed! 🚀  