### PR TITLE
Release 1.3.1: POD hash enum + Conan packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Ignore auxiliary directories from GitHub Linguist stats
+.github/** linguist-vendored
+tools/** linguist-vendored
+
+# Explicitly ignore experimental/ which is not ignored by default
+experimental/* linguist-vendored
+experimental/** linguist-vendored

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,158 @@
+name: Release Conan Packages
+
+on:
+  release:
+    types: [ published ]
+env:
+  pack_version: 1.3.1
+
+jobs:
+
+  pod-package:
+    name: POD Package (Header-Only)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Python & Conan
+        run: |
+          pip install conan
+
+      - name: Set Conan Remote
+        run: conan remote add github "https://conan.pkg.github.com/${{ github.repository_owner }}" --insert
+        env:
+          CONAN_LOGIN_USERNAME: ${{ github.actor }}
+          CONAN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create + Upload POD
+        run: |
+          conan create tools/conan/conanfile-pod.py --user jh --channel stable
+          conan upload jh-toolkit-pod/${{ pack_version }}@jh/stable --remote=github --all --confirm
+        env:
+          CONAN_LOGIN_USERNAME: ${{ github.actor }}
+          CONAN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+  linux-x86_64:
+    name: Full Package - Linux x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install tools
+        run: sudo apt update && sudo apt install -y ninja-build g++ cmake
+
+      - name: Install Conan
+        run: pip install conan
+
+      - name: Set Conan Remote
+        run: conan remote add github "https://conan.pkg.github.com/${{ github.repository_owner }}" --insert
+        env:
+          CONAN_LOGIN_USERNAME: ${{ github.actor }}
+          CONAN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create + Upload (Linux x86_64)
+        run: |
+          conan create tools/conan/conanfile-all.py --user jh --channel stable
+          conan upload jh-toolkit/${{ pack_version }}@jh/stable --remote=github --all --confirm
+        env:
+          CONAN_LOGIN_USERNAME: ${{ github.actor }}
+          CONAN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+  macos-arm64:
+    name: Full Package - macOS ARM
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install tools
+        run: brew install cmake ninja llvm
+
+      - name: Install Conan
+        run: pip install conan
+
+      - name: Set Conan Remote
+        run: conan remote add github "https://conan.pkg.github.com/${{ github.repository_owner }}" --insert
+        env:
+          CONAN_LOGIN_USERNAME: ${{ github.actor }}
+          CONAN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create + Upload (macOS ARM)
+        run: |
+          export CC=/opt/homebrew/opt/llvm/bin/clang
+          export CXX=/opt/homebrew/opt/llvm/bin/clang++
+          conan create tools/conan/conanfile-all.py --user jh --channel stable
+          conan upload jh-toolkit/${{ pack_version }}@jh/stable --remote=github --all --confirm
+        env:
+          CONAN_LOGIN_USERNAME: ${{ github.actor }}
+          CONAN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+  windows-x86_64:
+    name: Full Package - Windows MSYS2 UCRT64
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-ninja
+            python-pip
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Conan
+        run: pip install conan
+
+      - name: Set Conan Remote
+        run: conan remote add github "https://conan.pkg.github.com/${{ github.repository_owner }}" --insert
+        env:
+          CONAN_LOGIN_USERNAME: ${{ github.actor }}
+          CONAN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create + Upload (Windows)
+        run: |
+          conan create tools/conan/conanfile-all.py --user jh --channel stable
+          conan upload jh-toolkit/${{ pack_version }}@jh/stable --remote=github --all --confirm
+        env:
+          CONAN_LOGIN_USERNAME: ${{ github.actor }}
+          CONAN_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+  # Linux ARM optional job using docker cross-build
+  linux-arm64:
+    name: Full Package - Linux ARM64 (Cross)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install Docker & Conan
+        run: |
+          sudo apt update && sudo apt install -y docker.io python3-pip
+          pip install conan
+
+      - name: Cross-Build using Docker (experimental)
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/src -w /src arm64v8/ubuntu bash -c "
+            apt update && apt install -y build-essential cmake ninja-build python3-pip &&
+            pip install conan &&
+            conan profile detect &&
+            conan remote add github https://conan.pkg.github.com/${{ github.repository_owner }} --insert &&
+            conan create tools/conan/conanfile-all.py --user jh --channel stable &&
+            conan upload jh-toolkit/${{ pack_version }}@jh/stable --remote=github --all --confirm
+          "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(GNUInstallDirs)  # Ensure standardized installation directories
 
-set(PROJECT_VERSION 1.3.0)
+set(PROJECT_VERSION 1.3.1)
 
 # Register custom build type
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo;MinSizeRel;FastDebug" CACHE STRING "" FORCE)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # JH Toolkit
 
-### **version: 1.3.0**
+### **version: 1.3.1**
 
 **A Modern, Modular C++20 Toolkit for High-Performance Generic Programming — Featuring POD Utilities, Immutable Structures, Coroutine Generators, Concept-Driven Abstractions, and Lightweight Object Pools.**
 
@@ -20,38 +20,38 @@
 
 ---
 
-## 🚀 What's New in 1.3.x
+## 🚀 What's New in 1.3.1
 
-JH Toolkit `1.3.x` brings enhancements focused on **STL interop**, **runtime-optimized structures**, and **modern `C++20` concept design** — all while retaining **zero-overhead abstractions**.
+JH Toolkit `1.3.1` introduces targeted enhancements to the **POD system**, along with early preparations for **Conan packaging via GitHub**.
 
-- ✨ **`runtime_arr<T>`**  
-  A fixed-size, heap-allocated array where **size is known at runtime**.  
-  Designed to offer **raw-layout performance** and STL-like usability without dynamic resizing.  
-  When initialized with primitive or POD types, `runtime_arr` avoids unnecessary heap operations and performs faster than `std::vector` in many **fully-initialized** scenarios (e.g., when compared to `std::vector(N)`).
+### 🔹 POD Hash Support Updates
 
-- 🔁 **`sequence`** + **`views`**  
-  `sequence` now supports `.to_range()` to expose **`std::ranges::input_range`-compatible views**, enabling smooth STL interop.  
-  A new module `jh::views` introduces allocation-free range adaptors like `enumerate`, `zip`, and more — **based on `sequence` rather than `range`**, ensuring type safety without RTTI.
+- ✅ `pod::string_view`: Now supports **selectable hash algorithms** via `hash(jh::utils::hash_fn::c_hash)`, while keeping API and default behavior unchanged (`fnv1a64`).
+- 🆕 `pod::bytes_view`: Adds a `.hash(...)` method with the same selectable hash algorithm support.
 
-- 🌀 **`generator<T>`**  
-  Added support for **generator factories from callable objects**, including lambdas that return a `co_yield` generator.  
-  This allows simple coroutine-based logic to integrate with pipelines via `to_range()` — provided the generator is of the **non-`send`** (pure `co_yield`) kind.
+#### 🧩 Available Algorithms (`c_hash`)
+```cpp
+enum class c_hash : std::uint8_t {
+    fnv1a64 = 0,  // default
+    fnv1_64 = 1,
+    djb2    = 2,
+    sdbm    = 3
+};
+```
 
-- 🔒 **`immutable_str`**  
-  Improved hash interop, transparent pointer compatibility, and ABI-safe layout.  
-  Now supports **transparent key lookup** for hash tables:
+- The hash value is computed **purely from raw byte content**, ignoring type semantics.
+- If `data == nullptr` or an invalid enum is provided, the return value is `-1`.
 
-  ```c++
-  std::unordered_set<jh::atomic_str_ptr, jh::atomic_str_hash, jh::atomic_str_eq> pool;
-  pool.insert(jh::make_atomic("cached"));
+> 💡 These changes make hash computation more flexible while maintaining full backward compatibility.
 
-  if (pool.find("cached") != pool.end()) {
-      // ✅ No need to construct immutable_str for lookup
-  }
-  ```
+---
 
-> These updates make `1.3.x` the most robust and STL-aligned version yet — ideal for performance-focused, modern C++ development across Linux, macOS, and Windows.
+### 📦 Conan Packaging (Planned)
 
+Initial setup for a **Conan-based package** is underway:
+
+- Will support `conan install jh-toolkit/...` from GitHub Packages
+- Makes `jh-toolkit` easier to consume in modern C++ build systems
 
 ---
 

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,7 +1,7 @@
 {
   "project": {
     "name": "JH-Toolkit",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "A cross-platform C++20 toolkit library",
     "platforms": [
       "Ubuntu",

--- a/docs/pod.md
+++ b/docs/pod.md
@@ -361,6 +361,10 @@ JH_ASSERT_POD_LIKE(Packet);
 Packet pkt{123, 0b0101};
 auto view = jh::pod::bytes_view::from(pkt);
 Packet copy = view.clone<Packet>();
+
+// since v1.3.1
+[[nodiscard]] constexpr std::uint64_t
+hash(jh::utils::hash_fn::c_hash hash_method = jh::utils::hash_fn::c_hash::fnv1a64) const noexcept;
 ```
 
 #### 🧠 Design Intent
@@ -368,6 +372,8 @@ Packet copy = view.clone<Packet>();
 - `.from(...)` creates a byte-level view over object or array memory.
 - `.at<T>()` and `.fetch<T>()` reinterpret contents as typed structs (with optional offset).
 - `.clone<T>()` **copies** content into a stack-allocated object (`T must be pod_like`).
+- `.hash(hash_method)` computes a 64-bit hash of the byte content — based only on **raw data and length**, not on any type semantics.  
+  Returns `-1` if `data == nullptr`, or if an invalid `c_hash` enum is passed.
 
 #### ⚠️ Safety Note
 
@@ -468,8 +474,11 @@ bool ends_with(const string_view& suffix) const noexcept;
 uint64_t find(char ch) const noexcept;
 
 string_view sub(uint64_t offset, uint64_t len = 0) const noexcept;
-uint64_t hash() const noexcept;
 void copy_to(char* buffer, uint64_t max_len) const noexcept;
+
+// updated by v1.3.1
+[[nodiscard]] constexpr std::uint64_t
+hash(jh::utils::hash_fn::c_hash hash_method = jh::utils::hash_fn::c_hash::fnv1a64) const noexcept;
 ```
 
 #### 💡 Example
@@ -477,6 +486,12 @@ void copy_to(char* buffer, uint64_t max_len) const noexcept;
 jh::pod::string_view name{"abc", 3};
 if (name.starts_with("a")) ...
 ```
+
+#### 🧠 Design Intent
+
+- `string_view` is intended for fast, POD-safe, non-owning string slices.
+- `.hash(hash_method)` computes a stable 64-bit hash based on string **content and length**, not null-termination.  
+  Returns `-1` if `data == nullptr`, or if an invalid `c_hash` enum is used.
 
 ---
 

--- a/examples/example_pod_basics.cpp
+++ b/examples/example_pod_basics.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <cstring>
 #include <numeric>
+#include <iomanip> // for std::setw
 
 namespace example {
 
@@ -130,6 +131,57 @@ namespace example {
         const pod::string_view sv{buffer.data, std::strlen(message)};
         std::cout << "String view over buffer: " << std::string_view(sv.data, sv.len) << "\n";
     }
+    /**
+     * @brief Demonstrates matrix-style reinterpretation from flat array using bytes_view::fetch
+     */
+    void matrix_view_usage() {
+        std::cout << "\n\U0001F539 pod::array as flat matrix view:\n";
+
+        constexpr std::size_t Rows = 3;
+        constexpr std::size_t Cols = 4;
+
+        // Flat storage: 3 rows * 4 cols
+        pod::array<int, Rows * Cols> flat{};
+        std::iota(flat.begin(), flat.end(), 1); // Fill with 1..12
+
+        const auto view = pod::bytes_view::from(flat);
+
+        std::cout << "Matrix as rows:\n";
+
+        for (std::size_t row = 0; row < Rows; ++row) {
+            const auto* r = view.fetch<pod::array<int, Cols>>(row * sizeof(pod::array<int, Cols>));
+            if (r != nullptr) {
+                for (int val : *r) {
+                    std::cout << std::setw(2) << val << " ";
+                }
+                std::cout << "\n";
+            }
+        }
+    }
+    /**
+     * @brief Demonstrates full reinterpretation of flat array into array<array<int, Cols>, Rows>
+     */
+    void matrix_structured_view_usage() {
+        std::cout << "\n\U0001F539 pod::array as structured matrix view (array<array<>>):\n";
+
+        constexpr std::size_t Rows = 3;
+        constexpr std::size_t Cols = 4;
+
+        pod::array<int, Rows * Cols> flat{};
+        std::iota(flat.begin(), flat.end(), 1); // Fill 1..12
+
+        const auto view = pod::bytes_view::from(flat);
+        const auto* matrix = view.fetch<pod::array<pod::array<int, Cols>, Rows>>();
+
+        if (matrix != nullptr) {
+            for (const jh::pod::pod_like auto& row : *matrix) {
+                for (int val : row) {
+                    std::cout << std::setw(2) << val << " ";
+                }
+                std::cout << "\n";
+            }
+        }
+    }
 
 } // namespace example
 
@@ -144,5 +196,7 @@ int main() {
     example::span_usage();
     example::string_view_usage();
     example::array_string_buffer_usage();
+    example::matrix_view_usage();
+    example::matrix_structured_view_usage();
     return 0;
 }

--- a/include/jh/pods/span.h
+++ b/include/jh/pods/span.h
@@ -148,7 +148,4 @@ namespace jh::pod {
         -> span<const std::remove_pointer_t<decltype(c.data())>> {
         return {c.data(), static_cast<std::uint64_t>(c.size())};
     }
-
-    /// @brief Compile-time POD conformance
-    static_assert(pod_like<span<int> >);
 } // namespace jh::pod

--- a/include/jh/pods/string_view.h
+++ b/include/jh/pods/string_view.h
@@ -50,7 +50,7 @@ namespace jh::pod {
      * and provides basic comparison, slicing, hashing, and utility access
      * — all without breaking POD rules.
      */
-    struct string_view final{
+    struct string_view final {
         const char *data;       ///< Pointer to string data (not null-terminated)
         std::uint64_t len;      ///< Number of valid bytes in the view
 
@@ -135,13 +135,23 @@ namespace jh::pod {
         }
 
         /**
-         * @brief FNV-1a 64-bit hash of view content.
-         * @note Not cryptographic. Use only for mapping, bucketing, IDs.
-         * @return 64-bit stable hash of the bytes (or -1 if null).
+         * @brief Hash the byte view content using a selectable non-cryptographic algorithm.
+         *
+         * Provides stable 64-bit hashing over the view contents, using a selectable
+         * algorithm from `jh::utils::hash_fn::c_hash`. Suitable for use in hashing,
+         * lookup tables, unique identifiers, etc.
+         *
+         * @param hash_method Algorithm to use for hashing (default: FNV-1a 64-bit).
+         * @return 64-bit hash of the view data, or `-1` if `data == nullptr`.
+         *
+         * @note This is not a cryptographic hash. Do not use it for security-related logic.
+         * @note If `data` is null, the return value is `-1` as a sentinel.
+         * @note The hash is based only on the byte contents and length, not on type information.
          */
-        [[nodiscard]] constexpr std::uint64_t hash() const noexcept {
+        [[nodiscard]] constexpr std::uint64_t
+        hash(jh::utils::hash_fn::c_hash hash_method = jh::utils::hash_fn::c_hash::fnv1a64) const noexcept {
             if (!data) return static_cast<std::uint64_t>(-1);
-            return utils::hash_fn::fnv1a64(data, len);
+            return utils::hash_fn::hash(hash_method, data, len);
         }
 
         /**

--- a/include/jh/utils/hash_fn.h
+++ b/include/jh/utils/hash_fn.h
@@ -14,18 +14,84 @@
  * limitations under the License.
  */
 
+/**
+ * @file hash_fn.h
+ * @brief constexpr-safe hashing utilities with static algorithm selection.
+ *
+ * Provides multiple 64-bit non-cryptographic hash functions (FNV-1a, FNV-1, DJB2, SDBM)
+ * for use in IDs, bucketing, and lightweight data indexing.
+ *
+ * The enum class `c_hash` selects the algorithm at compile-time.
+ * All functions are constexpr-friendly and avoid heap or STL dependencies.
+ *
+ * Not suitable for cryptographic use.
+ */
+
+
 #pragma once
 
 #include <cstdint>
 
 namespace jh::utils::hash_fn {
 
+    /// Compile-time selectable hash algorithm tag (FNV, DJB2, SDBM, etc.)
+    enum class c_hash : std::uint8_t {
+        fnv1a64 = 0,  ///< FNV-1a 64-bit hash
+        fnv1_64 = 1,  ///< FNV-1 64-bit hash
+        djb2 = 2,  ///< DJB2 hash (classic string hash)
+        sdbm = 3   ///< SDBM hash (used in readdir, DBM)
+    };
+
+    /// FNV-1a 64-bit hash implementation (default choice)
     constexpr std::uint64_t fnv1a64(const char *data, const std::uint64_t size) noexcept {
-           std::uint64_t h = 14695981039346656037ull;
-           for (std::uint64_t i = 0; i < size; ++i) {
-               h ^= static_cast<std::uint8_t>(data[i]);
-               h *= 1099511628211ull;
-           }
-           return h;
-       }
+        std::uint64_t h = 14695981039346656037ull;
+        for (std::uint64_t i = 0; i < size; ++i) {
+            h ^= static_cast<std::uint8_t>(data[i]);
+            h *= 1099511628211ull;
+        }
+        return h;
+    }
+
+    /// FNV-1 64-bit hash (multiply before xor)
+    constexpr std::uint64_t fnv1_64(const char *data, const std::uint64_t size) noexcept {
+        std::uint64_t h = 14695981039346656037ull;
+        for (std::uint64_t i = 0; i < size; ++i) {
+            h *= 1099511628211ull;
+            h ^= static_cast<std::uint8_t>(data[i]);
+        }
+        return h;
+    }
+
+    /// DJB2 hash (hash * 33 + c)
+    constexpr std::uint64_t djb2(const char *str, const std::uint64_t size) noexcept {
+        std::uint64_t hash = 5381;
+        for (std::uint64_t i = 0; i < size; ++i) {
+            hash = ((hash << 5) + hash) + static_cast<std::uint8_t>(str[i]);
+        }
+        return hash;
+    }
+
+    /// SDBM hash (used in several DB engines)
+    constexpr std::uint64_t sdbm(const char *str, const std::uint64_t size) noexcept {
+        std::uint64_t hash = 0;
+        for (std::uint64_t i = 0; i < size; ++i) {
+            hash = static_cast<std::uint8_t>(str[i]) + (hash << 6) + (hash << 16) - hash;
+        }
+        return hash;
+    }
+
+    /// Dispatch to selected hash algorithm based on c_hash
+    constexpr std::uint64_t hash(const c_hash algo, const char *data, const std::uint64_t size) noexcept {
+        switch (algo) {
+            case c_hash::fnv1a64:
+                return fnv1a64(data, size);
+            case c_hash::fnv1_64:
+                return fnv1_64(data, size);
+            case c_hash::djb2:
+                return djb2(data, size);
+            case c_hash::sdbm:
+                return sdbm(data, size);
+        }
+        return static_cast<std::uint64_t>(-1); // Illegal
+    }
 }

--- a/tools/conan/conanfile-all.py
+++ b/tools/conan/conanfile-all.py
@@ -1,0 +1,33 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+
+class JHToolkitFull(ConanFile):
+    name = "jh-toolkit"
+    version = "1.3.1"
+    license = "Apache-2.0"
+    url = "https://github.com/JeongHan-Bae/jh-toolkit"
+    description = "Full modular toolkit for modern C++20 generic programming"
+    settings = "os", "arch", "compiler", "build_type"
+    exports_sources = "CMakeLists.txt", "include/*", "src/*"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["TAR"] = "ALL"
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.includedirs = ["include"]
+        self.cpp_info.libdirs = ["lib"]

--- a/tools/conan/conanfile-pod.py
+++ b/tools/conan/conanfile-pod.py
@@ -1,0 +1,36 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+
+class JHToolkitPOD(ConanFile):
+    name = "jh-toolkit-pod"
+    version = "1.3.1"
+    license = "Apache-2.0"
+    url = "https://github.com/JeongHan-Bae/jh-toolkit"
+    description = "Header-only POD system from JH Toolkit"
+    settings = "os", "arch", "compiler", "build_type"
+    exports_sources = "CMakeLists.txt", "include/*"
+    generators = "CMakeDeps", "CMakeToolchain"
+    no_copy_source = True
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.variables["TAR"] = "POD"
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_id(self):
+        self.info.clear()  # header-only
+
+    def package_info(self):
+        self.cpp_info.includedirs = ["include"]


### PR DESCRIPTION
This PR finalizes version `1.3.1` of JH Toolkit with the following changes:

---

### 🧩 POD System Improvements

- Removed redundant `static_assert` usage in header-only `pod` components
- Introduced `jh::utils::hash_fn::c_hash` enum:
  - Supports 4 hash algorithms: `fnv1a64` (default), `fnv1_64`, `djb2`, and `sdbm`
  - Applied to both `pod::string_view` and `pod::bytes_view`

---

### 📦 Conan Publishing Setup

- Added versioned Conan publishing via GitHub Packages:
  - `jh-toolkit-pod` (header-only)
  - `jh-toolkit` (full build with native targets)
- Platforms covered in release:
  - ✅ Linux x86_64 (GCC)
  - ✅ macOS ARM64 (LLVM Clang)
  - ✅ Windows (MSYS2 UCRT64)
  - 🚀 Linux ARM64 via Docker-based Conan cross-build

---

### 🔧 CMake

- Updated `CMakeLists.txt` version to `1.3.1`

---

### ✅ Status

- All CI tests passed for supported platforms
- Conan packages tested locally and ready for `conan upload`

---

**Ready for merge into `main`**
