### PR TITLE
1.1.1 MinGW-fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ install(EXPORT jh-toolkitTargets
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
         "${CMAKE_CURRENT_BINARY_DIR}/jh-toolkit-config-version.cmake"
-        VERSION 1.1.0
+        VERSION 1.1.1
         COMPATIBILITY SameMajorVersion
 )
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JH Toolkit
 
-### **version: 1.1.0**
+### **version: 1.1.1**
 
 **A Modern C++20 Utility Library with Coroutine-based Generators, Immutable Strings, and Sequence Concepts**
 

--- a/include/jh/generator.h
+++ b/include/jh/generator.h
@@ -501,7 +501,7 @@ namespace jh {
          * @return `true` if iterators are not equal, otherwise `false`.
          */
         bool operator!=(const iterator &other) const {
-            return *this != other;
+            return !(*this == other);
         }
 
     private:

--- a/include/jh/generator.h
+++ b/include/jh/generator.h
@@ -51,6 +51,7 @@
 #include <vector>
 #include <variant>
 #include <stdexcept>
+#include <utility>
 
 #include "sequence.h"
 #include "iterator.h"
@@ -71,7 +72,7 @@ namespace jh {
          * This defines the type of values that are yielded by the generator.
          * It enables compatibility with standard iterator traits.
          */
-        using value_type = T;
+        using value_type [[maybe_unused]] = T;
 
         /**
          * @brief Type alias for the iterator associated with the generator.
@@ -182,16 +183,16 @@ namespace jh {
             struct awaiter {
                 promise_type &promise; ///< Reference to the coroutine promise.
 
-                static bool await_ready() { return false; } ///< Always returns false to suspend.
+                [[maybe_unused]] static bool await_ready() { return false; } ///< Always returns false to suspend.
 
-                static void await_suspend(std::coroutine_handle<>) {
+                [[maybe_unused]] static void await_suspend(std::coroutine_handle<>) {
                 } ///< No-op on suspension.
 
                 /**
                  * @brief Retrieves the last sent value or a default.
                  * @return The most recent value sent to the generator.
                  */
-                U await_resume() {
+                [[maybe_unused]] U await_resume() {
                     return promise.last_sent_value.value_or(U{});
                 }
             };
@@ -300,7 +301,7 @@ namespace jh {
          * @brief Retrieves the last value sent to the generator.
          * @return An optional containing the last sent value.
          */
-        std::optional<U> last_sent_value() {
+        [[maybe_unused]] std::optional<U> last_sent_value() {
             return co_ro.promise().last_sent_value;
         }
 
@@ -372,11 +373,11 @@ namespace jh {
      */
     template<typename T, typename U>
     struct iterator<generator<T, U> > {
-        using iterator_category = std::input_iterator_tag;
+        using iterator_category [[maybe_unused]] = std::input_iterator_tag;
         using value_type = T;
-        using difference_type = std::ptrdiff_t;
+        using difference_type [[maybe_unused]] = std::ptrdiff_t;
         using pointer = value_type *;
-        using reference = value_type &;
+        using reference [[maybe_unused]] = value_type &;
 
         std::optional<std::reference_wrapper<generator<T, U> > > gen;
         ///< Reference to the generator (optional to handle end-state).
@@ -500,7 +501,7 @@ namespace jh {
          * @return `true` if iterators are not equal, otherwise `false`.
          */
         bool operator!=(const iterator &other) const {
-            return !(*this == other);
+            return *this != other;
         }
 
     private:

--- a/include/jh/immutable_str.h
+++ b/include/jh/immutable_str.h
@@ -198,7 +198,7 @@ namespace jh {
     };
 
     template<typename T>
-    atomic_str_ptr make_atomic(T str) = delete;
+    [[maybe_unused]] atomic_str_ptr make_atomic(T str) = delete;
 
     /**
      * @brief Creates a shared pointer to an `immutable_str`.

--- a/include/jh/iterator.h
+++ b/include/jh/iterator.h
@@ -63,7 +63,7 @@ namespace jh {
     };
 
     template<typename T>
-    inline constexpr bool has_value_type_v = has_value_type<T>::value;
+    [[maybe_unused]] inline constexpr bool has_value_type_v = has_value_type<T>::value;
 
     /**
      * @brief Concept to check if a type `I` is a valid input iterator.


### PR DESCRIPTION
### jh-toolkit 1.1.1 Update Notes

#### Enhancements and Fixes

1. **Improved GCC Compatibility on MinGW**
   - Adjusted behavior to better match GCC-specific implementations, improving compatibility and preventing unexpected compilation issues.

2. **Fixed `std::exchange` Recognition Issue in GCC**
   - Added `#include <utility>` explicitly to ensure `std::exchange` is correctly recognized by GCC, preventing compilation errors.

3. **Reduced GCC Warnings in Structs**
   - Introduced `[[maybe_unused]]` attributes inside struct definitions to suppress unnecessary warnings generated by GCC.

4. **No `[[maybe_unused]]` for Standalone Functions**
   - The warnings reported by Clang-Tidy on GCC are considered false positives.
   - We **do not** add `[[maybe_unused]]` to standalone functions just to suppress these warnings, as they are unnecessary and should be addressed by tooling improvements rather than code changes.