### PR TITLE
1.2.1 MINGW fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ install(EXPORT jh-toolkitTargets
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
         "${CMAKE_CURRENT_BINARY_DIR}/jh-toolkit-config-version.cmake"
-        VERSION 1.2.0
+        VERSION 1.2.1
         COMPATIBILITY SameMajorVersion
 )
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JH Toolkit
 
-### **version: 1.2.0**
+### **version: 1.2.1**
 
 **A Modern C++20 Utility Library with Coroutine-based Generators, Behavior-defined Iterator Concepts, Immutable Strings, Sequence Concepts and Weak pointer-based Object Pooling.**
 

--- a/include/jh/immutable_str.h
+++ b/include/jh/immutable_str.h
@@ -74,6 +74,7 @@
 #include <string>           // for std::string
 #include <string_view>      // for std::string_view
 #include <cstdint>          // for std::uint64_t
+#include <optional>         // for std::optional
 #include "pool.h"
 
 namespace jh {
@@ -135,7 +136,7 @@ namespace jh {
         /**
          * @brief Deleted move constructor.
          * @details
-         * Unlike typical moveable types, `immutable_str` does not support move semantics because
+         * Unlike typical movable types, `immutable_str` does not support move semantics because
          * immutable objects should not be transferred but rather shared.
          * - Movement would mean transferring ownership of the internal buffer, which contradicts
          *   the intended immutability.
@@ -224,7 +225,7 @@ namespace jh {
      * Using `std::shared_ptr<immutable_str>` avoids unnecessary deep copies of string data.
      */
     using atomic_str_ptr = std::shared_ptr<immutable_str>;
-    using weak_str_ptr = std::weak_ptr<immutable_str>;
+    using weak_str_ptr [[maybe_unused]] = std::weak_ptr<immutable_str>;
 
     /**
      * @brief Custom hash function for `atomic_str_ptr`.


### PR DESCRIPTION
## 1.2.1 MINGW fix

### Fixes:
- Added necessary `#include` directives for `jh/immutable_str` to ensure compatibility with MinGW (GCC).
- Refactored `cleanup` function in `jh/sim_pool.h` to avoid iterator invalidation during `unordered_set` modification.

### Changes:
- Ensured MinGW compatibility by adding missing includes.
- Modified `cleanup()` to collect valid elements first before replacing `pool_`, preventing crashes.
  
Closes #6.
