### PR TITLE
[1.3.2] Prepare release: version bump, docs finalized, CMake SIMD update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: ctest --test-dir build-fastdebug --output-on-failure
 
   macos-ci:
-    name: macOS (LLVM Clang)
+    name: macOS (LLVM Clang + libc++)
     runs-on: macos-latest
     steps:
       - name: Checkout repository
@@ -48,13 +48,15 @@ jobs:
         run: |
           brew install cmake ninja llvm
 
-      - name: Configure (FastDebug with LLVM Clang)
+      - name: Configure (FastDebug with LLVM Clang + libc++)
         run: >
           cmake -B build-fastdebug
           -DCMAKE_BUILD_TYPE=FastDebug
           -G Ninja
           -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang
           -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++
+          -DCMAKE_CXX_FLAGS="-std=c++20 -stdlib=libc++"
+          -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -lc++abi"
 
       - name: Build
         run: cmake --build build-fastdebug -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,23 +38,29 @@ jobs:
         run: ctest --test-dir build-fastdebug --output-on-failure
 
   macos-ci:
-    name: macOS (LLVM Clang + libc++)
+    name: macOS (LLVM Clang 20 + libc++)
     runs-on: macos-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Dependencies (LLVM Clang + CMake + Ninja)
+      - name: Install Dependencies (LLVM@20 + CMake + Ninja)
         run: |
-          brew install cmake ninja llvm
+          brew install cmake ninja llvm@20
+          brew link llvm@20 --force
 
-      - name: Configure (FastDebug with LLVM Clang + libc++)
+      - name: Show compiler version
+        run: |
+          clang++ --version
+          /opt/homebrew/opt/llvm@20/bin/clang++ --version
+
+      - name: Configure (FastDebug with LLVM 20 + libc++)
         run: >
           cmake -B build-fastdebug
           -DCMAKE_BUILD_TYPE=FastDebug
           -G Ninja
-          -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm/bin/clang
-          -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm/bin/clang++
+          -DCMAKE_C_COMPILER=/opt/homebrew/opt/llvm@20/bin/clang
+          -DCMAKE_CXX_COMPILER=/opt/homebrew/opt/llvm@20/bin/clang++
           -DCMAKE_CXX_FLAGS="-std=c++20 -stdlib=libc++"
           -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -lc++abi"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(GNUInstallDirs)  # Ensure standardized installation directories
 
-set(PROJECT_VERSION 1.3.1)
+set(PROJECT_VERSION 1.3.2)
 
 # Register custom build type
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo;MinSizeRel;FastDebug" CACHE STRING "" FORCE)
@@ -30,13 +30,50 @@ endif ()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
     message(STATUS "Applying extra CPU optimizations for Release build.")
+    # Detect architecture-specific -march option
+    set(EXTRA_OPT_FLAGS "")
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+        if (NOT CMAKE_CROSSCOMPILING)
+            include(CheckCXXCompilerFlag)
+            check_cxx_compiler_flag("-march=native" HAS_MARCH_NATIVE)
+            if (HAS_MARCH_NATIVE)
+                set(EXTRA_OPT_FLAGS "-march=native")
+            endif ()
+        else ()
+            message(STATUS "Cross-compiling for processor: ${CMAKE_SYSTEM_PROCESSOR}")
+            if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64)$")
+                set(EXTRA_OPT_FLAGS "-march=x86-64-v3")
+            elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+                set(EXTRA_OPT_FLAGS "-march=armv8-a")
+            elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^armv7")
+                set(EXTRA_OPT_FLAGS "-march=armv7-a")
+            else ()
+                message(WARNING "Unknown target architecture: ${CMAKE_SYSTEM_PROCESSOR}, no -march set")
+            endif ()
+        endif ()
 
-    add_compile_options(
-            -march=native
-            -ftree-vectorize
-            -funroll-loops
-            -fno-omit-frame-pointer
-    )
+        message(STATUS "Applied -march flag: ${EXTRA_OPT_FLAGS}")
+
+        # Apply optimization flags based on build type
+        if (CMAKE_BUILD_TYPE STREQUAL "Release")
+            add_compile_options(
+                    ${EXTRA_OPT_FLAGS}
+                    -O3
+                    -ftree-vectorize
+                    -funroll-loops
+                    -fno-omit-frame-pointer
+                    -Wall -Wextra -Wpedantic
+            )
+            message(STATUS "Release build: enabled aggressive optimization")
+        elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")
+            add_compile_options(
+                    -O2
+                    -Wall -Wextra -Wpedantic
+            )
+            message(STATUS "Debug build: light optimization with warnings")
+        endif ()
+    endif ()
+
 endif ()
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_UPPER)
@@ -91,6 +128,7 @@ if (ENABLE_POD)
             ${CMAKE_SOURCE_DIR}/include/jh/utils/hash_fn.h
             ${CMAKE_SOURCE_DIR}/include/jh/utils/platform.h
             ${CMAKE_SOURCE_DIR}/include/jh/utils/typed.h
+            ${CMAKE_SOURCE_DIR}/include/jh/utils/base64.h
             DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/jh/utils
     )
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JH Toolkit
 
-### **version: 1.3.1**
+### **version: 1.3.2**
 
 **A Modern, Modular C++20 Toolkit for High-Performance Generic Programming — Featuring POD Utilities, Immutable
 Structures, Coroutine Generators, Concept-Driven Abstractions, and Lightweight Object Pools.**
@@ -19,33 +19,61 @@ Structures, Coroutine Generators, Concept-Driven Abstractions, and Lightweight O
 [![POD System](https://img.shields.io/badge/pod--system-trivial_types%2C_layout_stable-brown)](docs/pod.md)
 
 ---
+## 🚀 Highlights of v1.3.2 (CI-Stable / LTS-Compatible)
 
-## 🚀 Highlights of v1.3.1 (CI-Stable / LTS-Compatible)
+This release refines **POD utilities**, improves **pool stability**, and updates documentation across the toolkit.
+It also fixes CI hash instability issues by enforcing LLVM Clang 20 with `libc++`.
 
-JH Toolkit `1.3.1` introduces targeted enhancements to the **POD system**, along with early preparations for **Conan
-packaging via GitHub CI**.
+### 🔹 POD System Enhancements
 
-### 🔹 POD Hash Support Updates
+* 🆕 All STL-style POD containers (`pod::span`, `pod::array`, `pod::pair`) now provide **std-compatible type aliases** (e.g. `element_type`, `size_type`), and `pod::string_view` likewise exposes a pseudo-`value_type = char` for seamless interop with `std::string_view`.
+* 🆕 `pod::optional<T>`: clarified ABI (`sizeof == sizeof(T) + 1`), added `value_or` and `nullopt` printing.
+* 🆕 `pod::string_view`: enriched API docs; clarified **content-based equality** vs `span`'s address-based equality.
+* 🆕 Added **`stringify` utilities** (`operator<<`) for all POD wrappers (`array`, `pair`, `optional`, `bitflags`, `bytes_view`, `span`, `string_view`).
 
-- ✅ `pod::string_view`: Now supports **selectable hash algorithms** via `hash(jh::utils::hash_fn::c_hash)`, while
-  keeping API and default behavior unchanged (`fnv1a64`).
-- 🆕 `pod::bytes_view`: Adds a `.hash(...)` method with the same selectable hash algorithm support.
+  * Designed for **human-readable debugging**.
+  * Distinct from **serialization**, which uses `bytes_view + base64`.
+* 📝 Full POD system API docs updated → see [`docs/pod.md`](docs/pod.md).
 
-#### 🧩 Available Algorithms (`c_hash`)
+### 🔹 Pool & String Improvements
 
-```cpp
-enum class c_hash : std::uint8_t {
-    fnv1a64 = 0,  // default
-    fnv1_64 = 1,
-    djb2    = 2,
-    sdbm    = 3
-};
-```
+* 🛠️ `sim_pool`: refined allocation policy to avoid repeated **thrashing near capacity limits**,
+  making pooling behavior smoother under high churn.
+* 🛠️ `immutable_str`: now uses **transparent template deduction** for more stable interop with `std::string_view`,
+  reducing implicit copy overhead in generic code.
+* ✅ Both modules preserve the **same public API**, ensuring compatibility with 1.3.x clients.
 
-- The hash value is computed **purely from raw byte content**, ignoring type semantics.
-- If `data == nullptr` or an invalid enum is provided, the return value is `-1`.
+### 🔹 CI & Compiler Fixes
 
-> 💡 These changes make hash computation more flexible while maintaining full backward compatibility.
+* 🛠️ Explicitly force GitHub CI to use **LLVM Clang 20 + libc++**.
+
+  * Fixes unstable `std::hash` exports seen in intermediate Clang versions.
+  * Local (Clang ≥20.1.3) and old CI builds (15) were stable → issue traced to mid-upgrade CI env.
+
+### 🔹 CMake Build Optimization
+
+* ⚡ Build system no longer defaults to **`-march=native`**.
+* ✅ Instead, applies **portable SIMD-aware `-march` flags** based on platform when cross-compiling (e.g., Docker builds):
+
+  * `x86_64 / amd64` → `-march=x86-64-v3`
+  * `aarch64 / arm64` → `-march=armv8-a`
+  * `armv7` → `-march=armv7-a` (**fallback only, not officially supported**)
+* 🛠 Ensures **safe SIMD optimizations** even in **same-architecture cross-compilation** (e.g., x86→x86, arm→arm).
+* ⚠️ **Heterogeneous cross-compilation is not recommended**:
+
+  * May introduce significant runtime overhead
+  * SIMD optimizations may be ineffective or counterproductive
+* 📌 **Note on `armv7`**: This flag is included only as a *CMake fallback* for toolchains that default to ARMv7.
+  The JH Toolkit does **not support 32-bit platforms** — actual builds will fail the `static_assert(sizeof(size_t) == 8)` check.
+  This fallback exists solely to provide a valid SIMD flag during toolchain detection.
+
+### 🔹 Documentation Updates
+
+* 📚 `sim_pool` and `immutable_str`:
+  updated file headers → `@version 1.2.x → 1.3.x`.
+* 📚 Updated module docs for POD (`docs/pod.md`) and object pools.
+  Clarified migration guidance (`tuple` → `JH_POD_STRUCT`).
+* 📖 `README.md` updated to 1.3.2 with new highlights.
 
 ---
 
@@ -53,7 +81,7 @@ enum class c_hash : std::uint8_t {
 
 Conan packages are now distributed **as `.tar.gz` archives** attached to **GitHub Release Assets**.
 
-**Available (v1.3.1):**
+**Available (v1.3.2):**
 
 - 🧩 `jh-toolkit-pod` — Header-only (platform independent)
 - 🛠️ `jh-toolkit` — Full builds for:
@@ -95,11 +123,11 @@ Conan packages are now distributed **as `.tar.gz` archives** attached to **GitHu
 
 ```bash
 # Download from GitHub Releases
-wget https://github.com/JeongHan-Bae/JH-Toolkit/releases/download/JH-Toolkit-1.3.1/jh-toolkit-linux-x86_64-1.3.1.tar.gz
+wget https://github.com/JeongHan-Bae/JH-Toolkit/releases/download/JH-Toolkit-1.3.2/jh-toolkit-linux-x86_64-1.3.2.tar.gz
 
 # Inject into local Conan 2.x cache
 mkdir -p ~/.conan2/p/jh-toolkit
-tar -xzf jh-toolkit-linux-x86_64-1.3.1.tar.gz -C ~/.conan2/p/jh-toolkit
+tar -xzf jh-toolkit-linux-x86_64-1.3.2.tar.gz -C ~/.conan2/p/jh-toolkit
 ```
 
 > 🔍 Inspect cache layout using `conan list` or `conan cache path`

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,7 +1,7 @@
 {
   "project": {
     "name": "JH-Toolkit",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "A cross-platform C++20 toolkit library",
     "platforms": [
       "Ubuntu",

--- a/docs/sim_pool.md
+++ b/docs/sim_pool.md
@@ -1,6 +1,6 @@
 # 📦 JH Toolkit: `sim_pool` Simple Object Pool API Documentation
 
-📌 **Version:** 1.2  
+📌 **Version:** 1.3  
 📅 **Date:** 2025  
 👤 **Author:** JeongHan-Bae `<mastropseudo@gmail.com>`
 
@@ -14,24 +14,39 @@ The `jh::sim_pool<T, Hash, Eq>` class is a **generic weak pointer-based object p
 It is particularly useful for scenarios where objects are frequently created and destroyed, ensuring **deduplication and automatic cleanup** of expired instances.
 
 ### **Key Features**
+
 ✅ **Automatic Object Pooling**
-- Prevents redundant `std::shared_ptr<T>` allocations by **storing only one instance of semantically identical objects**.
+
+* Prevents redundant `std::shared_ptr<T>` allocations by **storing only one instance of semantically identical objects**.
 
 ✅ **Dynamic Memory Management**
-- **Expands dynamically** when full and **shrinks automatically** when underutilized.
-- Uses `std::atomic<std::uint64_t>` for **efficient, lock-free size tracking**.
+
+* **Expands dynamically** when full and **shrinks automatically** when underutilized.
+* Uses `std::atomic<std::uint64_t>` for **efficient, lock-free size tracking**.
+* Introduces **high/low watermark ratios** (87.5% / 25%) to prevent jittery expand/shrink decisions.
+
+  > 🆕 *Watermark Ratios Added in **v1.3.2***
 
 ✅ **Thread-Safe Implementation**
-- Uses `std::shared_mutex` for **safe concurrent access**.
-- `acquire()` and `cleanup()`(`cleanup_shrink()`) operations are **lock-protected**.
+
+* Uses `std::shared_mutex` for **safe concurrent access**.
+* `acquire()` and `cleanup()`(`cleanup_shrink()`) operations are **lock-protected**.
+* Cleanup, resize decisions, and size checks are now consistently performed under a **single lightweight lock**.
+
+  > 🆕 *Improved in **v1.3.2***
 
 ✅ **Custom Hashing and Equality Support**
-- **Uses content-based hashing** (`Hash`) and equality (`Eq`) instead of pointer-based lookup.
-- Allows **custom pool policies** for managing objects based on their content.
+
+* **Uses content-based hashing** (`Hash`) and equality (`Eq`) instead of pointer-based lookup.
+* Allows **custom pool policies** for managing objects based on their content.
 
 ✅ **Automatic Expiration Handling**
-- Once all shared references are gone, the object **expires and will be removed upon the next cleanup cycle**.
 
+* Once all shared references are gone, the object **expires and will be removed upon the next cleanup cycle**.
+* Public `cleanup`, `cleanup_shrink`, and internal `expand_and_cleanup` now share a **unified design** for consistency.
+
+  > 🆕 *Refactored in **v1.3.2***
+  
 ---
 
 ## **2. When Should You Use `sim_pool<T, Hash, Eq>`?**

--- a/include/jh/immutable_str.h
+++ b/include/jh/immutable_str.h
@@ -289,9 +289,9 @@ namespace jh {
                     while (trailing > leading && detail::is_space_ascii(value[trailing - 1])) {
                         --trailing;
                     }
-                    return std::hash<std::string_view>{}({value + leading, trailing - leading});
+                    return std::hash<std::string_view>{}(std::string_view{value + leading, trailing - leading});
                 }
-                return std::hash<std::string_view>{}(value);  // NOLINT if !auto_trim
+                return std::hash<std::string_view>{}(std::string_view{value});  // NOLINT if !auto_trim
             }
         }
     };

--- a/include/jh/immutable_str.h
+++ b/include/jh/immutable_str.h
@@ -62,7 +62,7 @@
  * - **Constructing**: Supports construction from [C-strings] and [`std::string_view` with mutex protection].
  * - **Pooling Support**: Compatible with `jh::pool` for efficient object pooling.
  *
- * @version 1.2.x
+ * @version 1.3.x
  * @date 2025
  */
 

--- a/include/jh/pod.h
+++ b/include/jh/pod.h
@@ -63,3 +63,4 @@
 #include "pods/string_view.h"
 #include "pods/tools.h"
 #include "pods/optional.h"
+#include "pods/stringify.h"

--- a/include/jh/pods/array.h
+++ b/include/jh/pods/array.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstddef>
 #include "pod_like.h"
 
 namespace jh::pod {
@@ -54,20 +55,31 @@ namespace jh::pod {
      *
      * @warning Do not use this for large arrays or heap-like buffers.
      */
-    template<pod_like T, std::uint16_t N>
-    requires (sizeof(T) * N <= max_pod_array_bytes)
-    struct alignas(alignof(T)) array final{
+    template<pod_like T, std::uint16_t N> requires (sizeof(T) * N <= max_pod_array_bytes)
+    struct alignas(alignof(T)) array final {
         T data[N];
 
-        constexpr T &operator[](std::size_t i) noexcept { return data[i]; }
-        constexpr const T &operator[](std::size_t i) const noexcept { return data[i]; }
+        using value_type = T;
+        using size_type [[maybe_unused]] = std::uint16_t;
+        using difference_type [[maybe_unused]] = std::ptrdiff_t;
+        using reference [[maybe_unused]] = value_type &;
+        using const_reference [[maybe_unused]] = const value_type &;
+        using pointer [[maybe_unused]] = value_type *;
+        using const_pointer [[maybe_unused]] = const value_type *;
 
-        constexpr T *begin() noexcept { return data; }
-        [[nodiscard]] constexpr const T *begin() const noexcept { return data; }
-        constexpr T *end() noexcept { return data + N; }
-        [[nodiscard]] constexpr const T *end() const noexcept { return data + N; }
+        constexpr reference operator[](std::size_t i) noexcept { return data[i]; }
 
-        [[nodiscard]] static constexpr std::size_t size() noexcept { return N; }
+        constexpr const_reference operator[](std::size_t i) const noexcept { return data[i]; }
+
+        constexpr pointer begin() noexcept { return data; }
+
+        [[nodiscard]] constexpr const_pointer begin() const noexcept { return data; }
+
+        constexpr pointer end() noexcept { return data + N; }
+
+        [[nodiscard]] constexpr const_pointer end() const noexcept { return data + N; }
+
+        [[nodiscard]] static constexpr size_type size() noexcept { return N; }
 
         constexpr bool operator==(const array &) const = default;
     };

--- a/include/jh/pods/bits.h
+++ b/include/jh/pods/bits.h
@@ -206,7 +206,7 @@ namespace jh::pod {
 
 
             /// @brief Inverts all bits in-place.
-            constexpr void flip_all() noexcept { bits = ~bits; }
+            [[maybe_unused]] constexpr void flip_all() noexcept { bits = ~bits; }
 
             [[nodiscard]] constexpr std::uint16_t count() const noexcept {
                 return popcount(bits);
@@ -237,7 +237,7 @@ namespace jh::pod {
                 data[bit / 8] &= ~static_cast<std::uint8_t>(1 << (bit % 8));
             }
 
-            constexpr void flip(const std::uint16_t bit) noexcept {
+            [[maybe_unused]] constexpr void flip(const std::uint16_t bit) noexcept {
                 data[bit / 8] ^= static_cast<std::uint8_t>(1 << (bit % 8));
             }
 
@@ -245,8 +245,8 @@ namespace jh::pod {
                 return (data[bit / 8] & static_cast<std::uint8_t>(1 << (bit % 8))) != 0;
             }
 
-            constexpr void set_all() noexcept { *this = max(); }
-            constexpr void reset_all() noexcept { clear(); }
+            [[maybe_unused]] constexpr void set_all() noexcept { *this = max(); }
+            [[maybe_unused]] constexpr void reset_all() noexcept { clear(); }
 
             constexpr bitflags_bytes operator|(const bitflags_bytes &rhs) const noexcept {
                 bitflags_bytes out = *this;
@@ -289,7 +289,7 @@ namespace jh::pod {
             }
 
             /// @brief Inverts all bits in-place.
-            constexpr void flip_all() noexcept {
+            [[maybe_unused]] constexpr void flip_all() noexcept {
                 for (std::uint16_t i = 0; i < NUM_BYTES; ++i)
                     data[i] = static_cast<std::uint8_t>(~data[i]);
             }

--- a/include/jh/pods/optional.h
+++ b/include/jh/pods/optional.h
@@ -1,5 +1,5 @@
 /**
-* Copyright 2025 JeongHan-Bae <mastropseudo@gmail.com>
+ * Copyright 2025 JeongHan-Bae <mastropseudo@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,8 @@ namespace jh::pod {
         std::byte storage[sizeof(T)];
         bool has_value;
 
+        using value_type [[maybe_unused]] = T;
+
         /// @brief Default constructor (empty state). Value must be assigned manually.
         constexpr optional() noexcept = default;
 
@@ -99,6 +101,16 @@ namespace jh::pod {
          * @brief Returns a const reference to the stored value.
          */
         [[nodiscard]] const T &ref() const noexcept { return *get(); }
+
+        /**
+         * @brief Returns stored value if present; otherwise returns fallback.
+         * @param fallback A fallback value to return if empty.
+         * @return Copy of stored or fallback value.
+         */
+        [[nodiscard]] T value_or(T fallback) const noexcept {
+            return has_value ? ref() : fallback;
+        }
+
     };
 
     /**

--- a/include/jh/pods/pair.h
+++ b/include/jh/pods/pair.h
@@ -1,5 +1,5 @@
 /**
-* Copyright 2025 JeongHan-Bae <mastropseudo@gmail.com>
+ * Copyright 2025 JeongHan-Bae <mastropseudo@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,9 @@ namespace jh::pod {
     struct pair final{
         T1 first;
         T2 second;
+
+        using first_type [[maybe_unused]] = T1;
+        using second_type [[maybe_unused]] = T2;
 
         constexpr bool operator==(const pair &) const = default;
     };

--- a/include/jh/pods/pod_like.h
+++ b/include/jh/pods/pod_like.h
@@ -1,5 +1,5 @@
 /**
-* Copyright 2025 JeongHan-Bae <mastropseudo@gmail.com>
+ * Copyright 2025 JeongHan-Bae <mastropseudo@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/jh/pods/span.h
+++ b/include/jh/pods/span.h
@@ -44,6 +44,7 @@
 
 #include <cstdint>   // for uint64_t
 #include <concepts>  // NOLINT for std::convertible_to<>
+#include <type_traits>
 
 #include "pod_like.h"
 
@@ -70,19 +71,28 @@ namespace jh::pod {
         T *data;           ///< Pointer to the first element
         std::uint64_t len; ///< Number of elements
 
+        using element_type [[maybe_unused]] = T;
+        using value_type = std::remove_cv_t<T>;
+        using size_type [[maybe_unused]] = std::uint64_t;
+        using difference_type [[maybe_unused]] = std::ptrdiff_t;
+        using reference [[maybe_unused]] = value_type &;
+        using const_reference [[maybe_unused]] = const value_type &;
+        using pointer [[maybe_unused]] = value_type *;
+        using const_pointer [[maybe_unused]] = const value_type *;
+
         /// @brief Access an element by index (no bounds check).
-        constexpr T &operator[](std::uint64_t index) const noexcept {
+        constexpr const_reference operator[](std::uint64_t index) const noexcept {
             return data[index];
         }
 
         /// @brief Pointer to the first element.
-        [[nodiscard]] constexpr T *begin() const noexcept { return data; }
+        [[nodiscard]] constexpr const_pointer begin() const noexcept { return data; }
 
         /// @brief Pointer to one-past-the-end.
-        [[nodiscard]] constexpr T *end() const noexcept { return data + len; }
+        [[nodiscard]] constexpr const_pointer end() const noexcept { return data + len; }
 
         /// @brief Number of elements in view.
-        [[nodiscard]] constexpr std::uint64_t size() const noexcept { return len; }
+        [[nodiscard]] constexpr size_type size() const noexcept { return len; }
 
         /// @brief Whether the view is empty.
         [[nodiscard]] constexpr bool empty() const noexcept { return len == 0; }
@@ -124,13 +134,13 @@ namespace jh::pod {
     };
 
     /// @brief Create span from a raw array (T[N]).
-    template<typename T, std::size_t N>
+    template<typename T, std::uint64_t N>
     [[nodiscard]] constexpr span<T> to_span(T (&arr)[N]) noexcept {
         return {arr, static_cast<std::uint64_t>(N)};
     }
 
     /// @brief Create span from a const raw array (const T[N]).
-    template<typename T, std::size_t N>
+    template<typename T, std::uint64_t N>
     [[nodiscard]] constexpr span<const T> to_span(const T (&arr)[N]) noexcept {
         return {arr, static_cast<std::uint64_t>(N)};
     }
@@ -144,7 +154,7 @@ namespace jh::pod {
 
     /// @brief Const overload for containers.
     template<detail::LinearContainer C>
-    [[nodiscard]] constexpr auto to_span(const C &c) noexcept
+    [[maybe_unused]] [[nodiscard]] constexpr auto to_span(const C &c) noexcept
         -> span<const std::remove_pointer_t<decltype(c.data())>> {
         return {c.data(), static_cast<std::uint64_t>(c.size())};
     }

--- a/include/jh/pods/string_view.h
+++ b/include/jh/pods/string_view.h
@@ -54,24 +54,32 @@ namespace jh::pod {
         const char *data;       ///< Pointer to string data (not null-terminated)
         std::uint64_t len;      ///< Number of valid bytes in the view
 
+        using value_type = char;
+        using size_type [[maybe_unused]] = std::uint64_t;
+        using difference_type [[maybe_unused]] = std::ptrdiff_t;
+        using reference [[maybe_unused]] = value_type &;
+        using const_reference [[maybe_unused]] = const value_type &;
+        using pointer [[maybe_unused]] = value_type *;
+        using const_pointer [[maybe_unused]] = const value_type *;
+
         // === Iteration & Size ===
 
         /// @brief Index access (no bounds checking).
-        constexpr char operator[](const std::uint64_t index) const noexcept {
+        constexpr const_reference operator[](const std::uint64_t index) const noexcept {
             return data[index];
         }
 
         /// @brief Pointer to the beginning of data.
-        [[nodiscard]] constexpr const char *begin() const noexcept { return data; }
+        [[nodiscard]] constexpr const_pointer begin() const noexcept { return data; }
 
         /** @brief Pointer to end of data (`data + len`).
          *
          * @note This is not null-terminated. Use `len` for bounds.
          */
-        [[nodiscard]] constexpr const char *end() const noexcept { return data + len; }
+        [[nodiscard]] constexpr const_pointer end() const noexcept { return data + len; }
 
         /// @brief View length in bytes.
-        [[nodiscard]] constexpr std::uint64_t size() const noexcept { return len; }
+        [[nodiscard]] constexpr size_type size() const noexcept { return len; }
 
         /// @brief Whether the view is empty (`len == 0`).
         [[nodiscard]] constexpr bool empty() const noexcept { return len == 0; }

--- a/include/jh/pods/stringify.h
+++ b/include/jh/pods/stringify.h
@@ -1,0 +1,177 @@
+#pragma once
+
+#include "pod_like.h"
+#include <ostream>
+#include <sstream>
+#include <iomanip>
+#include "../utils/typed.h"
+#include "../utils/base64.h"
+#include "pair.h"
+#include "array.h"
+#include "bits.h"
+#include "bytes_view.h"
+#include "span.h"
+#include "string_view.h"
+#include "optional.h"
+
+namespace jh::pod {
+
+    template<typename T>
+    concept streamable = requires(std::ostream &os, const T &value) {
+        { os << value } -> std::same_as<std::ostream &>;
+    };
+
+    template<typename T>
+    concept streamable_pod =
+    jh::pod::pod_like<T> &&
+    streamable<T> &&
+    !std::is_fundamental_v<T> &&
+    !std::is_enum_v<T> &&
+    !std::is_pointer_v<T>;
+
+    template<streamable T, uint16_t N>
+    requires(!std::is_same_v<T, char> && // forbid printing char arrays
+             requires(std::ostream &os, T v) {
+                 { os << v }; // T should be printable
+             })
+    inline std::ostream &operator<<(std::ostream &os, const jh::pod::array<T, N> &arr) {
+        os << "[";
+        for (uint16_t i = 0; i < N; ++i) {
+            if (i != 0)
+                os << ", ";
+            os << arr[i];
+        }
+        os << "]";
+        return os;
+    }
+
+    template<uint16_t N>
+    inline std::ostream &operator<<(std::ostream &os, const jh::pod::array<char, N> &str) {
+        os << '"';  // start escaped JSON string
+        for (uint16_t i = 0; i < N && str[i] != '\0'; ++i) {
+            char c = str[i];
+            switch (c) {
+                case '\"':
+                    os << "\\\"";
+                    break;
+                case '\\':
+                    os << "\\\\";
+                    break;
+                case '\b':
+                    os << "\\b";
+                    break;
+                case '\f':
+                    os << "\\f";
+                    break;
+                case '\n':
+                    os << "\\n";
+                    break;
+                case '\r':
+                    os << "\\r";
+                    break;
+                case '\t':
+                    os << "\\t";
+                    break;
+                default:
+                    if (static_cast<unsigned char>(c) < 0x20 || static_cast<unsigned char>(c) > 0x7E) {
+                        os << "\\u"
+                           << std::hex << std::uppercase
+                           << std::setw(4) << std::setfill('0')
+                           << static_cast<int>(static_cast<unsigned char>(c))
+                           << std::dec << std::nouppercase;
+                    } else {
+                        os << c;
+                    }
+            }
+        }
+        os << '"';  // end escaped JSON string
+        return os;
+    }
+
+    inline std::ostream &operator<<(std::ostream &os, jh::typed::monostate &) {
+        os << "null";
+        return os;
+    }
+
+    template<streamable T1, streamable T2>
+    inline std::ostream &operator<<(std::ostream &os, const jh::pod::pair<T1, T2> &t) {
+        os << "{" << t.first << ", " << t.second << "}";
+        return os;
+    }
+
+    template<streamable T>
+    inline std::ostream &operator<<(std::ostream &os, const jh::pod::optional<T> &opt) {
+        if (opt.has()) {
+            os << opt.ref();
+        } else {
+            os << "nullopt";
+        }
+        return os;
+    }
+
+    template<std::uint16_t N>
+    inline std::ostream &operator<<(std::ostream &os, const jh::pod::bitflags<N> &flags) {
+        auto bytes = jh::pod::to_bytes(flags);
+        std::ios_base::fmtflags fmt = os.flags();
+
+        if ((fmt & std::ios_base::basefield) == std::ios_base::hex) {
+            // hex mode
+            os << "0x'";
+            for (int i = bytes.size() - 1; i >= 0; --i) {
+                os << std::hex << std::setw(2) << std::setfill('0')
+                   << static_cast<int>(bytes[i]);
+            }
+        } else {
+            // binary mode
+            os << "0b'";
+            for (int i = bytes.size() - 1; i >= 0; --i) {
+                for (int b = 7; b >= 0; --b)
+                    os << ((bytes[i] >> b) & 1);
+            }
+        }
+        os << "'";
+
+        return os;
+    }
+
+    inline std::ostream &operator<<(std::ostream &os, const jh::pod::bytes_view bv) {
+        os << "base64'";
+        const auto encoded = jh::utils::base64::encode(reinterpret_cast<const uint8_t *>(bv.data), bv.len);
+        os << encoded;
+        os << "'";
+        return os;
+    }
+
+    template<streamable T>
+    inline std::ostream &operator<<(std::ostream &os, const span<T> &sp) {
+        os << "span<" << typeid(T).name() << ">[";
+        for (std::uint64_t i = 0; i < sp.size(); ++i) {
+            if (i != 0) os << ", ";
+            os << sp[i];
+        }
+        os << "]";
+        return os;
+    }
+
+    inline std::ostream &operator<<(std::ostream &os, const string_view &sv) {
+        os << "string_view\"";
+        const auto buffer = std::string_view{sv.data, sv.len};
+        os << buffer;
+        os << "\"";
+        return os;
+    }
+
+    template<streamable_pod Pod>
+    std::string to_string(const Pod& p) {
+        std::ostringstream oss;
+        oss << p;
+        return oss.str();
+    }
+}
+
+namespace jh::typed{
+    inline std::ostream &operator<<(std::ostream &os, const jh::typed::monostate &) {
+        os << "null";
+        return os;
+    }
+}

--- a/include/jh/sim_pool.h
+++ b/include/jh/sim_pool.h
@@ -55,7 +55,7 @@
  * **For automatic pooling of types that already implement `operator==` and `T::hash()`**,
  * consider using `jh::pool<T>` by including `<jh/pool.h>`.
  *
- * @version 1.2.x
+ * @version 1.3.x
  * @date 2025
  */
 

--- a/include/jh/utils/base64.h
+++ b/include/jh/utils/base64.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <cstdint>
+#include <cstddef>
 #include <string>
 #include <vector>
+#include <iterator>
+#include <algorithm>
 #include "../pods/array.h"
 #include "../pods/string_view.h"
 #include "../pods/bytes_view.h"

--- a/include/jh/utils/base64.h
+++ b/include/jh/utils/base64.h
@@ -1,0 +1,187 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "../pods/array.h"
+#include "../pods/string_view.h"
+#include "../pods/bytes_view.h"
+
+namespace jh::utils::base64 {
+
+    static constexpr char kBase64Chars[] =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            "abcdefghijklmnopqrstuvwxyz"
+            "0123456789+/";
+
+    constexpr bool is_base64_char(char c) {
+        return (c >= 'A' && c <= 'Z') ||
+               (c >= 'a' && c <= 'z') ||
+               (c >= '0' && c <= '9') ||
+               c == '+' || c == '/' || c == '=';
+    }
+
+    namespace detail {
+
+        consteval auto make_base64_decode_table() {
+            jh::pod::array<uint8_t, 256> table{};
+
+            // initialize as illegal
+            for (int i = 0; i < 256; ++i) {
+                table[i] = 64;
+            }
+
+            // A–Z
+            for (int i = 'A'; i <= 'Z'; ++i) {
+                table[i] = i - 'A';
+            }
+
+            // a–z
+            for (int i = 'a'; i <= 'z'; ++i) {
+                table[i] = i - 'a' + 26;
+            }
+
+            // 0–9
+            for (int i = '0'; i <= '9'; ++i) {
+                table[i] = i - '0' + 52;
+            }
+
+            table['+'] = 62;
+            table['/'] = 63;
+
+            return table;
+        }
+
+        static constexpr auto kDecodeTable = detail::make_base64_decode_table();
+
+        inline std::vector<uint8_t> decode_base(const std::string &input, std::vector<uint8_t>& output) {
+            const std::size_t len = input.size();
+
+            // Length must be multiple of 4
+            if (len % 4 != 0) {
+                throw std::runtime_error("Invalid base64: input length must be multiple of 4");
+            }
+
+            // Validate all characters
+            if (std::any_of(input.begin(), input.end(), [](char c) {
+                return !is_base64_char(c);
+            })) {
+                throw std::runtime_error("Invalid base64: contains illegal characters");
+            }
+
+            output.reserve(input.size() * 3 / 4);
+
+            for (size_t i = 0; i < input.size(); i += 4) {
+                uint32_t val = 0;
+                int pad = 0;
+
+                for (int j = 0; j < 4; ++j) {
+                    char c = input[i + j];
+                    if (c == '=') {
+                        val <<= 6;
+                        pad++;
+                    } else {
+                        uint8_t decoded = kDecodeTable[static_cast<unsigned char>(c)];
+                        if (decoded == 64) throw std::runtime_error("Invalid character in base64");
+                        val = (val << 6) | decoded;
+                    }
+                }
+
+                output.push_back((val >> 16) & 0xFF);
+                if (pad < 2) output.push_back((val >> 8) & 0xFF);
+                if (pad < 1) output.push_back(val & 0xFF);
+            }
+
+            return output;
+        }
+    }
+
+
+    /**
+     * @brief Encode binary data into a Base64 string
+     * @param data Pointer to input data
+     * @param len Length of input data
+     * @return Base64-encoded string
+     */
+    [[maybe_unused]] inline std::string encode(const uint8_t *data, std::size_t len) noexcept {
+        std::vector<uint8_t> out;
+        out.reserve((len + 2) / 3 * 4);  // estimate output size
+
+        for (std::size_t i = 0; i < len; i += 3) {
+            uint32_t chunk = 0;
+            int pad = 0;
+
+            chunk |= data[i] << 16;
+            if (i + 1 < len) {
+                chunk |= data[i + 1] << 8;
+            } else {
+                pad++;
+            }
+            if (i + 2 < len) {
+                chunk |= data[i + 2];
+            } else {
+                pad++;
+            }
+
+            out.push_back(kBase64Chars[(chunk >> 18) & 0x3F]);
+            out.push_back(kBase64Chars[(chunk >> 12) & 0x3F]);
+            out.push_back(pad >= 2 ? '=' : kBase64Chars[(chunk >> 6) & 0x3F]);
+            out.push_back(pad >= 1 ? '=' : kBase64Chars[chunk & 0x3F]);
+        }
+
+        return {out.begin(), out.end()};
+    }
+
+    /**
+     * @brief Decode a Base64 string into a byte vector
+     * @param input Base64-encoded string
+     * @return Decoded byte vector
+     */
+    [[maybe_unused]] inline std::vector<uint8_t> decode(const std::string &input) {
+        std::vector<uint8_t> output;
+        detail::decode_base(input, output);
+        return output;
+    }
+
+    /**
+     * @brief Decode a Base64 string into a reusable byte buffer and return a view.
+     *
+     * This version decodes the input into the provided `output_buffer` and returns
+     * a `bytes_view` pointing to that buffer. The caller must ensure that
+     * `output_buffer` remains alive for the duration of the view.
+     *
+     * @param input Base64-encoded string
+     * @param output_buffer Target buffer to store decoded bytes (will be cleared and written)
+     * @return `bytes_view` into the decoded content (points to `output_buffer.data()`)
+     *
+     * @warning Do not use the returned view after `output_buffer` is modified or destroyed.
+     * @note This is efficient for zero-copy access patterns, especially in POD systems.
+     */
+    [[maybe_unused]] inline jh::pod::bytes_view decode(const std::string &input, std::vector<uint8_t>& output_buffer) {
+        output_buffer.clear();
+        detail::decode_base(input, output_buffer);
+        return jh::pod::bytes_view::from(output_buffer.data(), output_buffer.size());
+    }
+
+    /**
+     * @brief Decode a Base64 string into a `std::string` and return a `string_view`.
+     *
+     * This version is suitable for text content decoding. It decodes into the
+     * provided `output_buffer` and returns a view into its contents. The buffer
+     * must remain valid as long as the returned `string_view` is in use.
+     *
+     * @param input Base64-encoded string
+     * @param output_buffer Target string to store decoded data (will be overwritten)
+     * @return `string_view` pointing to the decoded text content
+     *
+     * @warning The returned `string_view` becomes invalid if `output_buffer` is destroyed or changed.
+     * @note Use this for UTF-8 or plain text decoding into reusable `std::string` buffers.
+     */
+    [[maybe_unused]] inline jh::pod::string_view decode(const std::string &input, std::string& output_buffer) {
+        std::vector<uint8_t> output;
+        detail::decode_base(input, output);
+        output_buffer.assign(output.begin(), output.end());
+        return {output_buffer.data(), output_buffer.size()};
+    }
+
+} // namespace jh::utils::base64

--- a/include/jh/utils/platform.h
+++ b/include/jh/utils/platform.h
@@ -1,5 +1,5 @@
 /**
-* Copyright 2025 JeongHan-Bae <mastropseudo@gmail.com>
+ * Copyright 2025 JeongHan-Bae <mastropseudo@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/include/jh/views/zip.h
+++ b/include/jh/views/zip.h
@@ -61,7 +61,8 @@ namespace jh::views {
     public:
         zip_view(const R1 &a, const R2 &b)
             : a_(a), b_(b),
-              size_(std::min(std::ranges::size(a), std::ranges::size(b))) {
+              size_(std::min(static_cast<uint64_t>(std::ranges::size(a)),
+                             static_cast<uint64_t>(std::ranges::size(b)))) {
         }
 
         class iterator {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(test_pool test_pool.cpp)
 add_executable(test_runtime_arr test_runtime_arr.cpp)
 add_executable(test_view test_view.cpp)
 add_executable(test_pods test_pod_sys.cpp)
+add_executable(test_base64 test_base64.cpp)
 
 # Ensure Catch2 is linked properly
 target_link_libraries(test_generator PRIVATE jh-toolkit Catch2::Catch2WithMain)
@@ -29,6 +30,7 @@ target_link_libraries(test_pool PRIVATE jh-toolkit Catch2::Catch2WithMain)
 target_link_libraries(test_runtime_arr PRIVATE jh-toolkit Catch2::Catch2WithMain)
 target_link_libraries(test_view PRIVATE jh-toolkit Catch2::Catch2WithMain)
 target_link_libraries(test_pods PRIVATE jh-toolkit Catch2::Catch2WithMain)
+target_link_libraries(test_base64 PRIVATE jh-toolkit Catch2::Catch2WithMain)
 
 # Ensure test executables can find Catch2 headers
 target_include_directories(test_generator PRIVATE ${CMAKE_SOURCE_DIR}/tests)
@@ -38,6 +40,7 @@ target_include_directories(test_pool PRIVATE ${CMAKE_SOURCE_DIR}/tests)
 target_include_directories(test_runtime_arr PRIVATE ${CMAKE_SOURCE_DIR}/tests)
 target_include_directories(test_view PRIVATE ${CMAKE_SOURCE_DIR}/tests)
 target_include_directories(test_pods PRIVATE ${CMAKE_SOURCE_DIR}/tests)
+target_include_directories(test_base64 PRIVATE ${CMAKE_SOURCE_DIR}/tests)
 
 # Register tests with CTest
 add_test(NAME generator_test COMMAND test_generator)
@@ -47,3 +50,4 @@ add_test(NAME sim_pool_test COMMAND test_pool)
 add_test(NAME runtime_arr_test COMMAND test_runtime_arr)
 add_test(NAME view_test COMMAND test_view)
 add_test(NAME pod_test COMMAND test_pods)
+add_test(NAME base64_test COMMAND test_base64)

--- a/tests/test_base64.cpp
+++ b/tests/test_base64.cpp
@@ -1,0 +1,28 @@
+#define CATCH_CONFIG_MAIN
+#include <random>
+#include <catch2/catch_all.hpp>
+#include "jh/utils/base64.h"
+
+TEST_CASE("Base64 Encode/Decode Roundtrip", "[base64]") {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<std::uint8_t> dist(0, 255);
+    std::uniform_int_distribution<std::size_t> len_dist(1, 256);
+
+    constexpr int total_tests = 128;
+
+    for (int i = 0; i < total_tests; ++i) {
+        SECTION("Randomized Test " + std::to_string(i + 1)) {
+            const std::size_t len = len_dist(gen);
+            std::vector<std::uint8_t> input(len);
+            for (auto &byte: input) {
+                byte = dist(gen);
+            }
+
+            const std::string encoded = jh::utils::base64::encode(input.data(), input.size());
+            const auto decoded = jh::utils::base64::decode(encoded);
+
+            REQUIRE(decoded == input);
+        }
+    }
+}


### PR DESCRIPTION
- Updated `CMakeLists.txt` and `README.md` to reflect version `1.3.2`
- Added platform-aware `-march` handling in Release builds
  - Uses `-march=native` when building natively
  - Falls back to arch-specific flags (`x86-64-v3`, `armv8-a`, `armv7-a`) for homogeneous cross-compilation
  - Clarified that heterogeneous cross-compilation is not recommended
- Refined POD system docs (`docs/pod.md`): added `stringify` vs serialization, clarified STL-style type aliases
- Updated `sim_pool` and `immutable_str` docs, version headers bumped to `1.3.x`
- README updated with new highlights and CI/compiler notes
