### PR TITLE
Merge 1.4.1-dev into main

### DIFF
--- a/.aiignore
+++ b/.aiignore
@@ -1,0 +1,98 @@
+# .aiignore, similar to .gitignore, specifies files and directories that should be ignored by AI indexing tools.
+# This helps to exclude irrelevant or sensitive information from being processed.
+
+# ------------------------------------
+# git ignoring rules
+# -------------------------------------
+
+# Build artifacts
+*build*/
+*Build*/
+*BUILD*/
+Debug*/
+Release*/
+out/
+Out*/
+bin/
+lib/
+obj/
+dist/
+CMakeFiles/
+CMakeCache.txt
+Makefile
+cmake_install.cmake
+compile_commands.json
+
+# C++ compiler generated files
+*.o
+*.obj
+*.so
+*.a
+*.lib
+*.dll
+*.exe
+*.exp
+*.pdb
+*.tar.gz
+*.tgz
+
+# Editor-specific files
+.idea/
+.vscode/
+*.suo
+*.ncb
+*.user
+*.sdf
+*.cbp
+*.layout
+*.clangd
+*.ccls-cache/
+*.vscode/
+
+# OS-specific files
+.DS_Store
+Thumbs.db
+
+# Debugging & Logs
+*.log
+*.swp
+*.swo
+*.bak
+
+# Doxygen generated files
+html/
+latex/
+doxy/
+man/
+rtf/
+xml/
+*.tag
+Doxyfile.tmp
+
+# ------------------------------------
+# ai specific files
+# ------------------------------------
+
+# Version control and workflow files
+.github/
+.git/
+
+# Non-semantic parts
+docs/img/
+docs/doxy_settings/
+
+# precompilation helpers, no actual semantics
+src/
+
+# The test includes boundary tests; these syntaxes may cause erroneous heuristics in the AI.
+tests/
+
+# Conan related files
+tools/
+
+# Git, Linguist, and Shield files
+.gitignore
+.gitattributes
+version_badge.json
+
+# C++ engineering-grade library, no secrets or sensitive data

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,11 +4,14 @@ tools/** linguist-vendored
 docs/** linguist-vendored
 
 # Explicitly ignore experimental/ which is not ignored by default
-experimental/* linguist-vendored
 experimental/** linguist-vendored
 
 # Force all headers in include/jh/ to be treated as C++
 include/jh/**/*.h linguist-language=C++
+
+# Force all aggregation headers in include/jh/ to be treated as C++
+include/jh/* linguist-language=C++
+include/jh/*.* -linguist-language
 
 # Explicitly force all examples and tests too
 examples/**/*.h linguist-language=C++

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -28,6 +28,8 @@ on:
       - 'include/jh/**'
       - 'docs/**'
       - '.github/workflows/docs-check.yml'
+      - '.github/workflows/docs_presence_check.py'
+      - '.github/workflows/docs_hygiene_check.py'
 
   pull_request:
     branches:
@@ -37,6 +39,8 @@ on:
       - 'include/jh/**'
       - 'docs/**'
       - '.github/workflows/docs-check.yml'
+      - '.github/workflows/docs_presence_check.py'
+      - '.github/workflows/docs_hygiene_check.py'
 
   workflow_dispatch:
 
@@ -68,8 +72,12 @@ jobs:
           BASE=HEAD^
           TARGET=HEAD
 
-          # Workflow file change → run both
-          if git diff --name-only "$BASE" "$TARGET" -- .github/workflows/docs-check.yml | grep -q .; then
+          # Workflow or check script change → run both
+          if git diff --name-only "$BASE" "$TARGET" -- \
+            .github/workflows/docs-check.yml \
+            .github/workflows/docs_presence_check.py \
+            .github/workflows/docs_hygiene_check.py \
+            | grep -q .; then
             RUN_PRESENCE=true
             RUN_HYGIENE=true
           fi

--- a/.github/workflows/docs-doxygen.yml
+++ b/.github/workflows/docs-doxygen.yml
@@ -27,43 +27,10 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Get Project Version
-        id: get_version
-        run: |
-          if [ -f .github/workflows/generate_dependencies.py ]; then
-            VERSION=$(python .github/workflows/generate_dependencies.py --get-version)
-          else
-            VERSION="unknown"
-          fi
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "PROJECT_VERSION=v$VERSION" >> $GITHUB_ENV
-
-      - name: Get Repository Description
-        id: get_desc
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          DESC=$(curl -s \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/${{ github.repository }} \
-            | jq -r '.description // empty')
-
-          if [ -z "$DESC" ] || [ "$DESC" = "null" ]; then
-            DESC="C++ Toolkit for software engineering"
-          fi
-
-          echo "PROJECT_DESCRIPTION=$DESC" >> $GITHUB_ENV
-
       - name: Generate Doxyfile
-        run: |
-          ESCAPED_VERSION=$(echo "$PROJECT_VERSION" | sed 's/|/\\|/g')
-          ESCAPED_DESC=$(echo "$PROJECT_DESCRIPTION" | sed 's/|/\\|/g')
-
-          sed \
-            -e "s|__VERSION__|$ESCAPED_VERSION|g" \
-            -e "s|__DESCRIPTION__|$ESCAPED_DESC|g" \
-            docs/doxy_settings/Doxyfile > Doxyfile.tmp
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python .github/workflows/generate_doxyfile.py
 
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/docs_hygiene_check.py
+++ b/.github/workflows/docs_hygiene_check.py
@@ -106,6 +106,8 @@ summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
 if summary_path:
     with open(summary_path, "a", encoding="utf-8") as f:
         f.write("\n".join(sections) + "\n")
+else:
+    print("\n".join(sections))
 
 
 # ---------- Warnings (signal only) ----------

--- a/.github/workflows/docs_presence_check.py
+++ b/.github/workflows/docs_presence_check.py
@@ -69,7 +69,8 @@ summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
 if summary_path:
     with open(summary_path, "a", encoding="utf-8") as f:
         f.write("\n".join(sections) + "\n")
-
+else:
+    print("\n".join(sections))
 
 # Emit warning but do NOT fail the job
 if missing_headers:

--- a/.github/workflows/generate_dependencies.py
+++ b/.github/workflows/generate_dependencies.py
@@ -112,7 +112,8 @@ def main(get_version_only=False):
         "project": {
             "name": "JH-Toolkit",
             "version": version,
-            "description": "A cross-platform C++20 toolkit library",
+            "description": "An engineering-oriented C++20 toolkit with duck-typed concepts, "
+                           "header-only, RTTI-free, and concurrency-friendly.",
             "platforms": ["Ubuntu", "macOS", "Windows"],
             "source": {
                 "repository": "https://github.com/JeongHan-Bae/JH-Toolkit",
@@ -124,8 +125,26 @@ def main(get_version_only=False):
                                 "name": "C++20 Standard Library",
                                 "platforms": ["Ubuntu", "macOS", "Windows"],
                                 "install": "Supports GCC 13+ and Clang 15+.\n"
-                                           "Recommended compilers: GCC 14.2+ (official Ubuntu builds only; PPA builds are not recommended), 14.3+, or Clang LLVM 20 (stable release).\n"
-                                           "Note that LLVM 17/18 provided via Homebrew may not be fully stable and should be avoided in production, similar to the unrecommended GCC PPA builds.",
+                                           "Recommended compilers: \n"
+                                           "GCC 14.2+ (official Ubuntu builds only; PPA builds are not recommended), 14.3+, or Clang LLVM 20 (stable release).",
+                                "note": "LLVM 17/18 provided via Homebrew may not be fully stable and should be avoided in production, \n"
+                                        "similar to the unrecommended GCC PPA builds.\n"
+                                        "GCC 13 has known issues with NTTP combined with constexpr, certain APIs are intentionally disabled via static_assert checks. \n"
+                                        "Attempting to call these APIs on GCC13 will result in a compilation failure.\n"
+                                        "GCC 14+ has some known compile-time frontend parser issues (where correct syntax causes dangling), \n"
+                                        "but these can be avoided by using our recommended syntax.\n"
+                                        "The MinGW series (MinGW-w64/MinGW-clang) occasionally exhibits visibility issues when mixed with Windows runtimes (msvcrt/ucrt) \n"
+                                        "(potentially stemming from SRWLock failing to produce total order even under seq_cst fences, \n"
+                                        "with atomic types not fully protected). Windows serves as a verification platform rather than a high-concurrency platform.\n"
+                                        "Some modules (refer to documentations) assumes POSIX semantics. The Windows implementation provides only the API, \n"
+                                        "serving as a verification platform rather than a primary platform.\n\n"
+                                        "Unsupported toolchains: \n"
+                                        "MSVC, whose behavior partially deviates from ISO expectations and whose mangling conventions are rather peculiar.\n\n"
+                                        "Highly recommended: \n"
+                                        "LLVM 20. \n"
+                                        "If no additional toolchain dependencies exist on Ubuntu, LLVM 20 can also be used as an alternative to GCC. \n"
+                                        "On Windows, MinGW (GCC) + MSYS2 (UCRT) is recommended for minimal jitter and visibility gaps.\n"
+                                        "(Generally, it will pull GCC 14.3+ or GCC 15).",
                                 "version": "C++20"
                             }
                         ] + deps

--- a/.github/workflows/generate_doxyfile.py
+++ b/.github/workflows/generate_doxyfile.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import pathlib
+import sys
+import argparse
+
+DEFAULT_REPO_URL = "https://github.com/JeongHan-Bae/JH-Toolkit"
+
+
+def normalize_repo(repo_env: str) -> str:
+    if not repo_env:
+        repo_env = DEFAULT_REPO_URL
+
+    if repo_env.startswith("http"):
+        repo_env = repo_env.rstrip("/")
+        repo_env = repo_env.split("github.com/")[-1]
+
+    return repo_env
+
+
+def get_project_version() -> str:
+    script_path = pathlib.Path(".github/workflows/generate_dependencies.py")
+
+    if not script_path.exists():
+        return "unknown"
+
+    try:
+        result = subprocess.run(
+            [sys.executable, str(script_path), "--get-version"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        version = result.stdout.strip()
+        return f"v{version}" if version else "unknown"
+    except subprocess.CalledProcessError:
+        return "unknown"
+
+
+def get_repo_description(repo: str, token: str) -> str:
+    repo = normalize_repo(repo)
+
+    curl_cmd = ["curl", "-s"]
+
+    if token:
+        curl_cmd.extend([
+            "-H", f"Authorization: Bearer {token}",
+            "-H", "Accept: application/vnd.github+json",
+        ])
+
+    curl_cmd.append(f"https://api.github.com/repos/{repo}")
+
+    try:
+        curl_proc = subprocess.run(
+            curl_cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        jq_proc = subprocess.run(
+            ["jq", "-r", ".description // empty"],
+            input=curl_proc.stdout,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+        desc = jq_proc.stdout.strip()
+        if not desc or desc == "null":
+            return "C++ Toolkit for software engineering"
+
+        return desc
+
+    except Exception:
+        return "C++ Toolkit for software engineering"
+
+
+def escape_pipe(value: str) -> str:
+    return value.replace("|", r"\|")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--no-html", action="store_true")
+    parser.add_argument("--use-xml", action="store_true")
+    args = parser.parse_args()
+
+    generate_html = "NO" if args.no_html else "YES"
+    generate_xml = "YES" if args.use_xml else "NO"
+
+    project_version = get_project_version()
+
+    repo_env = os.environ.get("GITHUB_REPOSITORY", "")
+    token = os.environ.get("GITHUB_TOKEN", "")
+
+    project_description = get_repo_description(repo_env, token)
+
+    template_path = pathlib.Path("docs/doxy_settings/Doxyfile")
+    output_path = pathlib.Path("Doxyfile.tmp")
+
+    if not template_path.exists():
+        print("Doxyfile template not found.", file=sys.stderr)
+        sys.exit(1)
+
+    content = template_path.read_text(encoding="utf-8")
+
+    content = content.replace("__VERSION__", escape_pipe(project_version))
+    content = content.replace("__DESCRIPTION__", escape_pipe(project_description))
+    content = content.replace("__GENERATE_HTML__", generate_html)
+    content = content.replace("__GENERATE_XML__", generate_xml)
+
+    output_path.write_text(content, encoding="utf-8")
+
+    print("Doxyfile generated.")
+    print("Repo:", normalize_repo(repo_env))
+    print("Version:", project_version)
+    print("Description:", project_description)
+    print("GENERATE_HTML:", generate_html)
+    print("GENERATE_XML:", generate_xml)
+
+
+if __name__ == "__main__":
+    main()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.21)
 project(jh-toolkit LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -8,6 +8,74 @@ include(GNUInstallDirs)  # Ensure standardized installation directories
 
 set(PROJECT_VERSION 1.4.0)
 
+# ------------------------------------------------------------------------------
+# Compilation Model and Integration Philosophy
+#
+# 1. Precompiled Components
+#    A small portion of the library provides precompiled implementations.
+#    When linking against `jh-toolkit-static`, those compiled units are built
+#    with Release-level optimizations by design.
+#
+#    IMPORTANT:
+#    Template code remains governed by the consumer project's compilation
+#    settings. Only the explicitly compiled translation units are subject
+#    to the enforced optimization policy.
+#
+# 2. Fully Templated Usage
+#    All functionality is available in header-only form via `jh-toolkit`.
+#    When consumed through `find_package`, the user retains full control
+#    over compilation flags and optimization strategy.
+#
+# 3. FetchContent / add_subdirectory Integration
+#    When integrated via FetchContent or add_subdirectory, this project
+#    intentionally overrides and enforces its global compilation strategy.
+#
+#    This behavior is deliberate:
+#    Using FetchContent/add_subdirectory implies adoption of the project's
+#    architectural philosophy and compilation discipline.
+#
+#    Consumers are expected to audit their codebase under this philosophy,
+#    including constraints such as RTTI prohibition and enforced optimization
+#    strategy.
+#
+#    If such constraints are not desired, the library should be consumed
+#    via find_package instead.
+# ------------------------------------------------------------------------------
+
+# Options
+
+option(JH_ENABLE_TESTING
+        "Build jh-toolkit tests"
+        ${PROJECT_IS_TOP_LEVEL})
+
+option(JH_ENABLE_EXAMPLES
+        "Build jh-toolkit examples"
+        ${PROJECT_IS_TOP_LEVEL})
+
+# Auto-enable development features (only top-level)
+
+if (PROJECT_IS_TOP_LEVEL)
+
+    if (WIN32 AND
+    (CMAKE_BUILD_TYPE STREQUAL "Release" OR
+            CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
+        set(JH_ENABLE_TESTING ON CACHE BOOL "" FORCE)
+        set(JH_ENABLE_EXAMPLES ON CACHE BOOL "" FORCE)
+    endif ()
+
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR
+            CMAKE_BUILD_TYPE STREQUAL "FastDebug")
+        set(JH_ENABLE_TESTING ON CACHE BOOL "" FORCE)
+        set(JH_ENABLE_EXAMPLES ON CACHE BOOL "" FORCE)
+    endif ()
+
+endif ()
+
+if (JH_ENABLE_TESTING AND NOT JH_ENABLE_EXAMPLES)
+    message(STATUS "Enabling examples because testing requires them.")
+    set(JH_ENABLE_EXAMPLES ON CACHE BOOL "" FORCE)
+endif ()
+
 # Register custom build type
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo;MinSizeRel;FastDebug" CACHE STRING "" FORCE)
 set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING "Choose the type of build." FORCE)
@@ -16,17 +84,24 @@ if (NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel|Fast
     message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}")
 endif ()
 
-# Optional: Define optimization flags globally for FastDebug
-if (CMAKE_BUILD_TYPE STREQUAL "FastDebug")
-    message(STATUS ">>> FastDebug mode enabled")
+if (PROJECT_IS_TOP_LEVEL)
 
-    # defined for logging
-    set(CMAKE_CXX_FLAGS_FASTDEBUG "-O2 -g" CACHE STRING "" FORCE)
-    set(CMAKE_C_FLAGS_FASTDEBUG "-O2 -g" CACHE STRING "" FORCE)
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR
+            CMAKE_BUILD_TYPE STREQUAL "FastDebug")
 
-    # Actually apply the flags (target-based or global)
-    add_compile_options(-O2 -g)
+        message(WARNING
+                "Install is disabled in Debug/FastDebug mode. "
+                "Use Release or RelWithDebInfo for installation.")
+
+        # Do not generate install rules
+        set(CMAKE_SKIP_INSTALL_RULES TRUE)
+
+    endif ()
+
 endif ()
+
+set(CMAKE_CXX_FLAGS_FASTDEBUG "-O2 -g1 -Wall -Wextra -Wpedantic")
+set(CMAKE_C_FLAGS_FASTDEBUG  "-O2 -g1 -Wall -Wextra -Wpedantic")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
     message(STATUS "Applying extra CPU optimizations for Release build.")
@@ -68,7 +143,7 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
             message(STATUS "Release build: enabled aggressive optimization")
         elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")
             add_compile_options(
-                    -O2
+                    -O0 -g
                     -Wall -Wextra -Wpedantic
             )
             message(STATUS "Debug build: light optimization with warnings")
@@ -241,24 +316,14 @@ install(FILES
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/jh-toolkit
 )
 
-if (WIN32 AND (CMAKE_BUILD_TYPE STREQUAL "Release" OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"))
-    message(STATUS "Windows Release/RelWithDebInfo: enabling tests")
+if (JH_ENABLE_TESTING)
     enable_testing()
-    add_subdirectory(tests)
+endif ()
+
+if (JH_ENABLE_EXAMPLES)
     add_subdirectory(examples)
 endif ()
 
-# Enable tests and examples only in Debug mode
-if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "FastDebug")
-    enable_testing()
+if (JH_ENABLE_TESTING)
     add_subdirectory(tests)
-    add_subdirectory(examples)
-
-    message(WARNING "Install is disabled in Debug or FastDebug mode. Use Release or RelWithDebInfo instead.")
-    add_custom_target(disable-install ALL
-            COMMENT "Install disabled in Debug mode"
-    )
-    function(install)
-        message(FATAL_ERROR "Install is explicitly disabled in Debug mode.")
-    endfunction()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,14 +46,13 @@ set(PROJECT_VERSION 1.4.0)
 
 option(JH_ENABLE_TESTING
         "Build jh-toolkit tests"
-        ${PROJECT_IS_TOP_LEVEL})
+        OFF)
 
 option(JH_ENABLE_EXAMPLES
         "Build jh-toolkit examples"
-        ${PROJECT_IS_TOP_LEVEL})
+        OFF)
 
 # Auto-enable development features (only top-level)
-
 if (PROJECT_IS_TOP_LEVEL)
 
     if (WIN32 AND
@@ -243,8 +242,7 @@ if (ENABLE_ALL)
         message(STATUS ">>> Building main implementation (ALL)")
     endif ()
     # Define the INTERFACE library for header-only components
-    add_library(jh-toolkit INTERFACE
-            include/jh/)
+    add_library(jh-toolkit INTERFACE)
     target_include_directories(jh-toolkit INTERFACE
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(GNUInstallDirs)  # Ensure standardized installation directories
 
-set(PROJECT_VERSION 1.4.0)
+set(PROJECT_VERSION 1.4.1)
 
 # ------------------------------------------------------------------------------
 # Compilation Model and Integration Philosophy
@@ -28,21 +28,52 @@ set(PROJECT_VERSION 1.4.0)
 #
 # 3. FetchContent / add_subdirectory Integration
 #    When integrated via FetchContent or add_subdirectory, this project
-#    intentionally overrides and enforces its global compilation strategy.
+#    normally overrides and enforces its global compilation strategy.
 #
 #    This behavior is deliberate:
 #    Using FetchContent/add_subdirectory implies adoption of the project's
 #    architectural philosophy and compilation discipline.
 #
+#    However, this behavior can be adjusted:
+#
+#    - Setting USE_JH_COMPILE_OPT=OFF disables jh-toolkit's compile option
+#      enforcement when used as a subproject.
+#
+#    - Setting JH_FORCE_RTTI=ON prevents jh-toolkit from disabling RTTI
+#      in Release builds, even when compile option enforcement is active.
+#
 #    Consumers are expected to audit their codebase under this philosophy,
 #    including constraints such as RTTI prohibition and enforced optimization
+#    strategy, unless explicitly opting out through the options above.
+#
+#    If full independence from these policies is desired, the library may
+#    alternatively be consumed via find_package.
+#    Compiler and Architecture Optimization
+#
+#    This project currently targets Clang and GCC toolchains (or compatible
+#    variants). Because these compilers expose consistent feature detection
+#    behavior, jh-toolkit is able to reliably detect the compilation
+#    environment and automatically select an appropriate -march optimization
 #    strategy.
 #
-#    If such constraints are not desired, the library should be consumed
-#    via find_package instead.
+#    For native builds, the project prefers `-march=native` when supported.
+#    For cross-compilation, a conservative architecture baseline is selected
+#    based on `CMAKE_SYSTEM_PROCESSOR`.
+#
+#    This automatic architecture tuning is part of the compile-option
+#    enforcement described above and is intended to provide optimal
+#    performance without requiring manual configuration.
 # ------------------------------------------------------------------------------
 
 # Options
+
+option(USE_JH_COMPILE_OPT
+        "Allow jh-toolkit to enforce compile optimization flags when used via add_subdirectory/FetchContent"
+        ON)
+
+option(JH_FORCE_RTTI
+        "Do not disable RTTI in Release builds even when jh-toolkit enforces its compile options"
+        OFF)
 
 option(JH_ENABLE_TESTING
         "Build jh-toolkit tests"
@@ -75,6 +106,13 @@ if (JH_ENABLE_TESTING AND NOT JH_ENABLE_EXAMPLES)
     set(JH_ENABLE_EXAMPLES ON CACHE BOOL "" FORCE)
 endif ()
 
+set(JH_APPLY_COMPILE_OPT TRUE)
+
+# If used as subproject and user disables compile options
+if (NOT PROJECT_IS_TOP_LEVEL AND NOT USE_JH_COMPILE_OPT)
+    set(JH_APPLY_COMPILE_OPT FALSE)
+endif ()
+
 # Register custom build type
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo;MinSizeRel;FastDebug" CACHE STRING "" FORCE)
 set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING "Choose the type of build." FORCE)
@@ -99,57 +137,65 @@ if (PROJECT_IS_TOP_LEVEL)
 
 endif ()
 
-set(CMAKE_CXX_FLAGS_FASTDEBUG "-O2 -g1 -Wall -Wextra -Wpedantic")
-set(CMAKE_C_FLAGS_FASTDEBUG  "-O2 -g1 -Wall -Wextra -Wpedantic")
+if (JH_APPLY_COMPILE_OPT)
 
-if (CMAKE_BUILD_TYPE STREQUAL "Release")
-    message(STATUS "Applying extra CPU optimizations for Release build.")
-    # Detect architecture-specific -march option
-    set(EXTRA_OPT_FLAGS "")
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-        if (NOT CMAKE_CROSSCOMPILING)
-            include(CheckCXXCompilerFlag)
-            check_cxx_compiler_flag("-march=native" HAS_MARCH_NATIVE)
-            if (HAS_MARCH_NATIVE)
-                set(EXTRA_OPT_FLAGS "-march=native")
-            endif ()
-        else ()
-            message(STATUS "Cross-compiling for processor: ${CMAKE_SYSTEM_PROCESSOR}")
-            if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64)$")
-                set(EXTRA_OPT_FLAGS "-march=x86-64-v3")
-            elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
-                set(EXTRA_OPT_FLAGS "-march=armv8-a")
-            elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^armv7")
-                set(EXTRA_OPT_FLAGS "-march=armv7-a")
-            else ()
-                message(WARNING "Unknown target architecture: ${CMAKE_SYSTEM_PROCESSOR}, no -march set")
-            endif ()
+    set(CMAKE_CXX_FLAGS_FASTDEBUG "-O2 -g1 -Wall -Wextra -Wpedantic")
+    set(CMAKE_C_FLAGS_FASTDEBUG "-O2 -g1 -Wall -Wextra -Wpedantic")
+
+    if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_compile_options(
+                -O0 -g
+                -Wall -Wextra -Wpedantic
+        )
+        message(STATUS "Debug build: light optimization with warnings")
+
+    elseif (CMAKE_BUILD_TYPE STREQUAL "Release")
+        message(STATUS "Applying extra CPU optimizations for Release build.")
+        # Detect architecture-specific -march option
+        set(EXTRA_OPT_FLAGS "")
+        set(JH_RTTI_FLAG "-fno-rtti")
+        if (JH_FORCE_RTTI)
+            set(JH_RTTI_FLAG "")
         endif ()
+        if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+            if (NOT CMAKE_CROSSCOMPILING)
+                include(CheckCXXCompilerFlag)
+                check_cxx_compiler_flag("-march=native" HAS_MARCH_NATIVE)
+                if (HAS_MARCH_NATIVE)
+                    set(EXTRA_OPT_FLAGS "-march=native")
+                endif ()
+            else ()
+                message(STATUS "Cross-compiling for processor: ${CMAKE_SYSTEM_PROCESSOR}")
+                if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64)$")
+                    set(EXTRA_OPT_FLAGS "-march=x86-64-v3")
+                elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+                    set(EXTRA_OPT_FLAGS "-march=armv8-a")
+                elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "^armv7")
+                    set(EXTRA_OPT_FLAGS "-march=armv7-a")
+                else ()
+                    message(WARNING "Unknown target architecture: ${CMAKE_SYSTEM_PROCESSOR}, no -march set")
+                endif ()
+            endif ()
 
-        message(STATUS "Applied -march flag: ${EXTRA_OPT_FLAGS}")
+            message(STATUS "Applied -march flag: ${EXTRA_OPT_FLAGS}")
+
+        endif () # CMAKE_CXX_COMPILER_ID
 
         # Apply optimization flags based on build type
-        if (CMAKE_BUILD_TYPE STREQUAL "Release")
-            add_compile_options(
-                    ${EXTRA_OPT_FLAGS}
-                    -O3
-                    -fno-rtti
-                    -ftree-vectorize
-                    -funroll-loops
-                    -fno-omit-frame-pointer
-                    -Wall -Wextra -Wpedantic
-            )
-            message(STATUS "Release build: enabled aggressive optimization")
-        elseif (CMAKE_BUILD_TYPE STREQUAL "Debug")
-            add_compile_options(
-                    -O0 -g
-                    -Wall -Wextra -Wpedantic
-            )
-            message(STATUS "Debug build: light optimization with warnings")
-        endif ()
-    endif ()
+        add_compile_options(
+                ${EXTRA_OPT_FLAGS}
+                -O3
+                ${JH_RTTI_FLAG}
+                -ftree-vectorize
+                -funroll-loops
+                -fno-omit-frame-pointer
+                -Wall -Wextra -Wpedantic
+        )
+        message(STATUS "Release build: enabled aggressive optimization")
 
-endif ()
+    endif () # CMAKE_BUILD_TYPE
+
+endif () # JH_APPLY_COMPILE_OPT
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" BUILD_TYPE_UPPER)
 message(STATUS "${CMAKE_BUILD_TYPE} CXX flags: ${CMAKE_CXX_FLAGS_${BUILD_TYPE_UPPER}}")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -523,6 +523,59 @@ Please commit *ONLY in English* using the following format:
 <detailed explanation: optional, multi-line, no-markdown-formatting, optional `*` for bullet points>
 ```
 
+Example:
+
+```
+refactor(module1_name, module2_name, tests): do something and something else
+
+This commit refactors module1 and module2 to improve performance and maintainability.
+
+Module1:
+* do something
+* do something else
+
+Module2:
+* do something
+* do something else
+
+Tests:
+* update some tests to reflect some semantic changes
+```
+
+```
+docs(module_name): update documentation for some behavior
+This commit updates the documentation for module_name to clarify the expected behavior of some function.
+
+module_name::submodule_name:
+* some_function: documented to reflect some behavior
+* some_sub_class: documented to reflect some behavior
+
+another_module_name:
+* some_function: documented to reflect some behavior
+```
+
+Anti-patterns:
+
+```
+fix: fix some bug in some module
+```
+> Explain: should use `fix(module_name):` instead of a generic `fix:`.
+
+```
+* Module2:
+  * do something
+```
+> Explain: no `*` for paragraphs, only for bullet points.
+> no nested bullet points.
+
+```
+**Module2**:
+ - do something
+```
+> Explain: use `*` for bullet points, not `-`.
+> Markdown formatting is not allowed in the commit message body.
+> Markdown `**` is not allowed in the commit message body.
+
 ### Pull Request format
 
 Please create PRs *ONLY in English*, including the following sections:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -520,7 +520,7 @@ Please commit *ONLY in English* using the following format:
 ```
 <behavior>(<domain>): <short description>
 
-<detailed explanation: optional, multi-line, no-markdown-formatting, only `*` for bullet points>
+<detailed explanation: optional, multi-line, no-markdown-formatting, optional `*` for bullet points>
 ```
 
 ### Pull Request format

--- a/README.md
+++ b/README.md
@@ -53,27 +53,26 @@ In other words, we aim to help you reclaim your understanding of modern C++ from
 performance, and enhanced security.
 </div>
 
-<div align="center">
-<p></p>
+<br>
+
+<div align="center" style="max-width: 80%; margin: 0 auto;">
 
 <!-- ✅ Core Info -->
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/JeongHan-Bae/JH-Toolkit/tree/main?tab=Apache-2.0-1-ov-file#readme)
+[![License](https://img.shields.io/github/license/JeongHan-Bae/JH-Toolkit.svg?labelColor=3E434A&color=1F6FEB&logo=github)](https://github.com/JeongHan-Bae/JH-Toolkit/tree/main?tab=Apache-2.0-1-ov-file#readme)
 [![C++20](https://img.shields.io/badge/C%2B%2B-20-violet.svg)](https://en.cppreference.com/w/cpp/20)
 ![Header-Only](https://img.shields.io/badge/header--only-supported-green)
-![Static Build](https://img.shields.io/badge/static--build-supported-green)
 
 <!-- ✅ CI / Contributors / Wiki -->
-[![CI](https://github.com/JeongHan-Bae/JH-Toolkit/actions/workflows/ci.yml/badge.svg?branch=1.3.x-LTS)](https://github.com/JeongHan-Bae/JH-Toolkit/actions/workflows/ci.yml)
-[![Contributors](https://img.shields.io/github/contributors/JeongHan-Bae/JH-Toolkit.svg)](https://github.com/JeongHan-Bae/JH-Toolkit/graphs/contributors)
-[![Wiki](https://img.shields.io/badge/docs-wiki-blue)](https://github.com/JeongHan-Bae/JH-Toolkit/wiki)
-
-<br>
+[![CI](https://github.com/JeongHan-Bae/JH-Toolkit/actions/workflows/ci.yml/badge.svg)](https://github.com/JeongHan-Bae/JH-Toolkit/actions/workflows/ci.yml)
+[![Contributors](https://img.shields.io/github/contributors/JeongHan-Bae/JH-Toolkit.svg?color=darkcyan)](https://github.com/JeongHan-Bae/JH-Toolkit/graphs/contributors)
+[![Wiki](https://img.shields.io/badge/wiki-overview-3A7DFF)](https://github.com/JeongHan-Bae/JH-Toolkit/wiki)
 
 <!-- ✅ Feature Highlights -->
 ![Pooling](https://img.shields.io/badge/pooling-powerful-brown)
 ![Immutable Strings](https://img.shields.io/badge/immutable--strings-safe-brown)
 ![Async](https://img.shields.io/badge/async%20%28coroutines%29-zero--boilerplate-brown)
 ![POD System](https://img.shields.io/badge/plain--old--data-primitive-brown)
+
 ![Duck Concepts](https://img.shields.io/badge/duck--concepts-smart-brown)
 ![Meta Programming](https://img.shields.io/badge/metaprogramming-compile--time-brown)
 ![Ranges and Views](https://img.shields.io/badge/ranges%20%26%20views-semantically--rich-brown)

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -1,7 +1,7 @@
 [project]
 name = "JH-Toolkit"
 version = "1.4.0"
-description = "A cross-platform C++20 toolkit library"
+description = "An engineering-oriented C++20 toolkit with duck-typed concepts, header-only, RTTI-free, and concurrency-friendly."
 platforms = ["Ubuntu", "macOS", "Windows"]
 
 [project.source]
@@ -13,8 +13,30 @@ name = "C++20 Standard Library"
 platforms = ["Ubuntu", "macOS", "Windows"]
 install = '''
 Supports GCC 13+ and Clang 15+.
-Recommended compilers: GCC 14.2+ (official Ubuntu builds only; PPA builds are not recommended), 14.3+, or Clang LLVM 20 (stable release).
-Note that LLVM 17/18 provided via Homebrew may not be fully stable and should be avoided in production, similar to the unrecommended GCC PPA builds.
+Recommended compilers: 
+GCC 14.2+ (official Ubuntu builds only; PPA builds are not recommended), 14.3+, or Clang LLVM 20 (stable release).
+'''
+note = '''
+LLVM 17/18 provided via Homebrew may not be fully stable and should be avoided in production, 
+similar to the unrecommended GCC PPA builds.
+GCC 13 has known issues with NTTP combined with constexpr, certain APIs are intentionally disabled via static_assert checks. 
+Attempting to call these APIs on GCC13 will result in a compilation failure.
+GCC 14+ has some known compile-time frontend parser issues (where correct syntax causes dangling), 
+but these can be avoided by using our recommended syntax.
+The MinGW series (MinGW-w64/MinGW-clang) occasionally exhibits visibility issues when mixed with Windows runtimes (msvcrt/ucrt) 
+(potentially stemming from SRWLock failing to produce total order even under seq_cst fences, 
+with atomic types not fully protected). Windows serves as a verification platform rather than a high-concurrency platform.
+Some modules (refer to documentations) assumes POSIX semantics. The Windows implementation provides only the API, 
+serving as a verification platform rather than a primary platform.
+
+Unsupported toolchains: 
+MSVC, whose behavior partially deviates from ISO expectations and whose mangling conventions are rather peculiar.
+
+Highly recommended: 
+LLVM 20. 
+If no additional toolchain dependencies exist on Ubuntu, LLVM 20 can also be used as an alternative to GCC. 
+On Windows, MinGW (GCC) + MSYS2 (UCRT) is recommended for minimal jitter and visibility gaps.
+(Generally, it will pull GCC 14.3+ or GCC 15).
 '''
 version = "C++20"
 

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -1,6 +1,6 @@
 [project]
 name = "JH-Toolkit"
-version = "1.4.0"
+version = "1.4.1"
 description = "An engineering-oriented C++20 toolkit with duck-typed concepts, header-only, RTTI-free, and concurrency-friendly."
 platforms = ["Ubuntu", "macOS", "Windows"]
 

--- a/docs/concurrent/flat_pool.md
+++ b/docs/concurrent/flat_pool.md
@@ -144,7 +144,19 @@ This enables **lookup-before-construction** and avoids provisional object creati
 | `ptr acquire(KArg&& key, std::tuple<Args...>)` | Map-like | Interns a key–value entry, constructing value once if absent.                           |
 | `ptr find(const Key&)`                         | Lookup   | Returns a handle to an existing entry; **returns `nullptr` if the key is not present**. |
 
-> Note: use `if (auto p = pool.find(...); p != nullptr)` as operator `bool` is currently not defined for `flat_pool::ptr`.
+> **Version note**
+>
+> - **1.4.0**: `flat_pool::ptr` does not define `operator bool()`.  
+>   Use:
+>
+>       if (auto p = pool.find(...); p != nullptr) { ... }
+>
+> - **Since 1.4.1**: `flat_pool::ptr` provides `explicit operator bool()`.  
+>   You may write:
+>
+>       if (auto p = pool.find(...)) { ... }
+>
+>   which is semantically equivalent to comparing against `nullptr`.
 
 **Deleted (by design):**
 
@@ -157,18 +169,19 @@ This enables **lookup-before-construction** and avoids provisional object creati
 
 ### 📎 `flat_pool::ptr` — Handle Type
 
-| Member            | Type        | Description                                                |
-|-------------------|-------------|------------------------------------------------------------|
-| `ptr()`           | Constructor | Constructs a null handle.                                  |
-| `ptr(nullptr_t)`  | Constructor | Explicit null handle.                                      |
-| `ptr(const ptr&)` | Copy        | Shares the reference and increments refcount.              |
-| `ptr(ptr&&)`      | Move        | Transfers ownership without refcount change.               |
-| `~ptr()`          | Destructor  | Releases reference (GC-like).                              |
-| `reset()`         | Modifier    | Releases the reference and becomes null.                   |
-| `operator*()`     | Access      | Returns reference to stored object (guard required in MT). |
-| `operator->()`    | Access      | Returns pointer to stored object (guard required in MT).   |
-| `operator==`      | Comparison  | Compares handle identity or against `nullptr`.             |
-| `guard()`         | Guard       | Prevents pool reallocation during dereference.             |
+| Member                     | Type        | Description                                                |
+|----------------------------|-------------|------------------------------------------------------------|
+| `ptr()`                    | Constructor | Constructs a null handle.                                  |
+| `ptr(nullptr_t)`           | Constructor | Explicit null handle.                                      |
+| `ptr(const ptr&)`          | Copy        | Shares the reference and increments refcount.              |
+| `ptr(ptr&&)`               | Move        | Transfers ownership without refcount change.               |
+| `~ptr()`                   | Destructor  | Releases reference (GC-like).                              |
+| `reset()`                  | Modifier    | Releases the reference and becomes null.                   |
+| `operator*()`              | Access      | Returns reference to stored object (guard required in MT). |
+| `operator->()`             | Access      | Returns pointer to stored object (guard required in MT).   |
+| `operator==`               | Comparison  | Compares handle identity or against `nullptr`.             |
+| `guard()`                  | Guard       | Prevents pool reallocation during dereference.             |
+| `explicit operator bool()` | Conversion  | Returns `true` if the handle is non-null. (1.4.1+)         |
 
 ---
 
@@ -658,15 +671,52 @@ jh::conc::flat_pool<Key, std::unique_ptr<V>>
 
 ### Windows-Specific Note
 
-`pointer_pool` / `observe_pool` rely on `shared_ptr` + `weak_ptr`.
+On POSIX platforms (macOS, Linux GCC ≥13), `std::shared_mutex` implementations are typically backed by
+`pthread_rwlock` or equivalent primitives that, in practice, exhibit strong global ordering behavior.
+Under these environments, `flat_pool` does **not** introduce additional fences.
 
-On **Windows (including UCRT)**:
+On Windows, the situation differs:
 
-* `shared_ptr` implementations are relatively slow
-* no Windows runtime guarantees high-concurrency performance for
-  `shared_ptr + weak_ptr`
+The ISO C++ standard does **not** require `std::shared_mutex` to establish a global total order.
+It only guarantees acquire–release semantics.
 
-`flat_pool` avoids this entirely by controlling synchronization internally.
+To approximate POSIX-style behavior, `flat_pool` introduces:
+
+```cpp
+std::atomic_thread_fence(std::memory_order_seq_cst);
+```
+
+around shared mutex boundaries (via <code>posix_smtx_&#42;_lock</code>).
+
+This is the strongest ordering primitive available within ISO C++.
+
+However:
+
+* It operates strictly within the C++ abstract machine.
+* It cannot strengthen ordering inside Windows runtime or kernel-level primitives.
+* It cannot eliminate hardware-level propagation delays.
+
+As a result:
+
+* The implementation is **algorithmically DRF**.
+* Undefined behavior (UB) risks have been eliminated at the ISO C++ level.
+* All inter-thread interactions respect the C++ memory model.
+
+Nevertheless, empirical behavior on certain Windows configurations
+(MinGW toolchains + MSVCRT/UCRT) may still exhibit rare instability
+under extreme contention.
+
+This does **not** indicate undefined behavior in `flat_pool`,
+but rather reflects environmental memory-model characteristics
+that do not provide POSIX-level closure.
+
+In summary:
+
+* POSIX platforms: strong practical ordering, no additional fences required.
+* Windows: language-level strengthening applied.
+* Full global ordering equivalence is not guaranteed in practice.
+* The design remains DRF and standards-compliant, but runtime behavior
+  may not fully match theoretical expectations under stress.
 
 ---
 

--- a/docs/concurrent/observe_pool.md
+++ b/docs/concurrent/observe_pool.md
@@ -204,21 +204,54 @@ Consequences:
 
 ### Windows-Specific Warning (Critical)
 
-On **Windows UCRT-based toolchains** (including MinGW):
+On POSIX platforms, `pointer_pool` / `observe_pool` behavior is generally stable in practice,
+as `std::shared_mutex` implementations tend to exhibit strong global ordering characteristics.
 
-* `std::shared_ptr` / `std::weak_ptr` exhibit unreliable synchronization
-* `weak_ptr::lock()` may succeed after destruction
-* unordered container insertion incurs heavy jitter
+On Windows, however:
 
-#### Practical Recommendation
+* ISO C++ guarantees only acquire–release semantics for `std::shared_mutex`.
+* `std::weak_ptr` / `std::shared_ptr` rely on atomic reference counting.
+* `unordered_map` introduces additional internal synchronization and rehash behavior.
 
-On Windows:
+The interaction between:
 
-* **≤ 4 concurrent threads**
-* **≤ ~2000 live pooled objects**
+* atomic reference-count operations (`shared_ptr` control blocks),
+* `std::shared_mutex`,
+* and `unordered_map` bucket management,
 
-Exceeding these limits is **strongly discouraged**.
+creates a more complex memory-ordering surface than `flat_pool`.
 
+Even though:
+
+* `std::atomic_thread_fence(std::memory_order_seq_cst)` is inserted around lock boundaries,
+* the implementation is algorithmically **DRF**,
+* no undefined behavior exists at the ISO C++ level,
+
+empirical testing shows that:
+
+* pointer-based pools (`pointer_pool` / `observe_pool`)
+  are **more sensitive to Windows runtime + MinGW coupling**
+  than contiguous-storage `flat_pool` / `resource_pool`.
+* Under extreme contention, instability manifests earlier than in `flat_pool`.
+
+This is likely due to:
+
+* additional indirection layers,
+* `weak_ptr` lock operations,
+* `unordered_map` rehash activity,
+* and weaker cross-domain ordering between atomics and system locks.
+
+Important:
+
+* Neither `observe_pool` nor `flat_pool` guarantees high-pressure stability on Windows.
+* Both remain standards-compliant and DRF.
+* Behavior may degrade under extreme multi-core contention.
+
+Official guidance:
+
+* Windows is treated as a **compatibility platform**, not a strong-ordering baseline.
+* Use low to moderate concurrency levels on Windows.
+* For maximum robustness under heavy load, prefer POSIX platforms.
 ---
 
 ## Intended Use Cases

--- a/docs/concurrent/overview.md
+++ b/docs/concurrent/overview.md
@@ -56,6 +56,156 @@ pools, include `<jh/pool>` so that `jh::observe_pool`/`jh::resource_pool` sit di
 
 ---
 
+## 🎍 Pool Module (Windows Semantics Notice)
+
+📁 **Module:** `<jh/pool>`  
+📦 **Namespace:** `jh`  
+📍 **Location:** `jh/concurrent/`
+
+`<jh/pool>` re-exports alias-based pools (`observe_pool`, `resource_pool`, etc.) directly under `jh::`.  
+These helpers are engineered around POSIX-style behavioral assumptions.
+
+As of 1.4.x, **Windows is treated as a compatibility platform, not a fully supported concurrency baseline** for the
+entire `jh/pool` module.
+
+---
+
+### ⚠️ Windows Memory-Model Limitation
+
+We introduced:
+
+```cpp
+std::atomic_thread_fence(std::memory_order_seq_cst);
+```
+
+around `shared_mutex` boundaries (via <code>posix_smtx_&#42;_lock</code>).
+
+This is the strongest ordering primitive available in ISO C++ at the language level.
+
+However, it does **not** fully close the visibility gaps observed under:
+
+* MinGW toolchains (MinGW-w64 / MinGW-clang)
+* Windows runtimes (MSVCRT / UCRT)
+* Interaction with OS-level primitives (e.g., SRWLock)
+
+The behavior remains **data-race-free (DRF)** at the algorithmic level.  
+The instability arises from environmental constraints beyond the abstract C++ model.
+
+*Note:*  
+On Windows, inserting
+`std::atomic_thread_fence(std::memory_order_seq_cst);`
+around `shared_mutex` boundaries measurably improves practical stability under contention.
+It raises the threshold at which race-like symptoms manifest and delays instability in stress scenarios.
+However, it cannot fully eliminate the underlying visibility gaps nor guarantee POSIX-level behavioral equivalence.
+
+---
+
+### 1️⃣ Fence Jurisdiction Limitation
+
+`std::atomic_thread_fence` can only constrain memory operations:
+
+* Emitted by the current compiler
+* Within the C++ abstract machine
+* Visible in user-space generated code
+
+It **cannot**:
+
+* Control hidden synchronization inside system DLLs
+* Strengthen ordering inside kernel-implemented locks
+* Inject barriers into opaque runtime components
+
+On Windows, primitives such as `SRWLock` are implemented inside system libraries (e.g., `ntdll.dll`).  
+If their internal memory ordering is optimized without full fences, user-inserted `seq_cst` cannot retroactively enforce
+stronger guarantees.
+
+The fence does not cross the ABI boundary.
+
+---
+
+### 2️⃣ Atomicity ≠ Global Visibility
+
+Atomic operations guarantee:
+
+* **Atomicity** — operations are indivisible.
+* **Ordering (within abstract machine)** — relative sequencing.
+
+They do **not** guarantee:
+
+* Immediate global visibility across CPU cores.
+* Hardware-level total ordering.
+
+Modern CPUs use:
+
+* Store buffers
+* Cache-coherence protocols (e.g., MESI)
+* Speculative execution
+
+Even with `seq_cst`, there can be a physical delay between:
+
+* Atomic write completion on CPU A
+* Cache-line propagation to CPU B
+
+If the Windows lock implementation does not enforce a bus-lock–grade synchronization boundary, extremely high-frequency
+contention may expose transient visibility windows.
+
+This is a hardware-level constraint, not a C++ bug.
+
+---
+
+### 3️⃣ Compiler / Runtime Coupling Effects
+
+In the MinGW + UCRT/MSVCRT environment:
+
+* The compiler may assume system calls imply sufficient ordering.
+* The runtime may assume atomic operations are independently ordered.
+* `std::shared_ptr` (atomic refcount) and `std::shared_mutex` (system lock) may not form a strongly coupled ordering
+  chain at the machine-code level.
+
+This weak cross-domain coupling can expose rare race-like symptoms under stress.
+
+---
+
+### Why We Do Not Escalate Further
+
+Once `std::memory_order_seq_cst` is insufficient, only two paths remain:
+
+1. Insert hardware-specific instructions (`MFENCE`, `LOCK` prefixes, inline assembly).
+2. Accept that the environment cannot provide POSIX-level closure.
+
+Option 1 destroys portability and maintainability.  
+Option 2 is engineering reality.
+
+If the strongest ISO C++ ordering primitive cannot bridge the gap, the issue is systemic, not algorithmic.
+
+---
+
+### Official Position
+
+* `jh/pool` implementations remain **algorithmically DRF**.
+* POSIX platforms (macOS, Linux GCC ≥13) define the reference behavior.
+* On Windows:
+
+    * API availability is guaranteed.
+    * Single-threaded or low-pressure multi-threaded usage is recommended.
+    * Full POSIX-equivalent global ordering is not guaranteed.
+
+The inserted fences:
+
+* Raise the instability threshold.
+* Delay manifestation under contention.
+* Improve convergence in practice.
+
+They:
+
+* Do **not** eliminate hardware-level reordering.
+* Do **not** establish a true global total order.
+
+This is a boundary where software cannot defeat hardware and platform policy.
+
+Accordingly, the entire `<jh/pool>` module does **not** provide full Windows concurrency support.
+
+---
+
 ## 🧭 Navigation
 
 | Resource                                 |                                                                       Link                                                                       |

--- a/docs/concurrent/pointer_pool.md
+++ b/docs/concurrent/pointer_pool.md
@@ -224,15 +224,45 @@ The pool uses `std::shared_mutex` internally.
 
 ## Platform Notes (Windows)
 
-On Windows environments based on **Universal CRT** (including MinGW):
+On POSIX platforms, `std::shared_mutex` implementations typically exhibit strong practical ordering,
+and `pointer_pool` behaves as expected under high concurrency.
 
-* `shared_ptr` / `weak_ptr` may exhibit incorrect refcount synchronization
-* `weak_ptr::lock()` may succeed on already-destroyed objects
-* inserting `weak_ptr` into unordered containers may incur heavy jitter
+On Windows:
 
-As a result:
+* ISO C++ guarantees only acquire–release semantics for `std::shared_mutex`.
+* `pointer_pool` relies on:
 
-> High-pressure concurrent use of `pointer_pool` is **not recommended** on Windows UCRT-based toolchains.
+    * atomic reference counting inside `std::shared_ptr`
+    * `std::weak_ptr` lock operations
+    * `std::shared_mutex`
+    * `std::unordered_map` bucket management
+
+To strengthen ordering at the language level,
+`std::atomic_thread_fence(std::memory_order_seq_cst)` is inserted
+around shared mutex boundaries.
+
+This:
+
+* removes undefined behavior risks at the ISO C++ level
+* preserves data-race-freedom (DRF)
+* improves practical stability under contention
+
+However:
+
+* it cannot enforce hardware-level global ordering
+* it cannot strengthen opaque runtime or kernel primitives
+* it does not guarantee POSIX-equivalent behavior
+
+Empirically, pointer-based pools are **more sensitive** on Windows
+than contiguous-storage `flat_pool`,
+due to the combined interaction of atomics, weak pointers,
+and hash-table rehash behavior.
+
+Important:
+
+* High-pressure multicore stability is **not guaranteed** on Windows.
+* Windows is treated as a **compatibility platform**, not a strong-ordering baseline.
+* For extreme concurrency workloads, POSIX platforms are recommended.
 
 ---
 

--- a/docs/core/ordered_map.md
+++ b/docs/core/ordered_map.md
@@ -265,6 +265,39 @@ auto m = jh::ordered_map<K,V>::from_sorted(v);
 
 This is often **faster than random insertion**, even including sort cost.
 
+### Additional Considerations: Refreshing the Table
+
+In long-running systems, an `ordered_*` container may gradually lose some of its traversal locality.
+Although it never fragments (because storage is contiguous), repeated insertions and erasures can cause the internal node ordering to drift away from the optimal layout, which reduces hardware prefetch efficiency.
+
+If memory is sufficient, it can be beneficial to occasionally rebuild the table using:
+
+```cpp
+m = jh::ordered_map<K,V>::from_sorted(std::move(m));
+```
+
+This restores a perfectly shaped AVL layout and recovers optimal iteration locality.
+After rebuilding, the container can be used for a relatively stable period. Eventually the table can be discarded or cleared, which is allocator-friendly and fits well with PMR or arena allocation workflows where structures are periodically rebuilt rather than mutated indefinitely.
+
+```
++----------------------------+
+|  Step 1: Run for a period  |
+|  and add entries           |
++----------------------------+
+              |
+              |  (optional rebuild via from_sorted)
+              v
++----------------------------+
+|  Step 2: Fixed usage       |
++----------------------------+
+              |
+              v
++----------------------------+
+|  Step 3: Discard and       |
+|  allocator-friendly reset  |
++----------------------------+
+```
+
 ---
 
 ## Range / Iterator Construction
@@ -398,11 +431,11 @@ For performance-critical bulk builds, `from_sorted()` remains the preferred path
 
 ---
 
-## Engineering Philosophy: Why Vector Beats Pointers in Practice
+## Engineering Philosophy: Why Pair Beats Pointers in Practice
 
 This container is designed from an **engineering-first** perspective rather than a purely abstract data-structure view.
 
-### Vector-based trees are more predictable than pointer-based trees
+### Pair-based trees are more predictable than pointer-based trees
 
 From a systems standpoint, a container built on top of `std::vector` has several structural advantages over
 pointer-linked trees:
@@ -525,7 +558,7 @@ The STL provides maximal generality.
 
 In short:
 
-> **Vector-based structures behave better over time.
+> **Pair-based structures behave better over time.
 > Pointer-based structures behave better in isolation.**
 
 This library is written for the former.

--- a/docs/doxy_settings/Doxyfile
+++ b/docs/doxy_settings/Doxyfile
@@ -129,13 +129,13 @@ EXCLUDE_PATTERNS       = */detail \
                          */detail/* \
                          *detail/ \
                          *detail/*
-EXCLUDE_SYMBOLS = *detail*          \
-                  detail*           \
-                  *detail           \
-                  *Detail*          \
-                  *DETAIL*          \
-                  *::detail*        \
-                  detail::*
+EXCLUDE_SYMBOLS        = *detail*          \
+                         detail*           \
+                         *detail           \
+                         *Detail*          \
+                         *DETAIL*          \
+                         *::detail*        \
+                         detail::*
 EXAMPLE_PATH           =
 EXAMPLE_PATTERNS       = *
 EXAMPLE_RECURSIVE      = NO
@@ -158,7 +158,7 @@ USE_HTAGS              = YES
 VERBATIM_HEADERS       = YES
 ALPHABETICAL_INDEX     = YES
 IGNORE_PREFIX          =
-GENERATE_HTML          = YES
+GENERATE_HTML          = __GENERATE_HTML__
 HTML_OUTPUT            = html
 HTML_FILE_EXTENSION    = .html
 HTML_HEADER            =
@@ -221,7 +221,7 @@ LATEX_MAKEINDEX_CMD    = makeindex
 COMPACT_LATEX          = NO
 GENERATE_RTF           = NO
 GENERATE_MAN           = NO
-GENERATE_XML           = NO
+GENERATE_XML           = __GENERATE_XML__
 GENERATE_DOCBOOK       = NO
 GENERATE_AUTOGEN_DEF   = NO
 GENERATE_SQLITE3       = NO

--- a/docs/metax/t_str.md
+++ b/docs/metax/t_str.md
@@ -129,11 +129,18 @@ template argument.
 constexpr jh::meta::t_str s{"Hello"};
 ```
 
-| API      | Description                                   |
-|----------|-----------------------------------------------|
-| `val()`  | Returns `const char*` (null-terminated)       |
-| `size()` | Length excluding the null terminator          |
-| `view()` | `std::string_view` over the stored characters |
+| API          | Description                                       |
+|--------------|---------------------------------------------------|
+| `val()`      | Returns `const char*` (null-terminated)           |
+| `size()`     | Length excluding the null terminator              |
+| `view()`     | `std::string_view` over the stored characters     |
+| `pod_view()` | `jh::pod::string_view` over the stored characters |
+| `str()`      | Converts to `std::string`                         |
+
+
+`pod_view()` provides a POD-compatible view type used across JH Toolkit POD
+containers and lookup structures.
+> Note: Introduced in version 1.4.1+
 
 ---
 
@@ -165,6 +172,40 @@ s.is_hex();
 s.is_base64();
 s.is_base64url();
 ```
+
+### UTF-8 / printable legality
+
+```cpp
+s.is_legal();
+```
+
+> Note: Introduced in version 1.4.1+
+
+This function validates that the string is composed of printable ASCII or valid
+UTF-8 byte sequences.
+
+### POSIX relative path validation
+
+```cpp
+s.is_valid_relative_path();
+s.is_valid_relative_path<true>();
+```
+
+> Note: Introduced in version 1.4.1+
+
+Validates a strict POSIX-style relative path.
+
+Compiler requirement:
+
+* **Clang**
+* **GCC 14+**
+
+GCC 13 contains a known `constexpr` evaluation defect affecting NTTP string
+instances where the compiler may incorrectly report that `this` does not exist
+during evaluation.
+Because this behavior is nondeterministic (sometimes compiling, sometimes failing),
+the API is intentionally disabled under GCC 13 to prevent unstable development
+behavior.
 
 Invalid literals can be rejected **at compile time**, before they propagate into
 other templates.
@@ -200,6 +241,45 @@ Rules:
 * A new null terminator is appended
 * Total size must not exceed **16 KB**
 * Violations cause **compile-time failure**
+
+---
+
+## 🔎 Compile-time Substrings
+
+```cpp
+constexpr auto s = t_str{"HelloWorld"};
+
+constexpr auto a = s.sub<0,5>();        // "Hello"
+constexpr auto b = s.sub<5>();          // "World"
+
+auto v1 = s.sub_view<0,5>();
+auto v2 = s.sub_pod_view<5>();
+```
+
+> Note: Introduced in version 1.4.1+
+
+The substring APIs allow extracting compile-time substrings either as a new
+`t_str` object or as lightweight views.
+
+**Important lifetime rule**
+
+Never obtain a view directly from a temporary result such as:
+
+```cpp
+s.sub<0,5>().view(); // illegal: dangling view
+s.sub<0,5>().pod_view(); // illegal: dangling view
+(x + y).view(); // illegal: dangling view
+```
+
+Doing so creates a temporary `t_str` whose storage immediately expires,
+resulting in a **dangling view**.
+
+Recommended pattern:
+
+```cpp
+constexpr auto result_str = s.sub<0,5>();
+auto view = result_str.pod_view();
+```
 
 ---
 
@@ -316,6 +396,7 @@ any feature that requires **string identity at compile time**.
 
 * `t_str / TStr` enables string literals as first-class NTTPs
 * Template identity is derived from **content**, not pointer identity
-* Compile-time validation, transformation, concatenation, and hashing are built in
+* Compile-time validation, transformation, concatenation, substring extraction,
+  and hashing are built in
 * Explicit `bytes.size() + 1` sizing ensures correctness when reconstructing strings
 * Introduced in **JH Toolkit 1.4.0+** as a cornerstone for compile-time string-based design

--- a/docs/pods/string_view.md
+++ b/docs/pods/string_view.md
@@ -2,7 +2,7 @@
 
 📁 **Header:** `<jh/pods/string_view.h>`  
 📦 **Namespace:** `jh::pod`  
-📅 **Version:** 1.3.5+  
+📅 **Version:** **1.4.1+**  
 👤 **Author:** JeongHan-Bae `<mastropseudo@gmail.com>`
 
 <div align="right">
@@ -14,9 +14,9 @@
 
 ---
 
-## 🏷️ Overview
+# 🏷️ Overview
 
-`jh::pod::string_view` is a **POD-safe, deep-comparison string view** —
+`jh::pod::string_view` is a **POD-safe, deep-comparison string view** —  
 a minimal, read-only representation of immutable character data.
 
 It preserves the semantics of `std::string_view` but constrains usage
@@ -25,7 +25,7 @@ and **binary transparency**.
 
 ---
 
-## 🔹 Definition
+# 🔹 Definition
 
 ```cpp
 struct string_view final {
@@ -36,311 +36,575 @@ struct string_view final {
 
 ### Key Properties
 
-| Aspect     | Description                                                 |
-|------------|-------------------------------------------------------------|
-| Layout     | Flat POD layout — `const char* + uint64_t`                  |
-| Ownership  | Non-owning                                                  |
-| Comparison | Deep bytewise (`memcmp`) equality                           |
-| Hashing    | `constexpr` and `consteval`-safe                            |
-| Lifetime   | Must not outlive underlying memory (no dangling references) |
-| ABI        | Stable and deterministic                                    |
+| Aspect     | Description                                |
+|------------|--------------------------------------------|
+| Layout     | Flat POD layout — `const char* + uint64_t` |
+| Ownership  | Non-owning                                 |
+| Comparison | Deep bytewise (`memcmp`) equality          |
+| Hashing    | `constexpr` and `consteval`-safe           |
+| Lifetime   | Must not outlive underlying memory         |
+| ABI        | Stable and deterministic                   |
 
 ---
 
-## 🔬 API Breakdown
+# 🔬 API Breakdown
 
-### 🔹 `from_literal(const char(&lit)[N])`
+---
 
-Creates a `string_view` from a string literal, excluding the trailing null terminator.
+# 🔹 Construction
+
+### `from_literal(const char(&lit)[N])`
+
+Creates a `string_view` from a string literal.
 
 ```cpp
 auto sv = jh::pod::string_view::from_literal("hello");
 ```
 
-| Aspect   | Description                                                 |
-|----------|-------------------------------------------------------------|
-| Behavior | Returns `{lit, N - 1}` excluding the final `'\0'`.          |
-| Safety   | Always valid at compile time (`constexpr` and `consteval`). |
+| Aspect   | Description                                            |
+|----------|--------------------------------------------------------|
+| Behavior | Returns `{lit, N - 1}` excluding the final `'\0'`.     |
+| Safety   | Always compile-time valid (`constexpr` / `consteval`). |
 
 ---
 
-### 🔹 `sub(offset, length = 0)`
+# 🔹 Basic Access
+
+### `operator[](uint64_t index)`
+
+Returns the character at `index`.
+
+```cpp
+char c = sv[0];
+```
+
+| Property   | Description        |
+|------------|--------------------|
+| Bounds     | No bounds checking |
+| Complexity | O(1)               |
+
+---
+
+### `begin()` / `end()`
+
+Returns raw iterators to the view.
+
+```cpp
+for (char c : sv) { ... }
+```
+
+| Function  | Description             |
+|-----------|-------------------------|
+| `begin()` | Pointer to first byte   |
+| `end()`   | Pointer to `data + len` |
+
+---
+
+### `size()`
+
+Returns the number of bytes in the view.
+
+```cpp
+std::uint64_t n = sv.size();
+```
+
+---
+
+### `empty()`
+
+Returns whether the view is empty.
+
+```cpp
+if (sv.empty()) { ... }
+```
+
+---
+
+# 🔹 Substring
+
+### `sub(offset, length = 0)`
 
 Returns a substring view.
 
-| Aspect   | Description                                           |
-|----------|-------------------------------------------------------|
-| Bounds   | If `offset > len`, returns empty.                     |
-| Sentinel | If `length == 0`, extends to end.                     |
-| Behavior | Truncates rather than overflows — never out of range. |
+| Aspect   | Description                        |
+|----------|------------------------------------|
+| Bounds   | If `offset > len`, returns empty   |
+| Sentinel | `length == 0` extends to end       |
+| Safety   | Never produces out-of-range memory |
 
 ```cpp
-auto hello = sv.sub(0, 5);
+auto hello = sv.sub(0,5);
 auto tail  = sv.sub(6);
 ```
 
 ---
 
-### 🔹 `operator==(const string_view&)`
+# 🔹 Comparison
+
+### `operator==(const string_view&)`
 
 Performs **deep bytewise comparison**.
 
-| Aspect         | Description                                          |
-|----------------|------------------------------------------------------|
-| Equality rule  | Returns `true` if lengths are equal and bytes match. |
-| Implementation | Uses `memcmp(data, rhs.data, len)`.                  |
-| Meaning        | Independent of pointer identity.                     |
+| Rule           | Description                    |
+|----------------|--------------------------------|
+| Equality       | `len` equal AND contents equal |
+| Implementation | `memcmp(data, rhs.data, len)`  |
 
 ---
 
-### 🔹 `compare(const string_view&)`
+### `compare(const string_view&)`
 
-Lexical comparison, similar to `strcmp()`.
+Lexical comparison similar to `strcmp()`.
 
-| Return | Meaning      |
-|--------|--------------|
-| `< 0`  | `this < rhs` |
-| `0`    | Equal        |
-| `> 0`  | `this > rhs` |
-
----
-
-### 🔹 `starts_with()` / `ends_with()`
-
-Prefix and suffix checks based on raw bytes.
-
-| Function              | Description                                          |
-|-----------------------|------------------------------------------------------|
-| `starts_with(prefix)` | Returns `true` if first `prefix.size()` bytes match. |
-| `ends_with(suffix)`   | Returns `true` if last `suffix.size()` bytes match.  |
-
-#### Details
-
-* Matching is **strictly bytewise** — no special handling for `'\0'`.
-* Whether a terminator is compared depends on how the view was constructed:
-
-  ```cpp
-  jh::pod::string_view{"hello", strlen("hello")}   // excludes '\0'
-  jh::pod::string_view{"hello", sizeof("hello")}   // includes '\0'
-  ```
-* To avoid ambiguity, use `from_literal()`, which **excludes the terminator automatically**.
-* `jh::immutable_str::pod_view()` follows the same rule — it never includes the final `'\0'`.
+| Return | Meaning |
+|--------|---------|
+| `<0`   | less    |
+| `0`    | equal   |
+| `>0`   | greater |
 
 ---
 
-### 🔹 `find(char ch)`
-
-Returns index of first occurrence of `ch`, or `-1` if not found.
-
-```cpp
-auto i = sv.find('o'); // e.g. 4
-```
-
----
-
-### 🔹 `hash(hash_method = fnv1a64)`
-
-Computes a **constexpr-safe**, deterministic 64-bit hash of the string contents
-using the algorithms defined in [`jh::meta::hash`](../metax/hash.md).
-
-```cpp
-constexpr std::uint64_t
-hash(jh::meta::c_hash hash_method = jh::meta::c_hash::fnv1a64) const noexcept;
-```
-
-| Parameter     | Description                                   |
-|---------------|-----------------------------------------------|
-| `hash_method` | Hash algorithm selector (default: `fnv1a64`). |
-
-**Example:**
-
-```cpp
-using namespace jh::pod;
-
-constexpr auto sv = string_view::from_literal("example");
-constexpr auto h1 = sv.hash(); // FNV-1a 64-bit
-constexpr auto h2 = sv.hash(jh::meta::c_hash::xxhash64);
-```
-
-**Behavior and Notes:**
-
-* The hash is based strictly on the `len` field —
-  including or excluding the trailing `'\0'` produces different results.
-* Fully `constexpr` and `consteval`-safe: may be evaluated at compile time.
-* Uses the same deterministic algorithms provided by [`jh::meta::hash`](../metax/hash.md).
-* No allocation, no RTTI, and no platform-specific variance.
-* Intended for identifiers, string literals, and compile-time symbol mapping.
-* For hashing arbitrary runtime memory, use [`jh::pod::bytes_view::hash()`](bytes_view.md#-hashhash_method--fnv1a64).
-
-**Supported Algorithms:** see
-👉 [`jh::meta::hash` — Core Components](../metax/hash.md#-core-components)
-
----
-
-### 🔹 `copy_to(char* buffer, uint64_t max_len)`
-
-Copies content into a C-style buffer with a null terminator.
-
-| Aspect   | Description                                          |
-|----------|------------------------------------------------------|
-| Purpose  | For debug or interoperability only.                  |
-| POD-safe | ❌ — Not strictly POD-safe; writes a null terminator. |
-| Behavior | Truncates to `max_len - 1`, then writes `'\0'`.      |
-
-> ⚠️ Recommended only for interop with legacy APIs.  
-> Avoid in normal POD pipelines.
-
----
-
-### 🔹 `to_std()` and Explicit Conversion
-
-Provides **interoperability with `std::string_view`** while keeping POD semantics.
-
-```cpp
-explicit constexpr operator std::string_view() const noexcept;
-constexpr std::string_view to_std() const noexcept;
-```
-
-| Function                               | Description                                                        |
-|----------------------------------------|--------------------------------------------------------------------|
-| `explicit operator std::string_view()` | Explicit conversion (requires `static_cast` or brace-init).        |
-| `to_std()`                             | Named helper; returns `std::string_view` directly, no cast needed. |
-
-**Semantics**
-
-* Both conversions perform **no allocation or copy** — they simply wrap the existing pointer and length.
-* Pointer and size are preserved **1:1**.
-* `explicit` form is used to prevent implicit conversions in overload resolution.
-* `to_std()` is a convenience wrapper for readability in mixed API contexts.
-
-**Example:**
-
-```cpp
-jh::pod::string_view sv = jh::pod::string_view::from_literal("world");
-std::string_view stdv = sv.to_std();        // direct named conversion
-std::string_view stdv2 = static_cast<std::string_view>(sv); // explicit cast
-```
-
----
-
-### 🔹 Three-Way Comparison (`operator<=>`)
-
-Performs a **lexicographical three-way comparison**,
-returning a `std::strong_ordering` consistent with **`std::string` and `std::string_view`** semantics.
+### Three-Way Comparison (`operator<=>`)
 
 ```cpp
 constexpr std::strong_ordering
-operator<=>(const jh::pod::string_view& rhs) const noexcept;
+operator<=>(const string_view& rhs) const noexcept;
 ```
 
-**Semantics**
+| Result    | Meaning      |
+|-----------|--------------|
+| `less`    | `this < rhs` |
+| `equal`   | equal        |
+| `greater` | `this > rhs` |
 
-* Returns:
+Properties:
 
-    * `std::strong_ordering::less` if `*this < rhs`
-    * `std::strong_ordering::equal` if `*this == rhs`
-    * `std::strong_ordering::greater` if `*this > rhs`
-* Implements **lexicographic comparison** identical to `compare()`.
-* Uses `std::strong_ordering` specifically to **align with the standard C++ `std::string` and `std::string_view`
-  three-way comparison** behavior,
-  ensuring consistent results and interoperability with standard library algorithms.
+* strict total ordering
+* consistent with `std::string_view`
+* automatically enables `< <= > >=`
 
-**Example:**
+---
+
+# 🔹 Prefix / Suffix
+
+### `starts_with(prefix)`
+
+Returns `true` if the view begins with `prefix`.
+
+### `ends_with(suffix)`
+
+Returns `true` if the view ends with `suffix`.
+
+Both operations compare **raw bytes**.
+
+---
+
+# 🔹 Search
+
+### `find(char ch)`
+
+Returns the index of the first occurrence.
 
 ```cpp
-using namespace jh::pod;
-
-constexpr auto a = string_view::from_literal("abc");
-constexpr auto b = string_view::from_literal("abd");
-
-static_assert((a <=> b) == std::strong_ordering::less);
+auto i = sv.find('o');
 ```
 
-**Properties**
-
-* Fully `constexpr` and `noexcept`.
-* Provides **strict total ordering** identical to the standard string types.
-* Automatically enables all relational operators (`<`, `<=`, `>`, `>=`).
-* Guarantees bitwise consistency with `compare()` and `operator==`.
+| Return | Meaning   |
+|--------|-----------|
+| index  | found     |
+| `-1`   | not found |
 
 ---
 
-### 🧩 Evaluation Model
+# 🔹 Hash
 
-Except for `copy_to()` — which exists purely as a **debugging and interop tool** —
-**all functions in `jh::pod::string_view` are `constexpr`**,
-and most internally use `std::is_constant_evaluated()` to **differentiate compile-time and runtime execution**.
+### `hash(hash_method = fnv1a64)`
 
-This dual-path design ensures:
+Computes a **constexpr-safe deterministic 64-bit hash**.
 
-* **Full compile-time support** (usable in `consteval` expressions).
-* **Optimized runtime behavior**, leveraging `memcmp`/`memcpy` for speed.
+```cpp
+constexpr auto h = sv.hash();
+```
 
-As a result, `jh::pod::string_view` can participate seamlessly in both
-**compile-time symbolic metaprogramming** and **high-performance runtime pipelines** without branching overhead.
+| Parameter     | Description        |
+|---------------|--------------------|
+| `hash_method` | algorithm selector |
+
+Characteristics:
+
+* constexpr / consteval safe
+* deterministic
+* byte-based
+
+Supported algorithms are defined in:
+
+```
+jh::meta::hash
+```
 
 ---
 
-## 🧾 Debug Stringification
+# 🔹 Character Validation
 
-When streamed to an `std::ostream`,
-a `jh::pod::string_view` renders its contents directly as a quoted literal:
+These APIs validate textual properties of the view.
+
+---
+
+### `is_digit()`
+
+Checks if all characters are decimal digits.
 
 ```
-string_view"Hello world"
+0-9
+```
+
+---
+
+### `is_number()`
+
+Validates full decimal number syntax.
+
+Grammar:
+
+```
+[+-]? DIGIT+ ('.' DIGIT+)? ([eE][+-]?DIGIT+)?
+```
+
+---
+
+### `is_alpha()`
+
+Checks if all characters are alphabetic.
+
+```
+A-Z a-z
+```
+
+---
+
+### `is_alnum()`
+
+Checks if characters are alphanumeric.
+
+```
+[A-Za-z0-9]
+```
+
+---
+
+### `is_ascii()`
+
+Returns true if every byte is within:
+
+```
+0 – 127
+```
+
+---
+
+### `is_printable_ascii()`
+
+Checks for printable ASCII.
+
+```
+32 – 126
+```
+
+---
+
+### `is_legal()`
+
+Validates that the string is composed of
+
+* printable ASCII
+* valid UTF-8 sequences
+
+Rejects:
+
+* invalid UTF-8
+* illegal ASCII control characters
+
+---
+
+### `is_hex()`
+
+Checks if the string is a valid hexadecimal sequence.
+
+Requirements:
+
+* length must be even
+* all characters must be hex digits
+
+---
+
+### `is_base64()`
+
+Checks if the string is valid Base64.
+
+Constraints:
+
+* length multiple of 4
+* valid alphabet
+* `=` padding allowed
+
+---
+
+### `is_base64url()`
+
+Checks Base64URL format.
+
+Characteristics:
+
+* URL-safe alphabet
+* optional padding
+
+---
+
+# 🔹 UTF-8 Utilities
+
+### `semantic_len()`
+
+Returns the number of **Unicode code points**.
+
+```cpp
+auto n = sv.semantic_len();
+```
+
+Notes:
+
+* counts UTF-8 code points
+* not grapheme clusters
+* assumes valid UTF-8
+
+---
+
+# 🔹 Utilities
+
+### `copy_to(char* buffer, uint64_t max_len)`
+
+Copies the content into a C-style buffer.
+
+Behavior:
+
+* truncates to `max_len-1`
+* always null-terminates
+
+⚠️ Intended only for debug or legacy interop.
+
+---
+
+# 🔹 Interoperability
+
+### Explicit conversion
+
+```cpp
+explicit operator std::string_view() const noexcept;
+```
+
+---
+
+### `to_std()`
+
+Named helper for conversion.
+
+```cpp
+std::string_view s = sv.to_std();
+```
+
+Characteristics:
+
+* zero-copy
+* zero-allocation
+
+---
+
+# 🔹 Literals
+
+Namespace:
+
+```cpp
+jh::pod::literals
+```
+
+### `_psv`
+
+User-defined literal for `string_view`.
+
+```cpp
+using namespace jh::pod::literals;
+
+auto sv = "hello"_psv;
+```
+
+Properties:
+
+* always safe
+* literal storage is static
+* never dangles
+
+---
+
+# 🧩 Evaluation Model
+
+All functions except `copy_to()` are `constexpr`.
+
+The implementation uses:
+
+```cpp
+std::is_constant_evaluated()
+```
+
+to distinguish between
+
+* **compile-time execution**
+* **optimized runtime paths**
+
+This allows:
+
+* compile-time hashing
+* constexpr validation
+* optimized runtime via `memcmp`
+
+---
+
+# 🧾 Debug Stringification
+
+When streamed to `std::ostream`, a `jh::pod::string_view` renders its contents directly as a quoted literal:
+
+```
+string_view"Hello"
 ```
 
 Example:
 
 ```cpp
-jh::pod::string_view sv = jh::pod::string_view::from_literal("Hello");
-std::cout << sv; // → string_view"Hello"
+std::cout << sv;
 ```
 
-> ⚠️ Output is **unescaped** — control or non-printable characters
-> will appear as-is.  
-> This is intentional: `string_view` is a **raw observation** type,
-> not an owned string with formatting semantics.
+⚠️ Output is **not escaped** — control or non-printable characters will appear exactly as stored.
+
+### Debug Support
+
+The debug stringification mechanism is **not automatically included** by all headers.
+
+It becomes available **only when the POD module is explicitly imported**:
+
+```cpp
+#include <jh/pod>
+```
+
+This header pulls in the internal debugging utilities:
+
+```
+jh/pods/stringify.h
+```
+
+Without including `<jh/pod>`, streaming operators for POD types are **not defined**.
 
 ---
 
-## 🧩 Integration Notes
+### Interaction with Derived Views
 
-* `jh::pod::string_view` is commonly used as a **POD-safe view** returned from
-  `jh::immutable_str::pod_view()`.
-* Like all `jh::pod` non-owning types, it must **not dangle** —
-  the underlying character storage must remain valid.
-* Unlike `bytes_view`, it is intended for **semantic string views**,
-  not arbitrary memory interpretation.
-* Supports compile-time usage in string-based metaprogramming
-  (e.g., constexpr identifiers or symbol tables).
+`jh::pod::string_view` often appears as the return type of:
+
+```cpp
+jh::immutable_str::pod_view()
+jh::meta::t_str::pod_view()
+```
+
+However:
+
+* Including
+
+```
+<jh/immutable_str>
+```
+
+or
+
+```
+<jh/meta>
+```
+
+**does NOT automatically enable POD debug printing.**
+
+The `std::ostream` streaming operator becomes available **only when `<jh/pod>` is included**.
 
 ---
 
-## 🧠 Summary
+### Stability Notice
 
-| Aspect     | Description                                 |
-|------------|---------------------------------------------|
-| Category   | POD string view                             |
-| Ownership  | Non-owning                                  |
-| Layout     | `const char* + uint64_t`                    |
-| Comparison | Deep bytewise equality                      |
-| Hashing    | Constexpr / Consteval safe                  |
-| Printing   | `string_view"..."` unescaped literal output |
-| Lifetime   | Must not dangle                             |
-| ABI        | Stable POD structure                        |
-| Consteval  | Supported (semantically meaningful)         |
+The file
+
+```
+jh/pods/stringify.h
+```
+
+exists **purely for debugging and inspection of POD types**.
+
+Its APIs are **not considered stable** and **may change without notice** between toolkit versions.
+
+---
+
+### Recommended Printing Method
+
+For production or stable formatting, convert to `std::string_view`:
+
+```cpp
+std::cout << sv.to_std();
+```
+
+or
+
+```cpp
+std::string_view s = sv.to_std();
+```
+
+This guarantees stable behavior independent of the POD debug facilities.
+
+---
+
+# 🧩 Integration Notes
+
+`jh::pod::string_view` commonly appears as the return type of:
+
+```
+jh::immutable_str::pod_view()
+jh::meta::t_str::pod_view()
+```
+
+Key rules:
+
+* non-owning
+* must not outlive the underlying storage
+* suitable for compile-time identifiers and symbol tables
+* debug printing requires explicit inclusion of `<jh/pod>`
+
+---
+
+# 🧠 Summary
+
+| Aspect     | Description                   |
+|------------|-------------------------------|
+| Category   | POD string view               |
+| Ownership  | Non-owning                    |
+| Layout     | `const char* + uint64_t`      |
+| Comparison | Deep bytewise                 |
+| Hashing    | constexpr safe                |
+| Encoding   | ASCII / UTF-8 aware utilities |
+| Printing   | raw literal form              |
+| ABI        | stable POD                    |
 
 ---
 
 > 📌 **Design Philosophy**
 >
 > `jh::pod::string_view` provides the semantic equivalent of `std::string_view`,
-> constrained to a POD-safe ABI.  
-> Its comparison and hashing are always **bytewise**,
-> ensuring predictable behavior across toolchains and platforms.
+> constrained to a POD-safe ABI.
 >
-> Unlike `bytes_view`, which represents *arbitrary reinterpretation of memory*,
-> `string_view` embodies the semantics of **immutable text** — 
-> making compile-time hashing, literal binding, and deep equality
-> both valid and well-defined.
+> Comparison and hashing are always **bytewise** to ensure deterministic
+> cross-platform behavior.
+>
+> Unlike `bytes_view`, which represents arbitrary memory,
+> `string_view` represents **immutable textual data** suitable for
+> compile-time metaprogramming and symbol identifiers.

--- a/docs/serialize_io/overview.md
+++ b/docs/serialize_io/overview.md
@@ -35,6 +35,7 @@ It does **not** provide object serialization frameworks or schema-based formats.
 | Submodule               | Header                        |  Status  | Description                                                                                                                                                                 |
 |-------------------------|-------------------------------|:--------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [`base64`](base64.md)   | `<jh/serialize_io/base64.h>`  | ✅ Stable | Binary-to-text encoding using Base64 / Base64URL (RFC 4648). Output is ASCII-safe and **universally decodable** by any compliant Base64 implementation.                     |
+| [`uri`](uri.md)         | `<jh/serialize_io/uri.h>`     | ✅ Stable | URI percent-encoding and decoding utilities (RFC 3986). Provides **basic APIs** and **UTF-8 validated APIs** for safely encoding textual data within URI components.        |
 | [`huffman`](huffman.md) | `<jh/serialize_io/huffman.h>` | ✅ Stable | Binary compression codec implementing standard and canonical Huffman algorithms. Streams are **signature-bound** and must be decoded using the same `Signature` definition. |
 
 ---
@@ -49,6 +50,13 @@ The codecs in `jh::serio` differ intentionally in **who can recover the data**.
 * Can be decoded by **any Base64 / Base64URL implementation**
 * No library- or project-specific metadata is required
 * Designed for interoperability and transport
+
+### `uri`
+
+* Output is standard URI percent-encoded text
+* Can be decoded by **any RFC 3986-compliant percent-decoder**
+* No library-specific metadata is required
+* Designed for URI/URL text escaping and transport safety
 
 ### `huffman`
 
@@ -76,6 +84,7 @@ A mismatched or missing signature causes decompression to fail explicitly.
 |------------------------|:----------------------------------------------------------------------------------------------------------------------------:|
 | 🏠 **Back to README**  |         [![Back to README](https://img.shields.io/badge/Back%20to%20README-blue?style=flat-square)](../../README.md)         |
 | 📗 **Go to `base64`**  |  [![Go to Base64 Reference](https://img.shields.io/badge/Go%20to%20Base64%20Reference-green?style=flat-square)](base64.md)   |
+| 📙 **Go to `uri`**     |       [![Go to URI Reference](https://img.shields.io/badge/Go%20to%20URI%20Reference-green?style=flat-square)](uri.md)       |
 | 📘 **Go to `huffman`** | [![Go to Huffman Reference](https://img.shields.io/badge/Go%20to%20Huffman%20Reference-green?style=flat-square)](huffman.md) |
 
 ---

--- a/docs/serialize_io/uri.md
+++ b/docs/serialize_io/uri.md
@@ -1,0 +1,309 @@
+# 🍯 **JH Toolkit — `jh::serio::uri` API Reference**
+
+📁 **Header:** `<jh/serialize_io/uri.h>`  
+📦 **Namespace:** `jh::serio::uri`  
+📅 **Version:** **1.4.1+** (2025)  
+👤 **Author:** JeongHan-Bae `<mastropseudo@gmail.com>`
+
+<div align="right">
+
+[![Back to README](https://img.shields.io/badge/%20Back%20to%20README-blue?style=flat-square)](../../README.md)
+[![Back to Module](https://img.shields.io/badge/%20Back%20to%20Module-green?style=flat-square)](overview.md)
+
+</div>
+
+---
+
+## 🧭 Introduction
+
+`jh::serio::uri` provides the **URI percent-encoding and decoding layer**
+of the JH Toolkit — a safe and portable implementation of **RFC 3986
+percent-encoding** designed for reliable transport of textual data
+through URI/URL components.
+
+The module offers two API tiers:
+
+* **Basic APIs** — high-performance encoding/decoding without input validation.
+* **Safe APIs** — strict UTF-8 validation and control-character rejection.
+
+This design allows developers to choose between **maximum flexibility**
+and **strong safety guarantees** depending on the context of the data.
+
+All functions are **header-only**, **cross-platform**, and throw
+**standard exceptions** when malformed data is encountered.
+
+---
+
+## 🌍 Overview
+
+| Property            | Description                                             |
+|---------------------|---------------------------------------------------------|
+| **Module**          | Serialization I/O (`jh::serio`)                         |
+| **Purpose**         | Encode and decode URI components using percent-encoding |
+| **Specification**   | RFC 3986                                                |
+| **Encoding format** | `%XX` hexadecimal byte representation                   |
+| **Text-safe**       | ✅ Yes                                                   |
+| **Binary support**  | Technically possible, but not recommended               |
+| **Safety layer**    | Optional UTF-8 validation                               |
+| **Integration**     | Uses `jh::pod::string_view` validation utilities        |
+
+---
+
+## 🔹 Core API
+
+| Function                        | Description                                         |
+|---------------------------------|-----------------------------------------------------|
+| `encode(std::string_view)`      | Percent-encode a string without validation.         |
+| `decode(std::string_view)`      | Decode percent-encoded text with syntax validation. |
+| `encode_safe(std::string_view)` | Encode after verifying UTF-8 legality.              |
+| `decode_safe(std::string_view)` | Decode and validate the resulting UTF-8 text.       |
+
+---
+
+## ✳️ Percent Encoding (`encode`)
+
+### `encode()`
+
+```cpp
+[[nodiscard]] inline std::string encode(
+    const std::string_view& input
+);
+```
+
+Encodes a string into **URI percent-encoded form**.
+
+Characters outside the **unreserved set defined by RFC 3986** are converted
+into the `%XX` hexadecimal representation.
+
+Example:
+
+```cpp
+auto encoded = jh::serio::uri::encode("hello world");
+// "hello%20world"
+```
+
+### Behavior
+
+* Unreserved characters remain unchanged.
+* Reserved or unsafe characters are encoded as `%XX`.
+* No UTF-8 or legality checks are performed.
+
+### Notes
+
+* Suitable when the caller already controls the input data.
+* Allows encoding of arbitrary byte sequences.
+
+---
+
+## ✳️ Percent Decoding (`decode`)
+
+### `decode()`
+
+```cpp
+[[nodiscard]] inline std::string decode(
+    const std::string_view& input
+);
+```
+
+Decodes percent-encoded URI text back into its original byte sequence.
+
+Example:
+
+```cpp
+auto decoded = jh::serio::uri::decode("hello%20world");
+// "hello world"
+```
+
+### Validation
+
+The function verifies:
+
+* Proper `%XX` structure
+* Valid hexadecimal digits
+* Correct sequence boundaries
+
+### Throws
+
+| Exception            | Condition                                 |
+|----------------------|-------------------------------------------|
+| `std::runtime_error` | Input contains malformed percent-encoding |
+
+---
+
+## 🔐 Safe API Variants
+
+The safe variants enforce **textual legality guarantees**.
+
+They validate that the processed data:
+
+* Is **valid UTF-8**
+* Contains **no control characters**
+
+These checks use the utility methods from `jh::pod::string_view`.
+
+---
+
+### `encode_safe()`
+
+```cpp
+[[nodiscard]] inline std::string encode_safe(
+    const std::string_view& input
+);
+```
+
+Encodes a string into percent-encoded form **after validating its legality**.
+
+### Validation Rules
+
+The input must satisfy:
+
+* Valid UTF-8 sequence
+* No control characters
+
+### Throws
+
+| Exception            | Condition                                               |
+|----------------------|---------------------------------------------------------|
+| `std::runtime_error` | Input is not valid UTF-8 or contains control characters |
+
+### Recommended Use
+
+Use this variant when handling:
+
+* HTTP query parameters
+* URL path segments
+* Web form input
+* Any **external or untrusted text**
+
+---
+
+### `decode_safe()`
+
+```cpp
+[[nodiscard]] inline std::string decode_safe(
+    const std::string_view& input
+);
+```
+
+Decodes percent-encoded text and validates the resulting string.
+
+### Validation Rules
+
+After decoding, the output must satisfy:
+
+* Valid UTF-8 sequence
+* No control characters
+
+### Throws
+
+| Exception            | Condition                                                        |
+|----------------------|------------------------------------------------------------------|
+| `std::runtime_error` | Malformed percent-encoding                                       |
+| `std::runtime_error` | Decoded output is not valid UTF-8 or contains control characters |
+
+### Recommended Use
+
+Use this function when decoding:
+
+* URLs from browsers
+* HTTP query strings
+* External API inputs
+* Any untrusted source
+
+---
+
+## 🧠 Design Notes
+
+### Two-tier Safety Model
+
+The API separates **encoding mechanics** from **semantic validation**:
+
+| Layer     | Purpose                               |
+|-----------|---------------------------------------|
+| Basic API | Maximum flexibility and compatibility |
+| Safe API  | Strict textual safety                 |
+
+This avoids unnecessary overhead for trusted internal data while
+still providing robust safety guarantees for external input.
+
+---
+
+### UTF-8 Legality Checking
+
+The safety layer relies on:
+
+```cpp
+jh::pod::string_view::is_legal()
+```
+
+This check ensures:
+
+* Proper UTF-8 byte sequences
+* Absence of ASCII control characters
+
+This validation cost is approximately equivalent to **a single linear
+scan of the string**.
+
+---
+
+### Internal Implementation
+
+The high-level API is built on optimized primitives located in:
+
+```cpp
+jh::detail::uri_common
+```
+
+These provide:
+
+* fast percent-encoding loops
+* precomputed character classification
+* minimal branching during encoding/decoding
+
+---
+
+## 🔄 URI Percent Encoding vs Base64
+
+Although both modules exist under `jh::serio`, they solve different problems.
+
+| Aspect        | URI Encoding        | Base64                  |
+|---------------|---------------------|-------------------------|
+| Category      | Text escaping       | Binary-to-text encoding |
+| Output format | `%XX` escapes       | Base64 alphabet         |
+| Data model    | Primarily textual   | Binary data             |
+| Output size   | Slightly larger     | ~33% larger             |
+| Typical usage | URLs, query strings | binary transport        |
+
+### Recommendation
+
+For arbitrary binary payloads:
+
+```cpp
+jh::serio::base64
+jh::serio::base64url
+```
+
+should be used instead of percent-encoding.
+
+---
+
+## 🧩 Summary
+
+`jh::serio::uri` provides a **robust and standards-compliant
+percent-encoding implementation** for URI and URL components.
+
+Its dual API design allows developers to choose between:
+
+* **Flexible encoding for internal pipelines**
+* **Strict validation for external data**
+
+| API             | Validation                   | Typical Usage     |
+|-----------------|------------------------------|-------------------|
+| `encode()`      | ✘ None                       | Internal encoding |
+| `decode()`      | ✔ Syntax only                | General decoding  |
+| `encode_safe()` | ✔ UTF-8 + control char check | User input        |
+| `decode_safe()` | ✔ Full validation            | Web/HTTP data     |
+
+The module integrates seamlessly with the JH Toolkit serialization
+ecosystem and complements binary codecs such as
+`jh::serio::base64` and `jh::serio::base64url`.

--- a/docs/synchronous/control_buf.md
+++ b/docs/synchronous/control_buf.md
@@ -54,24 +54,24 @@ This model intentionally rejects STL-style relocation semantics.
 Memory is allocated in **fixed-size blocks**.
 
 ```cpp
-static constexpr std::size_t BLOCK_SIZE = JH_FIXED_VEC_BLOCK_SIZE;
+static constexpr std::size_t BLOCK_SIZE = JH_CTRL_BUFFER_BLOCK_SIZE;
 ```
 
 ### Block size configuration
 
-`JH_FIXED_VEC_BLOCK_SIZE` can be configured in two ways:
+`JH_CTRL_BUFFER_BLOCK_SIZE` can be configured in two ways:
 
 1. **Preprocessor definition**
 
    ```cpp
-   #define JH_FIXED_VEC_BLOCK_SIZE 128
+   #define JH_CTRL_BUFFER_BLOCK_SIZE 128
    #include <jh/sync>
    ```
 
 2. **Build system (recommended)**
 
    ```cmake
-   add_compile_definitions(JH_FIXED_VEC_BLOCK_SIZE=128)
+   add_compile_definitions(JH_CTRL_BUFFER_BLOCK_SIZE=128)
    ```
 
 If not defined, the default value is **64**.

--- a/docs/synchronous/overview.md
+++ b/docs/synchronous/overview.md
@@ -34,11 +34,12 @@ larger systems without hidden coordination logic.
 
 ## 🔹 Core Components (Stable)
 
-| Component           | Header                                |  Status  | Description                                                                                                                                                     |
-|---------------------|---------------------------------------|:--------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `const_lock<Mutex>` | `<jh/synchronous/const_lock.h>`       | ✅ Stable | RAII-based **const-oriented lock guard** enforcing immutability barriers for mutex-like synchronization objects.                                                |
-| `control_buf<T>`    | `<jh/synchronous/control_buf.h>`      | ✅ Stable | **Block-allocated control container** for non-copyable, non-movable synchronization primitives with strict address stability guarantees.                        |
-| `ipc` (submodule)   | `<jh/synchronous/ipc.h>` / `<jh/ipc>` | ✅ Stable | **Inter-process synchronization primitives** built on OS semaphores and shared memory (mutexes, condition variables, counters, POD storage, process launchers). |
+| Component           | Header                                |  Status  | Description                                                                                                                                                                                                             |
+|---------------------|---------------------------------------|:--------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `const_lock<Mutex>` | `<jh/synchronous/const_lock.h>`       | ✅ Stable | RAII-based **const-oriented lock guard** enforcing immutability barriers for mutex-like synchronization objects.                                                                                                        |
+| `control_buf<T>`    | `<jh/synchronous/control_buf.h>`      | ✅ Stable | **Block-allocated control container** for non-copyable, non-movable synchronization primitives with strict address stability guarantees.                                                                                |
+| `strong_lock`       | `<jh/synchronous/strong_lock.h>`      | ✅ Stable | **Ordering-strengthened RAII lock adapters** (`strong_unique_lock`, `strong_shared_lock`) that insert `seq_cst` fences at lock boundaries to reduce cross-domain ordering anomalies when mixing locks and atomic types. |
+| `ipc` (submodule)   | `<jh/synchronous/ipc.h>` / `<jh/ipc>` | ✅ Stable | **Inter-process synchronization primitives** built on OS semaphores and shared memory (mutexes, condition variables, counters, POD storage, process launchers).                                                         |
 
 ---
 
@@ -48,16 +49,8 @@ larger systems without hidden coordination logic.
 
 * **const-correct synchronization semantics** (`const_lock`)
 * **stable-address control-object storage** (`control_buf`)
+* **ordering-strengthened lock adapters** (`strong_lock`)
 * **process-level coordination via shared memory** (`ipc`)
-
-All components are:
-
-* allocator-aware where applicable
-* free of hidden global state
-* explicit about ownership and lifetime
-* usable independently
-
-There is no implicit coupling between components.
 
 ---
 

--- a/docs/synchronous/strong_lock.md
+++ b/docs/synchronous/strong_lock.md
@@ -1,0 +1,459 @@
+## ⏱️ **JH Toolkit — `jh::sync::strong_lock` API Reference**
+
+📁 **Header:** `<jh/synchronous/strong_lock.h>`  
+📦 **Namespace:** `jh::sync`  
+📅 **Version:** 1.4.1+ (2026)  
+👤 **Author:** JeongHan-Bae `<mastropseudo@gmail.com>`
+
+---
+
+## 🧭 Introduction
+
+`jh::sync::strong_unique_lock` and `jh::sync::strong_shared_lock`
+provide **ordering-strengthened RAII adapters** for mutex-like synchronization primitives.
+
+They insert:
+
+```cpp
+std::atomic_thread_fence(std::memory_order_seq_cst);
+```
+
+* Immediately after lock acquisition
+* Immediately before lock release
+
+The purpose is to **reduce cross-domain ordering anomalies**
+when locks and atomics interact under high concurrency.
+
+---
+
+## 🔸 Ordering Semantics
+
+Standard C++ locking provides acquire-release semantics.  
+However, ISO C++ does **not** guarantee that such semantics fully replicate
+the observable global ordering often associated with POSIX `pthread_rwlock`.
+
+The strong adapters strengthen ordering within the **C++ abstract machine**
+by introducing sequentially-consistent fences around lock boundaries.
+
+### What This Guarantees
+
+* Stronger cross-thread visibility at the language level
+* Reduced observable reordering when mixing:
+
+    * `std::shared_mutex`
+    * atomics (`load`, `fetch_*`)
+    * reference-counted objects (`shared_ptr`, `weak_ptr`)
+
+### What This Does NOT Guarantee
+
+* No hardware-level global total order
+* No strict equivalence to POSIX `pthread_rwlock`
+* No elimination of all visibility anomalies under extreme stress
+
+> This is a bounded, practical strengthening — not a formal cross-platform equivalence layer.
+
+---
+
+## 🔹 Overview
+
+| Aspect                | Description                                       |
+|-----------------------|---------------------------------------------------|
+| **Purpose**           | Strengthen lock boundary ordering                 |
+| **Mechanism**         | `seq_cst` fences after acquire and before release |
+| **Exclusive Variant** | `strong_unique_lock`                              |
+| **Shared Variant**    | `strong_shared_lock`                              |
+| **Platform Alias**    | `posix_smtx_*_lock`                               |
+| **Primary Target**    | POSIX                                             |
+| **Windows Strategy**  | Language-level strengthening approximation        |
+
+---
+
+## 🔹 Core Components
+
+| Symbol                        | Type           | Description                      |
+|-------------------------------|----------------|----------------------------------|
+| `strong_unique_lock<Mutex>`   | Class Template | Strong exclusive lock adapter    |
+| `strong_shared_lock<Mutex>`   | Class Template | Strong shared lock adapter       |
+| `posix_smtx_unique_lock<Mtx>` | Alias Template | Platform-adaptive exclusive lock |
+| `posix_smtx_shared_lock<Mtx>` | Alias Template | Platform-adaptive shared lock    |
+
+---
+
+## 🔹 Class Reference — `strong_unique_lock`
+
+### Declaration
+
+```cpp
+template <jh::concepts::basic_lockable Mutex>
+class strong_unique_lock;
+```
+
+### Requirements
+
+* `Mutex` satisfies `jh::concepts::basic_lockable`
+* Must provide:
+
+    * `lock()`
+    * `unlock()`
+
+### Behavior
+
+| Phase        | Action                                    |
+|--------------|-------------------------------------------|
+| Construction | Calls `lock()` → issues `seq_cst` fence   |
+| Destruction  | Issues `seq_cst` fence → calls `unlock()` |
+
+---
+
+## 🔹 Class Reference — `strong_shared_lock`
+
+### Declaration
+
+```cpp
+template <jh::concepts::shared_lockable Mutex>
+class strong_shared_lock;
+```
+
+### Requirements
+
+* `Mutex` satisfies `jh::concepts::shared_lockable`
+* Must provide:
+
+    * `lock_shared()`
+    * `unlock_shared()`
+
+### Behavior
+
+| Phase        | Action                                           |
+|--------------|--------------------------------------------------|
+| Construction | Calls `lock_shared()` → issues `seq_cst` fence   |
+| Destruction  | Issues `seq_cst` fence → calls `unlock_shared()` |
+
+---
+
+## 🔹 Platform-Adaptive Aliases — `posix_smtx_*_lock`
+
+### On POSIX Systems
+
+| Alias                    | Expands To         |
+|--------------------------|--------------------|
+| `posix_smtx_unique_lock` | `std::unique_lock` |
+| `posix_smtx_shared_lock` | `std::shared_lock` |
+
+Relies on native pthread-backed semantics.
+
+---
+
+### On Windows
+
+| Alias                    | Expands To           |
+|--------------------------|----------------------|
+| `posix_smtx_unique_lock` | `strong_unique_lock` |
+| `posix_smtx_shared_lock` | `strong_shared_lock` |
+
+Provides a language-level strengthening approximation.
+
+---
+
+## 🔹 Recommended Usage Pattern
+
+Use `jh::sync::posix_smtx_*_lock` as a **drop-in replacement**
+for `std::*_lock` when operating on:
+
+* `std::shared_mutex`
+* `std::shared_timed_mutex`
+
+For simple scoped locking:
+
+```cpp
+std::shared_mutex sm;
+
+{
+    jh::sync::posix_smtx_unique_lock lock(sm);
+    // exclusive section
+}
+
+{
+    jh::sync::posix_smtx_shared_lock lock(sm);
+    // shared (reader) section
+}
+```
+
+---
+
+## 🔸 ISO Semantics vs Windows Observations (Extended Analysis)
+
+Under ISO C++ rules, replacing:
+
+```
+std::unique_lock / std::shared_lock
+```
+
+with:
+
+```
+jh::sync::posix_smtx_*_lock
+```
+
+remains fully conforming and **UB-risk-free at the language level**.
+
+The adapters only introduce additional
+`std::atomic_thread_fence(std::memory_order_seq_cst)`
+calls and do not alter lock ownership semantics.
+
+From the perspective of the C++ abstract machine:
+
+* `seq_cst` operations are globally ordered
+* Acquire–release relationships are preserved
+* No additional undefined behavior is introduced
+
+---
+
+### 🔹 Windows (MinGW) Runtime Characteristics
+
+Empirical stress testing on:
+
+* MinGW-w64 / MinGW-clang
+* Windows runtime libraries (msvcrt / ucrt)
+* High-core-count systems
+* Extreme high-concurrency workloads
+
+reveals behavior that differs from typical POSIX convergence characteristics.
+
+---
+
+### 1️⃣ Likely `shared_mutex` Backend: SRWLock
+
+On Windows, `std::shared_mutex` is very likely implemented on top of **SRWLock**.
+
+SRWLock:
+
+* Is optimized primarily for throughput
+* Prioritizes efficiency over fairness
+* May exhibit scheduling asymmetry under contention
+* Does not aim to emulate strict POSIX-style ordering convergence
+
+This design decision favors performance, not deterministic global ordering.
+
+---
+
+### 2️⃣ Cross-Layer Assumption Risk (Compiler vs Runtime)
+
+In MinGW environments:
+
+* The compiler may assume the Windows runtime provides sufficient atomic guarantees.
+* The runtime may assume the compiler emits sufficient fencing for atomic types.
+
+As a result:
+
+* Explicit `seq_cst` fences inserted at lock boundaries may not always translate
+  into sufficiently strong hardware barriers across all optimized paths.
+* Some fence effects may be absorbed or weakened at the machine-code level,
+  depending on architecture and optimization.
+
+This creates the possibility of **ordering dilution across abstraction layers**.
+
+---
+
+## 🔸 Practical Stress Amplification (Hardware-Originated Effects)
+
+On Windows (MinGW), increasing:
+
+* Thread count
+* Call frequency (pressure per unit time)
+* Per-operation computational cost
+* Lock + atomic interaction density
+
+increases the probability of:
+
+* **Visibility widening**
+* **Transient ordering anomalies**
+
+It is critical to clarify:
+
+These effects originate from **physical CPU behavior**, including:
+
+* Cache coherence propagation delay
+* Store buffer effects
+* Core-to-core scheduling asymmetry
+* Microarchitectural reordering windows
+
+At the **ISO C++ abstract machine level**,
+`seq_cst` operations are globally ordered and not reordered.
+
+The anomalies described here are therefore **not violations of the C++ memory model**.
+
+They arise from:
+
+* Real hardware propagation latency
+* SRWLock scheduling characteristics
+* Runtime-level atomic implementation details
+
+Under extreme pressure, the time window between:
+
+* "logically ordered"
+* and "physically visible on all cores"
+
+may widen enough to become observable.
+
+---
+
+## 🔸 Interaction Model: `shared_mutex` + Atomic Types
+
+The visibility effects are most pronounced when:
+
+* `std::shared_mutex` is used
+* and **atomic types** interact with it
+
+In this document, **atomic types** include:
+
+* `std::atomic<T>`
+* `std::shared_ptr`
+* `std::weak_ptr`
+
+The issue is **not** the mixture of `atomic<T>` and `shared_ptr` with each other.
+
+The problematic pattern is:
+
+> atomic types interacting with `shared_mutex` under high contention.
+
+Typical scenarios include:
+
+* Atomic counters updated inside or near shared/exclusive regions
+* Reference counting occurring concurrently with lock transitions
+* High-frequency ownership or lifetime transitions
+* Expensive operations inside lock-protected sections
+
+---
+
+## 🔸 Harmful Consequence: Stale Atomic Reads
+
+Reading stale values from atomic types is not benign.
+
+A particularly sensitive case is:
+
+```
+std::weak_ptr::lock()
+```
+
+Risk scenario:
+
+1. Logical reference count transitions from 1 → 0
+2. Managed object is destroyed
+3. Another core reads a stale count value of 1
+4. `weak_ptr::lock()` succeeds
+5. The returned `shared_ptr` dereferences freed memory
+
+At the language level, this constitutes **undefined behavior**.
+
+In practice, it most commonly manifests as:
+
+* Use-after-free
+* Invalid memory access
+* Out-of-bounds memory reads
+* Rare but severe crash conditions under stress
+
+While ISO C++ specifies sequential consistency,
+extreme real-world hardware scheduling can widen the propagation gap enough
+to expose such edge cases.
+
+---
+
+## 🔸 Rehash and Memory Movement Amplifiers
+
+Additional amplification factors include:
+
+* `unordered_*` rehash operations
+* Allocator pressure
+* Page-level memory movement
+* Cache-line bouncing under contention
+
+These behaviors are permitted by ISO C++ and do not violate the model.
+
+However, under extreme stress they may increase the width of observable
+cross-core visibility gaps.
+
+---
+
+## 🔸 Structural Limitation
+
+Once execution enters:
+
+* Runtime-managed reference counting (`shared_ptr`)
+* OS-level primitives (SRWLock)
+* Compiler-emitted atomic sequences
+
+this library cannot:
+
+* Inject fences into runtime internals
+* Modify `shared_ptr` reference counting logic
+* Alter SRWLock scheduling policy
+* Enforce hardware-level total order
+
+Therefore, no further defensive layer exists within this implementation.
+
+---
+
+## 🔸 Platform Scope and Design Priority
+
+JH-Toolkit is designed primarily for POSIX platforms.
+
+Windows (MinGW) support is:
+
+* A bounded engineering approximation
+* A best-effort strengthening strategy
+* Not a full semantic reconstruction
+
+A complete Windows-level solution would likely require:
+
+* Replacing `shared_mutex`
+* Replacing `shared_ptr` reference counting mechanisms
+* Designing a custom concurrency substrate
+
+Such changes would:
+
+* Dramatically increase implementation complexity
+* Significantly increase cognitive and maintenance burden
+* Reduce performance characteristics
+
+This is outside the intended scope of the project.
+
+---
+
+## 🔸 Final Limitation Statement
+
+This implementation:
+
+* Strengthens ordering at the C++ abstract machine level
+* Reduces many cross-domain anomalies
+* Improves practical determinism under stress
+
+But it **cannot guarantee**:
+
+* Elimination of all hardware-originated visibility gaps
+* Strict hardware-level global total order
+* Full equivalence to POSIX `pthread_rwlock` semantics
+
+Under extreme concurrency on Windows (MinGW),
+developers must not assume perpetual global total-order convergence,
+especially when atomic types interact with `shared_mutex`.
+
+---
+
+## 🧩 Summary
+
+`strong_lock` provides:
+
+* RAII lock adapters
+* Sequentially-consistent fences at lock boundaries
+* Platform-adaptive behavior
+* Practical strengthening for mixed lock/atomic workloads
+
+It does **not** claim:
+
+* Hardware-level total order
+* Strict POSIX equivalence
+* Complete elimination of concurrency anomalies
+
+> `strong_lock` is a pragmatic ordering reinforcement layer,
+> not a formal global-ordering guarantee.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,6 +10,7 @@ set(EXAMPLE_SOURCES
         example_process_lock.cpp
         example_occ_box.cpp
         example_process_shm.cpp
+        example_runtime_arr.cpp
         hello.cpp
 )
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,7 +17,10 @@ foreach(src ${EXAMPLE_SOURCES})
     get_filename_component(fname ${src} NAME)
     get_filename_component(target ${fname} NAME_WE)
     add_executable(${target} ${src})
-    target_include_directories(${target} PRIVATE ${PROJECT_SOURCE_DIR}/include)
+    target_link_libraries(${target}
+            PRIVATE
+            jh-toolkit
+    )
 endforeach()
 
 # Add process_lock subdirectory (defines writer/reader)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -11,6 +11,7 @@ set(EXAMPLE_SOURCES
         example_occ_box.cpp
         example_process_shm.cpp
         example_runtime_arr.cpp
+        example_ordered_map.cpp
         hello.cpp
 )
 

--- a/examples/ensure_output.h
+++ b/examples/ensure_output.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "jh/macros/platform.h"
+#include <jh/macros/platform.h>
 
 #if IS_WINDOWS
 #include <windows.h>

--- a/examples/ensure_output.h
+++ b/examples/ensure_output.h
@@ -27,13 +27,8 @@
 
 struct EnsureOutput {
     EnsureOutput() {
-        // On MinGW/Clang/GCC toolchains, fileno() is correct
-        _setmode(fileno(stdout), _O_U16TEXT);
-
-        // Ensure narrow-output (printf, cout) uses UTF-8
         SetConsoleOutputCP(CP_UTF8);
 
-        // Enable ANSI escape sequences (color, emoji, etc.)
         HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
         if (hOut != INVALID_HANDLE_VALUE) {
             DWORD dwMode = 0;

--- a/examples/ensure_output.h
+++ b/examples/ensure_output.h
@@ -1,35 +1,53 @@
 // ensure_output.h
+//
+// This header ensures that console output does not become garbled on Windows
+// when printing non-ASCII characters (e.g., UTF-8 text, emoji, etc.).
+//
+// Windows support in this library is limited to MinGW toolchains
+// (MinGW-w64 / MinGW-clang). MSVC is not supported.
+//
+// This file is unrelated to the actual standard operations demonstrated
+// by the library. It exists solely to make debug output readable.
+//
+// The library does not aim to provide a fully featured or production-ready
+// printing system. All stream output within the library is intended
+// strictly for debugging purposes.
+//
+// Any printing in the examples/ directory is for demonstration only.
+
 #pragma once
 
 #include "jh/macros/platform.h"
 
 #if IS_WINDOWS
 #include <windows.h>
-  #include <io.h>      // for _setmode / fileno
-  #include <fcntl.h>   // for _O_U16TEXT
-  #include <cstdio>    // for stdout
+#include <io.h>      // for _setmode / fileno
+#include <fcntl.h>   // for _O_U16TEXT
+#include <cstdio>    // for stdout
 
-  struct EnsureOutput {
-      EnsureOutput() {
-          // On MinGW/Clang/GCC toolchains, fileno() is correct
-          _setmode(fileno(stdout), _O_U16TEXT);
+struct EnsureOutput {
+    EnsureOutput() {
+        // On MinGW/Clang/GCC toolchains, fileno() is correct
+        _setmode(fileno(stdout), _O_U16TEXT);
 
-          // Ensure narrow-output (printf, cout) uses UTF-8
-          SetConsoleOutputCP(CP_UTF8);
+        // Ensure narrow-output (printf, cout) uses UTF-8
+        SetConsoleOutputCP(CP_UTF8);
 
-          // Enable ANSI escape sequences (color, emoji, etc.)
-          HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-          if (hOut != INVALID_HANDLE_VALUE) {
-              DWORD dwMode = 0;
-              if (GetConsoleMode(hOut, &dwMode)) {
-                  SetConsoleMode(hOut, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
-              }
-          }
-      }
-  };
+        // Enable ANSI escape sequences (color, emoji, etc.)
+        HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (hOut != INVALID_HANDLE_VALUE) {
+            DWORD dwMode = 0;
+            if (GetConsoleMode(hOut, &dwMode)) {
+                SetConsoleMode(hOut, dwMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+            }
+        }
+    }
+};
 #else
+
 // On POSIX platforms, nothing required
 struct EnsureOutput {
     EnsureOutput() noexcept = default;
 };
+
 #endif

--- a/examples/example_generator.cpp
+++ b/examples/example_generator.cpp
@@ -1,205 +1,1820 @@
 /**
  * @file example_generator.cpp
- * @brief Demonstrates the usage of `generator` in `jh-toolkit`.
+ * @brief Example demonstrating the usage of <code>&lt;jh/generator&gt;</code>.
  *
- * ## Overview
- * This example showcases the `generator` concept and its integration with `sequence.h`.
- * It demonstrates how to use **lazy evaluation**, **iterable generators**, and **interactive sending** in C++.
+ * <p>
+ * This file demonstrates how to use <code>&lt;jh/generator&gt;</code>
+ * and serves as a reference example for both developers and AI systems
+ * learning how to use this library.
+ * </p>
  *
- * ## Key Features
- * - **Lazy Evaluation**: Generates values **on demand**, reducing memory usage.
- * - **Iterable Generators**: Supports **range-based loops** and **custom iteration logic**.
- * - **Composable Sequences**: Easily integrates with `sequence.h` for **chaining and transformations**.
- * - **Interactive Input (`send()`)**: Allows sending values into a generator **to dynamically modify its state**.
- * - **Generator Consumer**: Converts generated sequences into `std::vector` or `std::deque`.
+ * <p>
+ * The canonical include form is:
+ * </p>
  *
- * ## Best Practices
- * - Use `generator` when dealing with **large data streams** to avoid unnecessary memory allocation.
- * - Combine `generator` with `sequence` to build **functional-style pipelines**.
- * - Use `send()` for **interactive modifications**, or `send_ite()` to **combine sending and advancing**.
- * - Use `to_vector(generator)` when you need **to collect all values into a concrete container**.
+ * @code
+ * #include &lt;jh/generator&gt;
+ * @endcode
  *
- * ## Linking Requirement
- * Since `generator.h` and `sequence.h` are **header-only modules**, ensure that you **link against `jh-toolkit`**
- * when building your project.
+ * <p>
+ * All symbols used in this example are exported under the
+ * <code>jh::</code> namespace. Internally, they originate from
+ * <code>jh::async</code>, but are re-exported into the root namespace
+ * for convenience.
+ * </p>
+ *
+ * <p>
+ * Specifically:
+ * <ul>
+ *   <li><code>jh::generator</code> is an alias of <code>jh::async::generator</code>.</li>
+ *   <li><code>jh::generator_range</code> forwards <code>jh::async::generator_range</code>.</li>
+ *   <li><code>jh::make_generator</code> is re-exported from <code>jh::async</code>.</li>
+ *   <li><code>jh::to_vector</code> and <code>jh::to_deque</code> are also re-exported convenience utilities.</li>
+ * </ul>
+ * </p>
+ *
+ * <p>
+ * For complete API documentation, refer to
+ * <code>jh/asynchronous/generator.h</code>. The Doxygen comments in that
+ * header define the official semantics of the component.
+ * </p>
+ *
+ * <p>
+ * In modern C++ (especially since C++20), interfaces are driven by
+ * semantic contracts rather than implementation details. Users should
+ * rely on the documented Doxygen specifications instead of inspecting
+ * implementation internals. The documentation expresses the intended
+ * and supported behavior; the underlying implementation is considered
+ * a replaceable detail.
+ * </p>
+ *
+ * <p>
+ * The header <code>&lt;jh/generator&gt;</code> is purely template-based.
+ * It does not participate in precompiled object linkage.
+ * </p>
+ *
+ * <p>
+ * Therefore, linking against either:
+ * <ul>
+ *   <li><code>jh::jh-toolkit</code></li>
+ *   <li><code>jh::jh-toolkit-static</code></li>
+ * </ul>
+ * yields identical behavior for this component, as no compiled
+ * generator-specific symbols are required at link time.
+ * </p>
+ *
+ * <p>
+ * This example focuses on practical usage patterns, including:
+ * <ul>
+ *   <li>Defining a coroutine-based generator.</li>
+ *   <li>Iterating over yielded values.</li>
+ *   <li>Materializing results into standard containers.</li>
+ * </ul>
+ * </p>
  */
 
-#include "jh/generator"
-#include <iostream>
-#include <vector>
-#include <ranges>
-#include <deque>
+
+#include <jh/generator>
 #include "ensure_output.h"
 
 #if IS_WINDOWS
 static EnsureOutput ensure_output_setup;
 #endif
 
+/**
+ * @page Mimicking Python requests.Response.iter_content() in C++20
+ *
+ * <h3>Overview</h3>
+ *
+ * This module demonstrates how to reproduce the internal <code>generate()</code>
+ * function used by <code>Response.iter_content()</code> in the Python
+ * <a href="https://github.com/psf/requests/blob/main/src/requests/models.py">
+ * requests</a> library, using modern C++20 facilities.
+ *
+ * The original Python implementation (simplified) is:
+ *
+ * @code{.py}
+ * def generate():
+ *     if hasattr(self.raw, "stream"):
+ *         yield from self.raw.stream(chunk_size, decode_content=True)
+ *     else:
+ *         while True:
+ *             chunk = self.raw.read(chunk_size)
+ *             if not chunk:
+ *                 break
+ *             yield chunk
+ *
+ *     self._content_consumed = True
+ * @endcode
+ *
+ * The objective of this C++ implementation is to construct an equivalent
+ * lazy, chunk-based generator using C++20 coroutines.
+ *
+ *
+ * <h3>Design Principles</h3>
+ *
+ * <h4>Behavior-Based Detection</h4>
+ *
+ * Instead of Python's <code>hasattr()</code>, C++20 relies on compile-time
+ * capability detection using <code>requires</code> expressions.
+ *
+ * The logic is:
+ *
+ * <ol>
+ *   <li>If the object behaves like an <code>std::istream</code>, chunks are
+ *       extracted using <code>read()</code> and <code>gcount()</code>.</li>
+ *   <li>If the stream additionally supports <code>seekg()</code> and
+ *       <code>tellg()</code>, it is considered file-like and may be extended
+ *       with file-specific logic.</li>
+ * </ol>
+ *
+ * No inheritance checks are required. Only observable behavior matters.
+ *
+ *
+ * <h4>Coroutine-Based Yielding</h4>
+ *
+ * Python:
+ *
+ * <code>yield chunk</code>
+ *
+ * C++20:
+ *
+ * <code>co_yield chunk;</code>
+ *
+ * The return type is:
+ *
+ * <code>
+ * jh::generator&lt;std::string&gt;
+ * </code>
+ *
+ * This preserves Python-style lazy iteration semantics.
+ *
+ *
+ * <h4>Error Handling</h4>
+ *
+ * The original Python code maps lower-level exceptions into higher-level
+ * request-specific exceptions.
+ *
+ * For simplification, this C++ implementation removes the exception
+ * conversion layer but fully supports <code>throw</code>.
+ * Exception translation can be introduced later as a policy layer.
+ *
+ *
+ * <h3>Conceptual C++ Structure</h3>
+ *
+ * @code
+ * template&lt;typename Raw&gt;
+ * requires StreamLike&lt;Raw&gt;
+ * jh::generator&lt;std::string&gt;
+ * make_generator(Raw&amp; raw, std::size_t chunk_size, bool&amp; consumed)
+ * {
+ *     while (...) {
+ *         co_yield chunk;
+ *     }
+ *
+ *     consumed = true;
+ * }
+ * @endcode
+ *
+ * This directly mirrors:
+ *
+ * @code{.py}
+ * yield ...
+ * self._content_consumed = True
+ * @endcode
+ *
+ *
+ * <h3>Historical Background and Practical Motivation</h3>
+ *
+ * This module was originally developed during an attempt to port a
+ * third-party pure Python PCB processing library to C++20.
+ *
+ * The purpose of that migration effort was:
+ *
+ * <ol>
+ *   <li>Replace CPU-based rendering with GPU-accelerated rendering
+ *       using OpenCV CUDA.</li>
+ *   <li>Maintain streaming and generator semantics equivalent to Python.</li>
+ *   <li>Improve performance while preserving behavioral compatibility.</li>
+ * </ol>
+ *
+ * The port was ultimately discontinued.
+ *
+ * The main difficulty was the Gerber format ecosystem:
+ *
+ * <ul>
+ *   <li>Multiple historical revisions</li>
+ *   <li>Vendor-specific extensions</li>
+ *   <li>Implementation-defined interpretations</li>
+ *   <li>Format behavior defined by industry practice rather than strict specification</li>
+ * </ul>
+ *
+ * Although these variants cannot strictly be called "non-standard",
+ * they are effectively fragmented across manufacturers.
+ *
+ * Full compatibility was therefore impractical.
+ *
+ *
+ * <h3>Outcome</h3>
+ *
+ * Even though the PCB migration project did not succeed,
+ * the coroutine-based generator abstraction proved valuable.
+ *
+ * The reusable <code>jh::generator</code> component was later extracted
+ * and consolidated into the standalone <b>jh-toolkit</b> as one of the first
+ * major features of the library.
+ *
+ * This demonstrates that:
+ *
+ * <ul>
+ *   <li>Python-style lazy iteration patterns have real-world business value.</li>
+ *   <li>C++20 coroutines can faithfully reproduce generator semantics.</li>
+ *   <li>Behavior-based compile-time detection enables flexible integration.</li>
+ * </ul>
+ *
+ *
+ * <h3>Business Significance</h3>
+ *
+ * This design originated from a real industrial requirement involving:
+ *
+ * <ul>
+ *   <li>High-performance PCB visualization</li>
+ *   <li>GPU-based rendering acceleration</li>
+ *   <li>Asynchronous conversion of <b>Gerber (PCB)</b> format data to <b>XML</b>
+ *       and rendering of PCB optical primitives defined in the <b>XML tree</b> using <b>OpenCV</b>.
+ *   </li>
+ * </ul>
+ *
+ * Although the initial migration effort was halted,
+ * the resulting generator abstraction remains a reusable architectural asset.
+ *
+ */
+
+#include <concepts>
+#include <istream>
+#include <sstream>
+#include <iostream>
+#include <string_view>
+
+namespace example::concepts {
+    template<typename T>
+    concept IStreamLike =requires(T &s, char *buf, std::streamsize n) {
+        { s.read(buf, n) } -> std::convertible_to<std::istream &>;
+        { s.gcount() } -> std::convertible_to<std::streamsize>;
+    };
+
+    template<typename T>
+    concept SeekableStream =
+    IStreamLike<T> && requires(T &s) {
+        { s.seekg(0, std::ios::cur) };
+        { s.tellg() } -> std::convertible_to<std::streampos>;
+    };
+}
+
+namespace example::simulated {
+    struct MemoryFile : std::istream {
+        std::stringbuf buffer;
+
+        MemoryFile(const std::string &data)
+                : std::istream(&buffer),
+                  buffer(data) {}
+    };
+}
+
+namespace example {
+    template<typename Raw>
+    requires (concepts::IStreamLike<Raw>)
+    jh::generator<std::string>
+    generate_chunks(Raw &raw,
+                    std::size_t chunk_size,
+                    bool &content_consumed) {
+        if constexpr (concepts::SeekableStream<Raw>) {
+            // file-like stream logic (e.g., could add file-specific optimizations here)
+            while (true) {
+                std::string buffer(chunk_size, '\0');
+                raw.read(buffer.data(), chunk_size);
+                auto n = raw.gcount();
+                if (n == 0)
+                    break;
+                buffer.resize(n);
+                co_yield buffer;
+            }
+        } else {
+            // normal stream mode (non-seekable)
+            while (true) {
+                std::string buffer(chunk_size, '\0');
+                raw.read(buffer.data(), chunk_size);
+                auto n = raw.gcount();
+                if (n == 0)
+                    break;
+                buffer.resize(n);
+                co_yield buffer;
+            }
+        }
+        content_consumed = true;
+    }
+
+    void example_generate_chunks() {
+        std::cout << "\n===== Industrial-style function-based generator "
+                     "(mimicking Python Response.iter_content) =====\n\n";
+
+        using namespace std::literals;
+
+        bool consumed = false;
+
+        // istringstream
+        std::istringstream iss("HelloIStringStream");
+
+        for (auto &&chunk: generate_chunks(iss, 5, consumed)) {
+            std::cout << "[" << chunk << "]";
+        }
+
+        std::cout << "\nconsumed=" << (consumed ? "true"sv : "false"sv) << "\n\n";
+
+        consumed = false;
+
+        simulated::MemoryFile memFile("HelloMemoryFileStream");
+
+        for (auto &&chunk: generate_chunks(memFile, 6, consumed)) {
+            std::cout << "[" << chunk << "]";
+        }
+
+        std::cout << "\nconsumed=" << (consumed ? "true"sv : "false"sv) << "\n";
+
+        std::cout << "\n===== end industrial-style function-based generator demo =====\n";
+
+    }
+
+    void example_lambda_gen() {
+        std::cout << "\n===== Simple lambda-based generator demo =====\n\n";
+
+        {
+            // capture by value
+            int x = 10;
+            auto gen = [x]() -> jh::generator<int> {
+                for (int i = 0; i < 3; ++i) {
+                    co_yield x + i;
+                }
+            }();
+
+            for (auto v: gen)
+                std::cout << "by value: " << v << "\n";
+        }
+
+        std::cout << "\n";
+
+        {
+            // capture by value with mutable lambda (copy is mutable)
+            int x = 20;
+            auto gen = [x]() mutable -> jh::generator<int> {
+                for (int i = 0; i < 3; ++i) {
+                    x += 2;
+                    co_yield x;
+                }
+            }();
+
+            for (auto v: gen)
+                std::cout << "by value mutable: " << v << "\n";
+
+            std::cout << "original x unchanged: " << x << "\n";
+        }
+
+        std::cout << "\n";
+
+        {
+            // capture by reference
+            int x = 30;
+            auto gen = [&x]() -> jh::generator<int> {
+                for (int i = 0; i < 3; ++i) {
+                    x += 3;
+                    co_yield x;
+                }
+            }();
+
+            for (auto v: gen)
+                std::cout << "by reference: " << v << "\n";
+
+            std::cout << "original x modified: " << x << "\n";
+        }
+
+        std::cout << "\n";
+
+        {
+            // move capture (C++14 init capture with std::move)
+            std::string s = "MoveCapture";
+            auto gen = [str = std::move(s)]() -> jh::generator<int> {
+                for (int i = 0; i < 3; ++i) {
+                    co_yield static_cast<int>(str.size() + i);
+                }
+            }();
+
+            for (auto v: gen)
+                std::cout << "move capture size+: " << v << "\n";
+            // We do NOT attempt to use 's' after moving, as it is in a valid but unspecified state.
+        }
+
+        std::cout << "\n";
+
+        {
+            // explicit initialized capture (C++14 init capture with expression)
+            int base = 100;
+            int factor = 5;
+
+            auto gen = [result = base * factor]() -> jh::generator<int> {
+                for (int i = 0; i < 3; ++i) {
+                    co_yield result + i;
+                }
+            }();
+
+            for (auto v: gen)
+                std::cout << "explicit initialized capture: " << v << "\n";
+        }
+
+        std::cout << "\n===== end lambda-based generator demo =====\n";
+    }
+
+}
+
+#include <numeric>
+#include <ranges>
+
+/**
+ * @page Generator_Stepping Canonical Stepping & Send Semantics
+ *
+ * <h3>Bidirectional Coroutine Model</h3>
+ *
+ * <code>jh::async::generator&lt;T, U&gt;</code> is a C++20 coroutine-based
+ * generator inspired by Python's:
+ *
+ * @code{.py}
+ * Generator[T, U, R]
+ * @endcode
+ *
+ * In the JH Toolkit, this is modeled as:
+ *
+ * @code
+ * template&lt;typename T, typename U = jh::typed::monostate&gt;
+ * class generator;
+ * @endcode
+ *
+ * <ul>
+ *   <li><b>T</b> — type yielded via <code>co_yield</code></li>
+ *   <li><b>U</b> — type received via <code>co_await</code> (through <code>send()</code>)</li>
+ * </ul>
+ *
+ * When:
+ *
+ * @code
+ * U == jh::typed::monostate
+ * @endcode
+ *
+ * the generator is <b>output-only</b> and compatible with range-style-for.
+ *
+ * When:
+ *
+ * @code
+ * U != jh::typed::monostate
+ * @endcode
+ *
+ * the generator becomes <b>interactive</b> (bidirectional) and must be
+ * stepped manually.
+ *
+ *
+ * <h3>Two-Phase Execution Contract</h3>
+ *
+ * Each iteration consists of exactly:
+ *
+ * <ul>
+ *   <li>One input phase (<code>co_await U{}</code>)</li>
+ *   <li>One output phase (<code>co_yield T</code>)</li>
+ * </ul>
+ *
+ * External control APIs:
+ *
+ * <ul>
+ *   <li><code>send(U)</code> — deliver input</li>
+ *   <li><code>next()</code> — advance to next yield</li>
+ *   <li><code>send_ite(U)</code> — canonical combined step</li>
+ * </ul>
+ *
+ *
+ * <h3>Canonical Stepping Form</h3>
+ *
+ * Although the API permits:
+ *
+ * @code
+ * gen.send(x);
+ * gen.next();
+ *
+ * // or
+ *
+ * gen.next();
+ * gen.send(x);
+ * @endcode
+ *
+ * the canonical and recommended form is:
+ *
+ * @code
+ * gen.send_ite(x);
+ * @endcode
+ *
+ * <b>send_ite()</b> expresses the full iteration contract:
+ *
+ * <ul>
+ *   <li>Provide exactly one input</li>
+ *   <li>Advance exactly one coroutine cycle</li>
+ *   <li>Produce exactly one output</li>
+ * </ul>
+ *
+ * It prevents partial stepping and makes coroutine pacing explicit.
+ *
+ * <h3>Output-Only Generators</h3>
+ *
+ * When <code>U == jh::typed::monostate</code>:
+ *
+ * <ul>
+ *   <li><code>send()</code> is not used</li>
+ *   <li><code>send_ite()</code> degenerates to <code>next()</code></li>
+ *   <li>The generator supports <code>begin()</code>/<code>end()</code></li>
+ * </ul>
+ *
+ * Example:
+ *
+ * @code
+ * jh::async::generator<int> g();
+ *
+ * for (auto v : g()) {
+ *     use(v);
+ * }
+ *
+ * // or
+ *
+ * // use step by step
+ * auto gen = g();
+ *
+ * while (gen.next() && additional_condition()) {
+ *    auto v = gen.value().value();
+ *    use(v);
+ * }
+ * @endcode
+ *
+ * @warning
+ * For infinite generators, range-for is not recommended as it may lead to infinite loops.
+ * use manual stepping with appropriate guards instead.
+ *
+ * <h3>Interactive Generators</h3>
+ *
+ * When <code>U != jh::typed::monostate</code>:
+ *
+ * <ul>
+ *   <li>No <code>begin()</code>/<code>end()</code></li>
+ *   <li>No range-for support</li>
+ *   <li>Manual stepping required</li>
+ * </ul>
+ *
+ * Example:
+ *
+ * @code
+ * jh::async::generator<int, int> gen_await();
+ *
+ * auto gen = gen_await();
+ *
+ * if (gen.send_ite(5)) {
+ *     auto v = gen.value().value();
+ * }
+ * @endcode
+ *
+ *
+ * <h3>Value Access Semantics</h3>
+ *
+ * The member:
+ *
+ * @code
+ * std::optional<T> value() const;
+ * @endcode
+ *
+ * returns the last yielded value.
+ *
+ * Important properties:
+ *
+ * <ul>
+ *   <li>Accessing <code>value()</code> does <b>not</b> consume it.</li>
+ *   <li>Repeated calls are idempotent.</li>
+ *   <li>The stored value changes only after successful stepping.</li>
+ * </ul>
+ *
+ *
+ * <h3>Correct Access Discipline</h3>
+ *
+ * When stepping is guarded:
+ *
+ * @code
+ * if (gen.next()) {
+ *     auto v = gen.value().value();
+ * }
+ *
+ * if (gen.send_ite(x)) {
+ *     auto v = gen.value().value();
+ * }
+ * @endcode
+ *
+ * it is guaranteed that the optional is engaged.
+ *
+ * In these guarded forms,
+ * <code>value().value()</code> is the correct access.
+ *
+ *
+ * <h3>Optional-aware Inspection</h3>
+ *
+ * Use:
+ *
+ * @code
+ * gen.value().has_value();
+ * gen.value().value_or(default_value);
+ * @endcode
+ *
+ * only when:
+ *
+ * <ul>
+ *   <li>No preceding guarded stepping exists</li>
+ *   <li>State is inspected without advancing</li>
+ * </ul>
+ *
+ * These forms are for defensive inspection — not normal iteration.
+ *
+ *
+ * <h3>Design Rules</h3>
+ *
+ * <ul>
+ *   <li><b>Use send_ite() as the canonical stepping form.</b></li>
+ *   <li><b>Use value().value() after guarded stepping.</b></li>
+ *   <li><b>Use has_value()/value_or() only for unguarded inspection.</b></li>
+ *   <li><b>value() access never consumes the yield.</b></li>
+ *   <li><b>Interactive generators require manual stepping.</b></li>
+ * </ul>
+ *
+ */
 
 namespace example {
 
-    /**
-     * @brief Generates a sequence from `[0, end)`.
-     */
-    jh::generator<int> range(const int end) {
-        for (int i = 0; i < end; ++i) {
+    jh::generator<int> infinite_sequence() {
+        // This generator yields an infinite sequence of integers starting from 0.
+        // It should never be used with range-for without an external guard, as it is infinite.
+        for (int i: std::views::iota(0))
             co_yield i;
+    }
+
+    jh::generator<int, int> interactive_counter() {
+        int base = 0;
+        while (true) {
+            int delta = co_await int{};
+            base += delta;
+            co_yield base;
         }
     }
 
-    /**
-     * @brief Generates a sequence from `[start, end)`.
-     */
-    jh::generator<int> range(const int start, const int end) {
-        for (int i = start; i < end; ++i) {
-            co_yield i;
+    void example_step_by_step() {
+        std::cout << "\n===== Step-by-step generator control =====\n\n";
+
+        // Output-only generator<int>
+        {
+            std::cout << "[Output-only stepping]\n";
+
+            auto gen = infinite_sequence();
+            std::size_t count = 0;
+            while (gen.next() && count < 5) {
+                auto v = gen.value().value();
+                std::cout << "value = " << v << "\n";
+                ++count;
+            }
         }
-    }
 
-    /**
-     * @brief Generates a sequence from `[start, end)` with a custom step size.
-     */
-    jh::generator<int> range(const int start, const int end, const int step) {
-        for (int i = start; i < end; i += step) {
-            co_yield i;
-        }
-    }
-
-    /**
-     * @brief Generates a countdown sequence interactively.
-     * - Users can **send a step value** to decrease the countdown dynamically.
-     */
-    jh::generator<int, int> countdown(int start) {
-        while (start > 0) {
-            const int step = co_await int{};  // NOLINT Receive new step size via send()
-            start -= step;
-            co_yield start;
-        }
-    }
-
-
-    /**
-     * @brief Demonstrates collecting a generator's output into a `std::vector<int>`.
-     */
-    void generator_to_vector_demo() {
-        std::cout << "\n\U0001F539 Collecting Generator to `std::vector<int>`:\n";
-
-        auto generator = range(1, 6);
-        const auto values = to_vector(generator);
-
-        std::cout << "Collected values: ";
-        for (const int val : values) {
-            std::cout << val << " ";
-        }
         std::cout << "\n";
-    }
 
-    /**
-     * @brief Demonstrates sending values into a countdown generator.
-     */
-    void interactive_generator_demo() {
-        std::cout << "\n\U0001F539 Interactive Generator with `send()`:\n";
+        // Interactive generator<int, int>
+        {
+            std::cout << "[Interactive stepping]\n";
 
-        auto countdown_gen = countdown(10);
-        const std::vector steps = {1, 2, 3, 2, 1, 1};
+            auto gen = interactive_counter();
 
-        std::cout << "Countdown steps: ";
-        auto ite = steps.begin();
-        while (countdown_gen.next() && ite != steps.end()) {
-            if (!countdown_gen.send(*ite)) break;
-            std::cout << countdown_gen.value().value() << " ";
-            ++ite;
+            if (gen.send_ite(5)) {
+                auto v = gen.value().value();
+                std::cout << "after +5 = " << v << "\n";
+            }
+
+            if (gen.send_ite(3)) {
+                auto v = gen.value().value();
+                std::cout << "after +3 = " << v << "\n";
+            }
+
+            if (gen.send_ite(2)) {
+                auto v = gen.value().value();
+                std::cout << "after +2 = " << v << "\n";
+            }
         }
-        std::cout << "\n";
-    }
 
-    /**
-     * @brief Demonstrates `send_ite()`, which combines `send()` and `next()`.
-     */
-    void send_ite_demo() {
-        std::cout << "\n\U0001F539 Interactive Generator with `send_ite()`:\n";
-
-        auto countdown_gen = countdown(10);
-        const std::vector steps = {1, 2, 3, 2, 1, 1};
-
-        std::cout << "Countdown steps: ";
-        for (const int step : steps) {
-            if (!countdown_gen.send_ite(step)) break;
-            std::cout << countdown_gen.value().value() << " ";
-        }
-        std::cout << "\n";
-    }
-
-    /**
-     * @brief Converts a generator with a step size into a `std::vector<int>`.
-     */
-    void step_generator_to_vector_demo() {
-        std::cout << "\n\U0001F539 Step Generator to `std::vector<int>`:\n";
-
-        auto generator = range(1, 20, 3);
-        const std::vector<int> values = to_vector(generator);
-
-        std::cout << "Collected values: ";
-        for (const int val : values) {
-            std::cout << val << " ";
-        }
-        std::cout << "\n";
-    }
-
-    /**
-     * @brief Converts a generator with steps into a `std::deque<int>`.
-     */
-    void step_generator_to_deque_demo() {
-        std::cout << "\n\U0001F539 Step Generator to `std::deque<int>`:\n";
-
-        auto generator = range(1, 20, 4);
-        const std::deque<int> values = to_deque(generator);
-
-        std::cout << "Collected values: ";
-        for (const int val : values) {
-            std::cout << val << " ";
-        }
-        std::cout << "\n";
-    }
-
-    void range_constructing() {
-        std::cout << "\n\U0001F539 Constructing Generator with `std::views::iota`:\n";
-        auto iota_view = std::views::iota(0, 10);
-        for (auto gen = jh::make_generator(iota_view); const auto v : gen) {
-            std::cout << v << " ";
-        }
-        std::cout << "\n";
-    }
-
-    void example_to_range() {
-        std::cout << "\n\U0001F539 Constructing Range with Lambda[Generator]:\n";
-        constexpr auto view = std::views::iota(0, 10);
-        const auto range_ = jh::to_range([view] {
-            return jh::make_generator(view);
-        });
-        std::cout << "First Loop:\n";
-        for (const auto v : range_) {
-            std::cout << v << " ";
-        }
-        std::cout << "\nSecond Loop:\n";
-        for (const auto v : range_) {
-            std::cout << v << " ";
-        }
-        std::cout << "\n";
+        std::cout << "\n===== end step-by-step demo =====\n";
     }
 
 } // namespace example
 
 /**
- * @brief Main entry point to run all examples.
+ * @page Generator_Stream_Semantics jh::generator Semantic Model — Consuming Stream, Not a Range
+ *
+ * <h3>Purpose</h3>
+ *
+ * This page clarifies the semantic nature of
+ * <code>jh::generator&lt;T, U&gt;</code>.
+ *
+ * The generator type is a coroutine-driven consuming stream.
+ * It must not be interpreted as a standard C++ range abstraction.
+ *
+ *
+ * <h3>Core Statement</h3>
+ *
+ * <code>jh::generator</code> represents:
+ *
+ * <ul>
+ *   <li>A progressing coroutine execution context</li>
+ *   <li>A single-pass stream of values</li>
+ *   <li>A stateful and mutating computation</li>
+ * </ul>
+ *
+ * It does <b>not</b> represent:
+ *
+ * <ul>
+ *   <li>A stable view over underlying data</li>
+ *   <li>A reusable sequence</li>
+ *   <li>A forward-iterable container abstraction</li>
+ * </ul>
+ *
+ *
+ * <h3>Single-Pass Consumption Model</h3>
+ *
+ * Every successful advancement of a generator:
+ *
+ * <ul>
+ *   <li>Resumes coroutine execution</li>
+ *   <li>Mutates internal coroutine state</li>
+ *   <li>Consumes progression history</li>
+ * </ul>
+ *
+ * Once exhausted, the generator cannot be restarted.
+ * Iteration is inherently destructive.
+ *
+ * This consumption property is fundamental to coroutine semantics
+ * and is not an implementation detail.
+ *
+ *
+ * <h3>Concept Matching Does Not Imply Range Semantics</h3>
+ *
+ * In some configurations, an output-only generator
+ * may satisfy certain C++20 range concepts
+ * (such as <code>std::ranges::input_range</code>).
+ *
+ * This syntactic compatibility does not redefine its semantic model.
+ *
+ * Concept satisfaction guarantees that required expressions exist.
+ * It does not guarantee:
+ *
+ * <ul>
+ *   <li>Referential stability</li>
+ *   <li>Reusability</li>
+ *   <li>Iterator independence</li>
+ * </ul>
+ *
+ * A generator remains a consuming stream
+ * even if it matches input-range concepts.
+ *
+ *
+ * <h3>Non-Forward Semantics</h3>
+ *
+ * A generator:
+ *
+ * <ul>
+ *   <li>Is single-pass only</li>
+ *   <li>Does not provide forward iteration guarantees</li>
+ *   <li>Does not allow duplication of iteration state</li>
+ * </ul>
+ *
+ * Iterator copies (when technically possible)
+ * must not be interpreted as independent traversal cursors.
+ *
+ *
+ * <h3>Recommended Abstraction for Range Semantics</h3>
+ *
+ * When true range semantics are required,
+ * the correct abstraction is:
+ *
+ * <ul>
+ *   <li><code>jh::generator_range&lt;T&gt;</code></li>
+ * </ul>
+ *
+ * A <code>generator_range</code> stores a factory
+ * capable of constructing a fresh generator instance
+ * upon each call to <code>begin()</code>.
+ *
+ * This restores:
+ *
+ * <ul>
+ *   <li>Proper input-range modeling</li>
+ *   <li>Well-defined iteration boundaries</li>
+ *   <li>Safe interoperability with C++20 views</li>
+ * </ul>
+ *
+ * The resulting range remains input-only
+ * and intentionally does not model forward-range.
+ *
+ *
+ * <h3>Design Rule</h3>
+ *
+ * <ul>
+ *   <li>Treat <code>jh::generator</code> as a stream abstraction.</li>
+ *   <li>Do not treat it as a reusable container.</li>
+ *   <li>Do not infer semantic guarantees from concept matching.</li>
+ *   <li>Use <code>generator_range</code> when range semantics are required.</li>
+ * </ul>
+ *
+ * In summary:
+ *
+ * <ul>
+ *   <li><code>generator</code> expresses coroutine state progression.</li>
+ *   <li><code>generator_range</code> expresses range abstraction.</li>
+ * </ul>
  */
+
+namespace example {
+
+    void example_generator_range() {
+
+        std::cout << "\n===== Using jh::to_range to create a repeatable generator range =====\n\n";
+        // example of using jh::to_range to create a repeatable range from a generator factory (lambda)
+        auto range = jh::to_range([] {
+            return infinite_sequence();
+        });
+
+        std::cout << "Range created from generator factory lambda.\n";
+        std::cout << "Iterating over the first 10 values:\n";
+
+        // iterate over the first 10 values
+        for (int v: range | std::views::take(10)) {
+            std::cout << v << " ";
+        }
+
+        std::cout << "\nResetting and iterating again...\n";
+        std::cout << "Iterating over the first 5 values again:\n";
+
+        // re-iterate over the first 5 values again, demonstrating repeatability
+        for (int v: range | std::views::take(5)) {
+            std::cout << v << " ";
+        }
+
+        std::cout << "\n===== end generator_range demo =====\n";
+    }
+}
+
+/**
+ * @page Generator_Namespace_and_Policy jh::generator Namespace Elevation and Execution Policy
+ *
+ * <h3>Namespace Positioning</h3>
+ *
+ * <p>
+ * <code>jh::generator</code> is re-exported into the root <code>jh::</code>
+ * namespace for convenience. Its canonical implementation resides in
+ * <code>jh::async::generator</code>.
+ * </p>
+ *
+ * <p>
+ * The elevation into <code>jh::</code> does not alter semantics.
+ * It remains architecturally part of the asynchronous subsystem.
+ * </p>
+ *
+ *
+ * <h3>Shared Philosophy with jh::async</h3>
+ *
+ * <p>
+ * <code>jh::generator</code> follows the same design discipline as all
+ * components under <code>jh::async</code>:
+ * </p>
+ *
+ * <ul>
+ *   <li>Asynchronous mechanisms handle asynchronous coordination.</li>
+ *   <li>Synchronous aggregation and distribution remain external.</li>
+ * </ul>
+ *
+ * <p>
+ * The generator is not a workflow engine.
+ * It is a coroutine stepping abstraction.
+ * </p>
+ *
+ *
+ * <h3>One-Round Execution Contract</h3>
+ *
+ * <p>
+ * Each logical iteration consists of exactly:
+ * </p>
+ *
+ * <ul>
+ *   <li>One permitted <code>co_await</code> (input phase)</li>
+ *   <li>One permitted <code>co_yield</code> (output phase)</li>
+ * </ul>
+ *
+ * <p>
+ * This models a single bidirectional exchange step.
+ * </p>
+ *
+ * <p>
+ * Multiple awaits per round or multiple yields per round are intentionally
+ * not part of the supported execution discipline.
+ * </p>
+ *
+ *
+ * <h3>No Internal Multi-Dispatch or Multi-Collection</h3>
+ *
+ * <p>
+ * If multiple values must be gathered before processing,
+ * the aggregation must be completed synchronously
+ * by the caller before invoking the generator.
+ * </p>
+ *
+ * <p>
+ * If a yielded value must be distributed to multiple destinations,
+ * the fan-out must be handled externally after retrieval.
+ * </p>
+ *
+ * <p>
+ * The generator does not manage:
+ * </p>
+ *
+ * <ul>
+ *   <li>Internal batching logic</li>
+ *   <li>Multi-recipient dispatch</li>
+ *   <li>Implicit synchronization barriers</li>
+ * </ul>
+ *
+ *
+ * <h3>Structured Data as Exchange Unit</h3>
+ *
+ * <p>
+ * A single input or output may represent structured data.
+ * </p>
+ *
+ * <p>
+ * For example:
+ * </p>
+ *
+ * <ul>
+ *   <li><code>co_await std::tuple&lt;A, B, C&gt;</code></li>
+ *   <li><code>co_yield MyDataClass</code></li>
+ * </ul>
+ *
+ * <p>
+ * The responsibility for assembling the tuple or struct
+ * lies with the caller before invoking <code>send()</code>.
+ * </p>
+ *
+ * <p>
+ * Likewise, any downstream distribution of yielded data
+ * must be performed outside the generator.
+ * </p>
+ *
+ *
+ * <h3>Copy-Based Value Sharing</h3>
+ *
+ * <p>
+ * The generator assumes that exchanged data is
+ * pure data rather than semantic or identity-sensitive objects.
+ * </p>
+ *
+ * <p>
+ * Value copying during stepping is therefore the default model.
+ * </p>
+ *
+ * <p>
+ * This ensures:
+ * </p>
+ *
+ * <ul>
+ *   <li>Isolation between coroutine state and caller state</li>
+ *   <li>Deterministic lifetime boundaries</li>
+ *   <li>Reduced semantic coupling</li>
+ * </ul>
+ *
+ *
+ * <h3>Handling Heavier Objects</h3>
+ *
+ * <p>
+ * If semantic objects must be exchanged,
+ * the recommended approach is to wrap them in
+ * <code>std::shared_ptr&lt;T&gt;</code>.
+ * </p>
+ *
+ * <p>
+ * This provides:
+ * </p>
+ *
+ * <ul>
+ *   <li>Cheap copy semantics</li>
+ *   <li>Explicit lifetime control</li>
+ *   <li>User-defined destruction behavior</li>
+ * </ul>
+ *
+ * <p>
+ * The generator itself does not enforce ownership policies.
+ * Ownership strategy remains a caller-level decision.
+ * </p>
+ *
+ *
+ * <h3>Design Rule Summary</h3>
+ *
+ * <ul>
+ *   <li><code>jh::generator</code> is semantically an asynchronous component.</li>
+ *   <li>Namespace elevation does not change its subsystem identity.</li>
+ *   <li>Each round permits exactly one <code>co_await</code> and one <code>co_yield</code>.</li>
+ *   <li>Multi-value coordination must be externally synchronized.</li>
+ *   <li>Data exchange is copy-oriented and value-centric.</li>
+ *   <li>Use <code>std::shared_ptr</code> when object semantics are required.</li>
+ * </ul>
+ *
+ */
+
+#include <stdexcept>
+#include <format>
+
+namespace example::simulated {
+    struct Employee {
+        std::string age_str;       // width 3, left padded with space
+        std::string service_str;   // width 3, left padded with space
+        std::string name_str;      // width 15, left padded with space
+    };
+
+    inline std::string left_pad(const std::string &s, std::size_t width) {
+        if (s.size() >= width) return s;
+        return std::string(width - s.size(), ' ') + s;
+    }
+}
+
+namespace example {
+    jh::generator<std::shared_ptr<simulated::Employee>,
+            std::tuple<unsigned int, unsigned int, std::string>>
+    gen_person() {
+        while (true) {
+
+            auto [age, service, name] =
+                    co_await std::tuple<unsigned int, unsigned int, std::string>{};
+
+            auto person = std::make_shared<simulated::Employee>();
+
+            if (age < 18) {
+                throw std::runtime_error(
+                        std::format("Age must be at least 18. name: {}, age: {}", name, age)
+                );
+            }
+
+            // This demonstration assumes the generator is handling a critical business flow that doesn't
+            // allow abnormal input, and also shows how to catch exceptions
+            // (the generator is done if an exception crosses its boundaries).
+
+            // If you actually need it to run continuously, you can change the output to
+            // std::shared_ptr<std::variant<Employee, ExceptionMsg>> or more brutally return nullptr.
+
+            person->age_str = simulated::left_pad(std::to_string(age), 3);
+            person->service_str = simulated::left_pad(std::to_string(service), 3);
+            person->name_str = simulated::left_pad(name, 15);
+
+            co_yield person;
+        }
+    }
+
+    void example_outer_ctrled_multi_input() {
+
+        using namespace std::literals;
+
+        std::cout << "\n===== Outer-controlled multi-input demo =====\n\n";
+
+        std::istringstream age_stream("25 41 30 8");
+        std::istringstream service_stream("3 12 10 1");
+        std::istringstream name_stream("Alice Bob Charlie John");
+
+        // Here we demonstrate an interactive generator that takes multiple inputs
+        // as a tuple and produces a structured output.
+
+        // The generator is expected to throw an exception when the age is below 18 (for John),
+        // which we will catch and display.
+
+        auto gen = gen_person();
+
+        std::cout << "Employee data input streams prepared. Starting generator iteration...\n";
+
+        try {
+            while (true) {
+
+                unsigned int age;
+                unsigned int service;
+                std::string name;
+
+                if (!(age_stream >> age)) break;
+                if (!(service_stream >> service)) break;
+                if (!(name_stream >> name)) break;
+
+                std::tuple<unsigned int, unsigned int, std::string> input{
+                        age, service, name
+                };
+
+                if (!gen.send_ite(input))
+                    break;
+
+                auto person_ptr = gen.value().value();
+
+                std::cout
+                        << "[" << person_ptr->age_str
+                        << "] [" << person_ptr->service_str
+                        << "] [" << person_ptr->name_str
+                        << "]\n";
+            }
+        }
+        catch (const std::exception &e) {
+            std::cout << "\nGenerator failed (as expected for invalid input) with error: "
+                      << e.what() << "\n";
+        }
+
+        // note: the try-catch works exactly as synchronous exception handling,
+        // even though the exception is thrown from within the generator's coroutine context.
+
+        // the error is defined before yielding,
+        // so it is thrown at the point of send_ite() that triggers the relevant coroutine execution step.
+        // "John" is not processed at all, as the exception occurs before any yield happens for that input.
+
+        std::cout << "generator is done: " << (gen.done() ? "yes"sv : "no"sv) << "\n";
+        // generator is done: yes, as the exception unwound the coroutine and marked it as done.
+
+        std::cout << "\n===== end multi-input demo =====\n";
+    }
+}
+
+/**
+ * @page Generator_Make_Generator_Sequence_vs_Range make_generator() — Sequence vs Range Overloads
+ *
+ * <h3>Original Design Motivation</h3>
+ *
+ * The original purpose of <code>make_generator()</code> was to align with
+ * the Python generator expression:
+ *
+ * @code{.py}
+ * (x for x in seq)
+ * @endcode
+ *
+ * The semantic meaning is:
+ *
+ * <ul>
+ *   <li>Transform traversal into lazy evaluation.</li>
+ *   <li>Do not modify the underlying sequence.</li>
+ *   <li>Do not consume the source container.</li>
+ * </ul>
+ *
+ *
+ * <h3>Overload Structure</h3>
+ *
+ * <h4>Duck-typed jh::concepts::sequence overload</h4>
+ *
+ * @code
+ * template&lt;concepts::sequence SeqType&gt;
+ * requires (!std::ranges::range&lt;SeqType&gt;)
+ * generator&lt;concepts::sequence_value_t&lt;SeqType&gt;&gt;
+ * make_generator(const SeqType& seq);
+ * @endcode
+ *
+ * <p>
+ * A type qualifies if:
+ * </p>
+ *
+ * <ul>
+ *   <li>It provides <code>begin()</code> and <code>end()</code>.</li>
+ *   <li>It supports range-style-for traversal.</li>
+ *   <li>Traversal does not consume or mutate the container.</li>
+ * </ul>
+ *
+ * <p>
+ * Concept relationship clarification:
+ * </p>
+ *
+ * <ul>
+ *   <li>
+ *   It is broader than the subset of <code>std::ranges::range</code>
+ *   representing non-consuming, container-like ranges.
+ *   </li>
+ *   <li>
+ *   It intentionally excludes consuming streams.
+ *   </li>
+ * </ul>
+ *
+ * <p>
+ * This overload always takes <code>const SeqType&</code>, even if the caller
+ * provides a non-const object. Const is enforced to guarantee non-consuming,
+ * non-mutating traversal and to avoid unpredictable behavior in legacy containers.
+ * </p>
+ *
+ * <h4>std::ranges::range overload</h4>
+ *
+ * @code
+ * template&lt;std::ranges::range R&gt;
+ * generator&lt;std::ranges::range_value_t&lt;R&gt;&gt;
+ * make_generator(R&& rng);
+ * @endcode
+ *
+ * <p>
+ * This overload accepts a universal reference and forwards the range.
+ * </p>
+ *
+ * <p>
+ * The <code>R&&</code> parameter follows normal reference collapsing rules:
+ * </p>
+ *
+ * <ul>
+ *   <li>Non-const lvalue → deduces to <code>R&</code></li>
+ *   <li>Const lvalue → deduces to <code>const R&</code></li>
+ *   <li>Rvalue → deduces to <code>R&&</code></li>
+ * </ul>
+ *
+ * <p>
+ * Therefore constness is preserved automatically.
+ * </p>
+ *
+ * <p>
+ * Unlike the sequence overload, this version:
+ * </p>
+ *
+ * <ul>
+ *   <li>Supports forwarded rvalue ranges.</li>
+ *   <li>Supports lazy views.</li>
+ *   <li>Allows ownership transfer into the coroutine.</li>
+ *   <li>Does not enforce non-consumption.</li>
+ * </ul>
+ *
+ *
+ * <h3>Iterator Invalidation Rule</h3>
+ *
+ * <p>
+ * When using the sequence overload, the generator internally stores
+ * and advances an iterator.
+ * </p>
+ *
+ * <p>
+ * For containers such as <code>std::vector</code> or <code>std::deque</code>,
+ * any operation that invalidates iterators (e.g. changing container size)
+ * must not be performed while the generator is still iterating.
+ * </p>
+ *
+ * <p>
+ * The generator conceptually behaves as if it holds:
+ * </p>
+ *
+ * @code
+ * auto it = seq.begin();
+ * @endcode
+ *
+ *
+ * <h3>Design Summary</h3>
+ *
+ * <ul>
+ *   <li>Sequence overload enforces non-consuming traversal via const reference.</li>
+ *   <li>Range overload forwards and preserves value category.</li>
+ *   <li>Constness is preserved through reference collapsing in the T&& overload.</li>
+ *   <li>Sequence is broader than non-consuming ranges but excludes consuming streams.</li>
+ *   <li>Iterator invalidation remains the caller's responsibility.</li>
+ * </ul>
+ */
+
+namespace example {
+
+    void example_make_generator() {
+
+        std::cout << "\n===== make_generator demo =====\n\n";
+        {
+            // lvalue std::vector
+            // Calling jh::make_generator(vec);
+            // results in a non-consuming traversal.
+            // In this context the deduced type behaves as
+            // const std::vector<int>&.
+
+            std::vector<int> vec{1, 2, 3, 4, 5};
+            auto gen_lvalue = jh::make_generator(vec);
+
+            std::cout << "(lvalue std::vector)\n";
+            while (gen_lvalue.next()) {
+                std::cout << gen_lvalue.value().value() << " ";
+            }
+            std::cout << "\n";
+        }
+        {
+            // rvalue std::vector (recommended explicit move pattern)
+            // Do NOT write: jh::make_generator(std::vector<int>{...});
+            // On some GCC 14+ front-end configurations,
+            // interaction between temporary materialization and coroutines
+            // may lead to dangling lifetime issues.
+            //
+            // Instead, declare and then move.
+            // In fact, jh::make_generator(std::vector<int>{...}); is semantically correct
+            // and should work in compliant compilers (and does work in Clang and GCC13),
+            // but the explicit move pattern is more robust across
+            // different compiler versions and configurations.
+
+            std::vector<int> tmp{100, 200, 300};
+            auto gen_rvalue = jh::make_generator(std::move(tmp));
+
+            std::cout << "(rvalue std::vector via std::move)\n";
+            while (gen_rvalue.next()) {
+                std::cout << gen_rvalue.value().value() << " ";
+            }
+            std::cout << "\n";
+        }
+        {
+            // std::views::iota (lazy range)
+            //
+            // Avoid directly passing a temporary view into make_generator.
+            // Declare the view first to ensure stable lifetime.
+
+            auto iota_view = std::views::iota(10, 15);
+            auto gen_iota = jh::make_generator(iota_view);
+
+            std::cout << "(std::views::iota lvalue view)\n";
+            while (gen_iota.next()) {
+                std::cout << gen_iota.value().value() << " ";
+            }
+            std::cout << "\n";
+        }
+        std::cout << "\n===== end make_generator demo =====\n";
+    }
+
+}
+
+/**
+ * @page Generator_Eager_Materialization Eager Materialization — Python-style list(gen) Semantics
+ *
+ * <h3>Overview</h3>
+ *
+ * Python supports eager materialization of generators:
+ *
+ * @code{.py}
+ * list(gen)
+ * @endcode
+ *
+ * This converts a lazy generator into a concrete container.
+ *
+ * The JH Toolkit provides equivalent eager utilities:
+ *
+ * <ul>
+ *   <li><code>jh::async::to_vector()</code></li>
+ *   <li><code>jh::async::to_deque()</code></li>
+ * </ul>
+ *
+ * These utilities consume the generator to completion
+ * and collect all yielded values into a container.
+ *
+ *
+ * <h3>Primary Design Recommendation</h3>
+ *
+ * The most recommended overload is:
+ *
+ * @code
+ * template&lt;typename T&gt;
+ * std::deque&lt;T&gt; to_deque(generator&lt;T&gt;& gen);
+ * @endcode
+ *
+ * or
+ *
+ * @code
+ * template&lt;typename T&gt;
+ * std::vector&lt;T&gt; to_vector(generator&lt;T&gt;& gen);
+ * @endcode
+ *
+ * This applies to <b>output-only generators</b>
+ * (<code>U == typed::monostate</code>).
+ *
+ *
+ * <h3>Why Output-Only Is Preferred</h3>
+ *
+ * When constructing a generator — especially via lambda —
+ * external state can be captured directly:
+ *
+ * @code
+ * int base = 5;
+ * auto gen = [base]() -> jh::generator&lt;int&gt; {
+ *     for (int i = 0; i < 3; ++i)
+ *         co_yield base + i;
+ * }();
+ *
+ * auto vec = jh::async::to_vector(gen);
+ * @endcode
+ *
+ * In modern C++, external data should be captured
+ * rather than forced through <code>send()</code>.
+ *
+ * Interactive stepping is intended for:
+ *
+ * <ul>
+ *   <li>Externally driven workflows</li>
+ *   <li>Streaming systems</li>
+ *   <li>Real-time coordination</li>
+ * </ul>
+ *
+ * It is <b>not</b> intended as a bulk parameter injection mechanism.
+ *
+ *
+ * <h3>Interactive Overloads</h3>
+ *
+ * Additional overloads exist:
+ *
+ * <ul>
+ *   <li>Fixed input value at every step</li>
+ *   <li>Range of input values</li>
+ * </ul>
+ *
+ * These allow:
+ *
+ * @code
+ * auto vec = jh::async::to_vector(gen, fixed_input);
+ * auto vec = jh::async::to_vector(gen, input_range);
+ * @endcode
+ *
+ * However:
+ *
+ * <ul>
+ *   <li>They assume that input data is already available.</li>
+ *   <li>They implicitly batch interactive behavior.</li>
+ *   <li>They obscure the intended coroutine stepping model.</li>
+ * </ul>
+ *
+ * <h3>Production Guidance</h3>
+ *
+ * These overloads are retained as a <b>development fallback</b>.
+ *
+ * They are useful:
+ *
+ * <ul>
+ *   <li>During early experimentation</li>
+ *   <li>When prototyping generator logic</li>
+ *   <li>When refactoring synchronous code into coroutine form</li>
+ * </ul>
+ *
+ * In production-grade systems, interactive generators
+ * should be driven explicitly by external control flow,
+ * rather than by bulk eager injection of inputs.
+ *
+ *
+ * <h3>Container Policy</h3>
+ *
+ * Two container targets are provided:
+ *
+ * <ul>
+ *   <li><code>std::vector</code></li>
+ *   <li><code>std::deque</code></li>
+ * </ul>
+ *
+ * Rationale:
+ *
+ * <ul>
+ *   <li>Both are high-performance contiguous or segmented linear containers.</li>
+ *   <li>They provide amortized O(1) <code>push_back()</code>.</li>
+ *   <li>They are suitable for modern high-throughput systems.</li>
+ * </ul>
+ *
+ * <h4>Why Not std::list?</h4>
+ *
+ * <ul>
+ *   <li>Poor cache locality</li>
+ *   <li>High fragmentation</li>
+ *   <li>Significant allocator overhead</li>
+ *   <li>Inferior performance on modern CPUs</li>
+ * </ul>
+ *
+ * Linked lists are not suitable for modern high-performance
+ * coroutine pipelines and are intentionally excluded.
+ *
+ *
+ * <h3>Semantic Warning</h3>
+ *
+ * Eager materialization:
+ *
+ * <ul>
+ *   <li>Consumes the generator.</li>
+ *   <li>Destroys lazy evaluation benefits.</li>
+ *   <li>May allocate large memory blocks.</li>
+ * </ul>
+ *
+ * It should be used intentionally,
+ * not as a default pattern.
+ *
+ *
+ * <h3>Design Summary</h3>
+ *
+ * <ul>
+ *   <li>Use output-only generators whenever possible.</li>
+ *   <li>Prefer <code>to_vector(gen)</code> or <code>to_deque(gen)</code>.</li>
+ *   <li>Avoid bulk input injection in production systems.</li>
+ *   <li>Interactive stepping should remain externally controlled.</li>
+ *   <li>Only vector and deque are supported by design.</li>
+ * </ul>
+ *
+ */
+
+namespace example {
+
+    void example_eager_materialization() {
+
+        std::cout << "\n===== Eager materialization demo =====\n\n";
+        {
+            // Capture a single external parameter.
+            //
+            // Philosophy:
+            // Instead of using an interactive generator and repeatedly sending
+            // a constant value, capture the parameter directly at construction time.
+            // This keeps the generator output-only and semantically clean.
+
+            int base = 10;
+            auto gen = [base]() -> jh::generator<int> {
+                for (int i = 0; i < 5; ++i) {
+                    co_yield base + i;
+                }
+            }();
+
+            auto vec = jh::async::to_vector(gen);
+            std::cout << "[Capture single parameter] ";
+            for (auto v: vec)
+                std::cout << v << " ";
+            std::cout << "\n";
+        }
+
+        std::cout << "\n";
+
+        {
+            // Capture an external range (std::vector).
+            //
+            // Philosophy:
+            // If the generator logic depends on a known sequence,
+            // capture the container and iterate internally.
+            // Do not push the data back through send().
+            //
+            // The generator remains output-only and externally deterministic.
+
+            std::vector<int> data{1, 2, 3, 4, 5};
+
+            // Use reference to avoid possible dangling (copying leads to a temporary
+            // that may be destroyed before the generator is done).
+            auto gen = [&data]() -> jh::generator<int> {
+                for (auto v: data) {
+                    co_yield v * 3;
+                }
+            }();
+
+            auto vec = jh::async::to_vector(gen);
+            std::cout << "[Capture range] ";
+            for (auto v: vec)
+                std::cout << v << " ";
+            std::cout << "\n";
+        }
+
+        std::cout << "\n";
+
+        {
+            // Capture multiple external values (structured configuration).
+            //
+            // Philosophy:
+            // If multiple parameters are required, assemble them
+            // into a structured external context and capture that context.
+            //
+            // This avoids turning the generator into a parameter-injection loop.
+            int multiplier = 2;
+            int offset = 5;
+
+            auto gen = [multiplier, offset]() -> jh::generator<int> {
+                for (int i = 0; i < 4; ++i) {
+                    co_yield i * multiplier + offset;
+                }
+            }();
+
+            auto dq = jh::async::to_deque(gen);
+            std::cout << "[Capture structured config] ";
+            for (auto v: dq)
+                std::cout << v << " ";
+            std::cout << "\n";
+        }
+
+        std::cout << "\n===== end eager materialization demo =====\n";
+    }
+}
+
+
+/**
+ * @page Generator_Range_Pipe_Interaction
+ *
+ * @brief Interaction model between jh::generator_range and the JH ranges framework.
+ *
+ * <h3>Overview</h3>
+ *
+ * <p>
+ * <code>jh::generator_range&lt;T&gt;</code> is a range façade constructed
+ * from a generator factory. Each call to <code>begin()</code> creates
+ * a new <code>jh::generator&lt;T&gt;</code>, restoring input-range
+ * semantics over a coroutine-based stream.
+ * </p>
+ *
+ * <p>
+ * This enables structural compatibility with:
+ * </p>
+ *
+ * <ul>
+ *   <li><code>&lt;jh/views&gt;</code></li>
+ *   <li><code>&lt;jh/ranges_ext&gt;</code></li>
+ *   <li>Standard <code>&lt;ranges&gt;</code> adaptors</li>
+ * </ul>
+ *
+ *
+ * <h3>Iterator Semantics</h3>
+ *
+ * <p>
+ * The iterator type produced by <code>generator_range</code> is:
+ * </p>
+ *
+ * <ul>
+ *   <li>Single-pass</li>
+ *   <li>Non-copyable</li>
+ * </ul>
+ *
+ * <p>
+ * The restriction is intentional. A generator instance represents a
+ * stateful coroutine. If iterator copying were permitted, two iterators
+ * could attempt to advance the same coroutine instance, resulting in
+ * ambiguous execution order and undefined semantics.
+ * </p>
+ *
+ * <p>
+ * Therefore, the iterator enforces unique ownership of coroutine
+ * progression.
+ * </p>
+ *
+ *
+ * <h3>Pipeline Interaction Rule</h3>
+ *
+ * <p>
+ * Many lazy range adaptors internally copy iterators. Because
+ * <code>generator_range</code> prohibits copying, it cannot safely
+ * participate in arbitrary lazy pipelines.
+ * </p>
+ *
+ * <p>
+ * To integrate a generator-driven range into a full adaptor chain,
+ * an explicit eager materialization boundary is required.
+ * </p>
+ *
+ *
+ * <h3>Materialization Boundary Pattern</h3>
+ *
+ * @code
+ * auto range =
+ *     jh::to_range([] {
+ *         some_finite_generator();
+ *     })
+ *     | jh::ranges::collect<std::vector<long>>();
+ * @endcode
+ *
+ * <p>
+ * The evaluation proceeds as follows:
+ * </p>
+ *
+ * <ol>
+ *   <li><code>collect&lt;std::vector&lt;&gt;&gt;</code> eagerly consumes the
+ *       single-pass generator.</li>
+ *   <li>The result becomes a stable, multi-pass container.</li>
+ * </ol>
+ *
+ * <p>
+ * After this boundary, the data may freely interact with:
+ * </p>
+ *
+ * <ul>
+ *   <li>All JH view adaptors</li>
+ *   <li>Structural collectors</li>
+ *   <li>Container construction adaptors</li>
+ * </ul>
+ *
+ *
+ * <h3>Role of jh::ranges::collect</h3>
+ *
+ * <p>
+ * <code>jh::ranges::collect&lt;C&gt;</code> defines an explicit evaluation
+ * boundary within a pipeline. It consumes a range and materializes it
+ * into a concrete container <code>C</code>.
+ * </p>
+ *
+ * <p>
+ * In the context of <code>generator_range</code>, it provides the
+ * semantic stabilization necessary to transition from a coroutine-driven
+ * single-pass stream to a conventional container-based range model.
+ * </p>
+ *
+ *
+ * <h3>Design Summary</h3>
+ *
+ * <ul>
+ *   <li><code>generator_range</code> restores range syntax over generators.</li>
+ *   <li>Its iterator is single-pass and intentionally non-copyable.</li>
+ *   <li>Lazy adaptor stacks may require iterator copying and are therefore restricted.</li>
+ *   <li>An eager materialization boundary must be introduced before deep pipeline interaction.</li>
+ *   <li><code>collect&lt;&gt;</code> provides the recommended boundary mechanism.</li>
+ * </ul>
+ *
+ */
+
+#include <jh/ranges_ext>
+#include <jh/views>
+#include <memory_resource>
+#include <jh/runtime_arr>
+
+namespace example::simulated {
+    struct mid {
+        long index;
+        int id;
+        std::string name;
+        int value;
+
+        mid(long i, int id_, std::string n, int v)
+                : index(i), id(id_), name(std::move(n)), value(v) {}
+
+        [[nodiscard]] std::pair<int, std::string> as_pair() const {
+            return {static_cast<int>(index), name + ":(" + std::to_string(value) + ", " + std::to_string(id) + ")"};
+        }
+    };
+}
+
+namespace example {
+
+    jh::generator<long> finite_long_sequence(long end = std::numeric_limits<long>::max()) {
+        // This generator yields an infinite sequence of integers starting from 0.
+        // It should never be used with range-for without an external guard, as it is infinite.
+        for (std::weakly_incrementable auto i: std::views::iota(static_cast<long>(0))){
+            if (i >= end)
+                break;
+            co_yield static_cast<long>(i);
+        }
+    }
+
+    void example_range_pipe() {
+
+        std::cout << "\n===== generator_range × views × ranges_ext demo =====\n\n";
+
+        jh::runtime_arr<std::string> names(3);
+        jh::runtime_arr<int> values(3);
+
+        for (auto [i, x]: std::views::iota(0, 3) | jh::ranges::views::enumerate(1))
+            x = static_cast<int>(i * 10);
+
+        for (auto [i, x]: values | jh::ranges::views::enumerate())
+            x = static_cast<int>((i + 1) * 100);
+
+        names[0] = "Alice";
+        names[1] = "Bob";
+        names[2] = "Carol";
+        long end_point = 5;
+
+        std::pmr::monotonic_buffer_resource pool;
+
+        // [id] -> [(index, id)] -> [((index, id), name, value)] -> [(index, id, name, value)] -> [mid] -> [pair]
+
+        auto pmr_map = jh::to_range([&end_point] {
+            return finite_long_sequence(end_point);
+        })
+                       | jh::ranges::collect<std::vector<long>>()
+                       | jh::ranges::views::enumerate(100)
+                       | jh::ranges::views::zip_pipe(names, values)
+                       | jh::ranges::views::flatten()
+                       | jh::ranges::collect<std::vector<simulated::mid>>()
+                       | jh::ranges::views::transform(&simulated::mid::as_pair)
+                       | jh::ranges::to<std::pmr::unordered_map<int, std::string>>(
+                0,
+                std::hash<int>{},
+                std::equal_to<int>{},
+                std::pmr::polymorphic_allocator<std::pair<const int, std::string>>(&pool));
+        std::cout << "Resulting pmr::unordered_map contents:\n";
+
+        for (auto & it : pmr_map) {
+            std::cout << "  key = " << it.first
+                      << ", value = " << it.second << "\n";
+        }
+
+        std::cout << "\n===== end generator_range pipeline demo =====\n";
+    }
+
+}
+
 int main() {
-    example::generator_to_vector_demo();
-    example::step_generator_to_vector_demo();
-    example::step_generator_to_deque_demo();
-    example::interactive_generator_demo();
-    example::send_ite_demo();
-    example::range_constructing();
-    example::example_to_range();
+    example::example_generate_chunks();
+    example::example_lambda_gen();
+    example::example_step_by_step();
+    example::example_generator_range();
+    example::example_outer_ctrled_multi_input();
+    example::example_make_generator();
+    example::example_eager_materialization();
+    example::example_range_pipe();
     return 0;
 }

--- a/examples/example_generator.cpp
+++ b/examples/example_generator.cpp
@@ -1060,9 +1060,16 @@ namespace example {
     gen_person() {
         while (true) {
 
+#if IS_GCC
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
+            // NOLINTNEXTLINE(readability-static-accessed-through-instance)
             auto [age, service, name] =
                     co_await std::tuple<unsigned int, unsigned int, std::string>{};
-
+#if IS_GCC
+#pragma GCC diagnostic pop
+#endif
             auto person = std::make_shared<simulated::Employee>();
 
             if (age < 18) {
@@ -1752,7 +1759,7 @@ namespace example {
     jh::generator<long> finite_long_sequence(long end = std::numeric_limits<long>::max()) {
         // This generator yields an infinite sequence of integers starting from 0.
         // It should never be used with range-for without an external guard, as it is infinite.
-        for (std::weakly_incrementable auto i: std::views::iota(static_cast<long>(0))){
+        for (std::weakly_incrementable auto i: std::views::iota(static_cast<long>(0))) {
             if (i >= end)
                 break;
             co_yield static_cast<long>(i);
@@ -1797,7 +1804,7 @@ namespace example {
                 std::pmr::polymorphic_allocator<std::pair<const int, std::string>>(&pool));
         std::cout << "Resulting pmr::unordered_map contents:\n";
 
-        for (auto & it : pmr_map) {
+        for (auto &it: pmr_map) {
             std::cout << "  key = " << it.first
                       << ", value = " << it.second << "\n";
         }

--- a/examples/example_immutable_str.cpp
+++ b/examples/example_immutable_str.cpp
@@ -1,289 +1,1189 @@
 /**
- * @file example_string.cpp
- * @brief Demonstrates the usage of `immutable_str` in `jh-toolkit`.
+ * @file example_immutable_str.cpp
+ * @brief Example demonstrating the usage of <code>&lt;jh/immutable_str&gt;</code>.
  *
- * ## Overview
- * `jh::immutable_str` is a lightweight, immutable string designed for **safe and efficient storage**.
- * Unlike `std::string`, it enforces **true immutability** at the memory level.
+ * <p>
+ * This file demonstrates how to use <code>&lt;jh/immutable_str&gt;</code>
+ * and serves as a reference example for both developers and AI systems
+ * learning how to use this library.
+ * </p>
  *
- * ## Key Features
- * - **Immutable & Thread-Safe**: Once created, it cannot be modified.
- * - **Efficient Storage**: Uses `std::unique_ptr<const char[]>` to minimize memory overhead.
- * - **Automatic Trimming**: Optionally removes leading/trailing whitespace.
- * - **Optimized for Hashing**: Designed for use in hash containers.
- * - **Supports Shared Ownership**: `std::shared_ptr<immutable_str>` allows efficient reference sharing.
+ * <p>
+ * The canonical include form is:
+ * </p>
  *
- * ## Best Practices
- * ✅ **Use `immutable_str` for fixed strings**, especially in **multithreaded applications**.
- * ✅ **Avoid direct construction from `std::string_view` or `std::string`** to prevent unintended behavior.
- * ✅ **Single-parameter constructor only accepts `const char*`**, ensuring safe type conversions and LLVM extern "C" compatibility.
- * ✅ **For `std::string_view` inputs, use a protecting mutex** to prevent data race issues.
- * ✅ **Use `make_atomic()` or `safe_from()`** for shared immutable string creation.
+ * @code
+ * #include &lt;jh/immutable_str&gt;
+ * @endcode
  *
- * ## Linking Requirement
- * Since this module has an associated **source file**, ensure that you **link against `jh-toolkit-impl`**
- * when building your project.
+ * <p>
+ * All symbols used in this example are exported directly under the
+ * <code>jh::</code> namespace.
+ * </p>
  *
- * ```cmake
- * target_link_libraries({your_project} PRIVATE jh-toolkit-impl)
- * ```
- * This ensures all necessary header files are available for compilation.
+ * <p>
+ * Specifically:
+ * <ul>
+ *   <li><code>jh::immutable_str</code> — immutable runtime string type.</li>
+ *   <li><code>jh::make_atomic</code> — factory returning <code>std::shared_ptr&lt;immutable_str&gt;</code>.</li>
+ *   <li><code>jh::safe_from</code> — thread-safe substring-based construction helper.</li>
+ *   <li><code>jh::atomic_str_ptr</code> and <code>jh::weak_str_ptr</code> — shared/weak aliases.</li>
+ * </ul>
+ * </p>
+ *
+ * <p>
+ * For complete API documentation, refer to
+ * <code>jh/core/immutable_str.h</code>. The Doxygen comments in that
+ * header define the official semantics of the component.
+ * </p>
+ *
+ * <p>
+ * In modern C++, immutability is often expressed only through
+ * const-qualified interfaces. However, <code>jh::immutable_str</code>
+ * enforces immutability at both the API and memory level.
+ * The underlying character storage is never exposed as writable memory,
+ * and no mutation operations are provided.
+ * </p>
+ *
+ * <p>
+ * Unlike <code>const std::string</code>, which may still allow
+ * modification via const-cast or internal reallocation behavior,
+ * <code>jh::immutable_str</code> represents a truly immutable runtime
+ * string abstraction.
+ * </p>
+ *
+ * <p>
+ * The component supports both header-only and static-library modes:
+ * </p>
+ *
+ * <ul>
+ *   <li><code>jh::jh-toolkit</code> — template / header-only mode.</li>
+ *   <li><code>jh::jh-toolkit-static</code> — precompiled static mode.</li>
+ * </ul>
+ *
+ * <p>
+ * Both targets provide identical semantics and API behavior.
+ * The static target ships with precompiled units and typically
+ * enables slightly stronger optimization characteristics in large builds.
+ * </p>
+ *
+ * <p>
+ * This example focuses on practical usage patterns, including:
+ * <ul>
+ *   <li>Basic immutable construction.</li>
+ *   <li>Thread-safe substring initialization.</li>
+ *   <li>Shared ownership via <code>std::shared_ptr</code>.</li>
+ *   <li>Deduplication via <code>jh::observe_pool</code>.</li>
+ * </ul>
+ * </p>
+ *
+ * <h3>Design Motivation — Filling the Immutability Spectrum</h3>
+ *
+ * <p>
+ * <code>jh::immutable_str</code> exists to fill a specific gap in the
+ * C++ immutability spectrum: runtime-created but permanently immutable text.
+ * </p>
+ *
+ * <table border="1" cellpadding="6" cellspacing="0">
+ * <tr>
+ *   <th>Immutability Level</th>
+ *   <th>Example Type</th>
+ *   <th>Mutability Strength</th>
+ * </tr>
+ * <tr>
+ *   <td>Compile-time enforced (NTTP)</td>
+ *   <td><code>jh::meta::t_str</code></td>
+ *   <td>Strongest (type-level)</td>
+ * </tr>
+ * <tr>
+ *   <td>Compile-time literal (.rodata)</td>
+ *   <td><code>std::string_view</code> literal</td>
+ *   <td>Strong (static storage)</td>
+ * </tr>
+ * <tr>
+ *   <td>Runtime-created immutable</td>
+ *   <td><code>jh::immutable_str</code></td>
+ *   <td>Strong (memory-enforced)</td>
+ * </tr>
+ * <tr>
+ *   <td>Semantic immutability</td>
+ *   <td><code>const std::string</code></td>
+ *   <td>Weak (logically const)</td>
+ * </tr>
+ * <tr>
+ *   <td>Mutable runtime string</td>
+ *   <td><code>std::string</code></td>
+ *   <td>Fully mutable</td>
+ * </tr>
+ * </table>
+ *
+ * <p>
+ * Compile-time strings (<code>t_str</code> or literal
+ * <code>string_view</code>) are ideal when the content is known
+ * at compile time. However, many real systems load configuration
+ * or construct identifiers at runtime and then require those
+ * strings to remain permanently stable.
+ * </p>
+ *
+ * <p>
+ * <code>jh::immutable_str</code> provides a dedicated abstraction
+ * for that category:
+ * </p>
+ *
+ * <ul>
+ *   <li>Configuration keys loaded during initialization.</li>
+ *   <li>Canonical identifiers in mini dataframe-like systems.</li>
+ *   <li>Country + region composite identifiers.</li>
+ *   <li>Symbol tables in educational compiler prototypes.</li>
+ * </ul>
+ *
+ * <p>
+ * Combined with <code>jh::observe_pool&lt;jh::immutable_str&gt;</code>,
+ * immutable strings can be deduplicated and shared safely via
+ * <code>std::shared_ptr</code>, allowing automatic reclamation
+ * when no longer referenced.
+ * </p>
+ *
  */
-#define JH_IMMUTABLE_STR_AUTO_TRIM true
-#include "jh/immutable_str"
-#include <iostream>
-#include <vector>
-#include <unordered_map>
-#include <unordered_set>
-#include <cstdint>
-#include <cstddef>
+
 #include "ensure_output.h"
-#include "jh/pod"
-#include "jh/concepts"
-#include "jh/jindallae"
 
 #if IS_WINDOWS
 static EnsureOutput ensure_output_setup;
 #endif
 
+/**
+ * @page ImmutableStr_AutoTrim_Config Example — Configuring JH_IMMUTABLE_STR_AUTO_TRIM
+ *
+ * @brief Demonstrates how to configure the automatic trimming policy
+ *        of <code>jh::immutable_str</code>.
+ *
+ * <p>
+ * By default, <code>jh::immutable_str</code> enables automatic trimming
+ * of leading and trailing ASCII whitespace:
+ * </p>
+ *
+ * @code
+ * #define JH_IMMUTABLE_STR_AUTO_TRIM true
+ * @endcode
+ *
+ * <p>
+ * The following example shows explicit definition before inclusion:
+ * </p>
+ *
+ * @code
+ * #define JH_IMMUTABLE_STR_AUTO_TRIM ... // true or false
+ * #include &lt;jh/immutable_str&gt;
+ * @endcode
+ *
+ * <p>
+ * In normal usage, you do not need to define this macro manually.
+ * The default is already <code>true</code>. This example exists only
+ * to demonstrate how configuration must occur <b>before inclusion</b>.
+ * </p>
+ *
+ * <h3>Configuration Rule</h3>
+ *
+ * <ul>
+ *   <li>The macro must be defined before any inclusion of
+ *       <code>&lt;jh/immutable_str&gt;</code>.</li>
+ *   <li>It must be a boolean literal: <code>true</code> or <code>false</code>.</li>
+ *   <li>All translation units must use the same value.</li>
+ * </ul>
+ *
+ * <h3>Behavior</h3>
+ *
+ * <ul>
+ *   <li><code>true</code> (default): remove leading and trailing ASCII whitespace.</li>
+ *   <li><code>false</code>: preserve input exactly as provided.</li>
+ * </ul>
+ *
+ * <p>
+ * Whitespace detection includes:
+ * </p>
+ *
+ * @code
+ * ch == ' '  ||
+ * ch == '\t' ||
+ * ch == '\n' ||
+ * ch == '\v' ||
+ * ch == '\f' ||
+ * ch == '\r'
+ * @endcode
+ *
+ * <h3>Performance Considerations</h3>
+ *
+ * <p>
+ * In typical engineering workloads, input strings contain little or no
+ * boundary whitespace. In such cases, trimming introduces virtually no
+ * measurable overhead.
+ * </p>
+ *
+ * <p>
+ * Benchmarks show initialization performance remains close to
+ * <code>std::string</code> construction.
+ * </p>
+ *
+ * <p>
+ * The default is enabled because <code>jh::immutable_str</code> is designed
+ * for configuration-heavy and infrastructure-level systems. In particular:
+ * </p>
+ *
+ * <ul>
+ *   <li>Strings constructed via temporary concatenation.</li>
+ *   <li>Strings derived from <code>std::string_view</code> slices.</li>
+ *   <li>Configuration keys loaded from external sources.</li>
+ * </ul>
+ *
+ * <p>
+ * Automatic trimming simplifies downstream equality checks and removes
+ * redundant conditional logic in caller code.
+ * </p>
+ *
+ * <h3>String Semantics (Not Buffer Semantics)</h3>
+ *
+ * <p>
+ * <code>jh::immutable_str</code> models a <b>string</b>, not a generic byte buffer.
+ * </p>
+ *
+ * <ul>
+ *   <li>Construction from <code>const char*</code> uses <code>strlen()</code>.</li>
+ *   <li>Construction from <code>std::string_view</code> uses <code>strnlen()</code> to
+ *   check if the strnlen is less than the view size, which would indicate embedded null characters.</li>
+ * </ul>
+ *
+ * <p>
+ * If a <code>std::string_view</code> contains embedded <code>'\0'</code>
+ * characters, it violates string semantics and construction throws:
+ * </p>
+ *
+ * @code
+ * std::logic_error(
+ *   "jh::immutable_str does not support string views containing embedded null characters.");
+ * @endcode
+ *
+ * <p>
+ * This enforcement ensures that <code>immutable_str</code> remains a
+ * semantically valid string abstraction rather than a raw memory container.
+ * </p>
+ */
+#define JH_IMMUTABLE_STR_AUTO_TRIM true
+
+#include <jh/immutable_str>
+
+#include <iostream>
+
+/**
+ * @page ImmutableStr_Single_Object_Construction
+ *
+ * @brief Rationale for restricting single-object construction to <code>const char*</code>.
+ *
+ * <h3>Design Rule</h3>
+ *
+ * <p>
+ * The primary single-object constructor of <code>jh::immutable_str</code>
+ * accepts only:
+ * </p>
+ *
+ * @code
+ * const char*
+ * @endcode
+ *
+ * <p>
+ * This includes:
+ * </p>
+ *
+ * <ul>
+ *   <li>String literals (after decay).</li>
+ *   <li>True <code>const char*</code> pointers.</li>
+ * </ul>
+ *
+ * <p>
+ * It intentionally does <b>not</b> accept:
+ * </p>
+ *
+ * <ul>
+ *   <li><code>std::string</code></li>
+ *   <li>Implicitly convertible character containers</li>
+ *   <li>Mutable owning string types</li>
+ * </ul>
+ *
+ * <h3>Rationale</h3>
+ *
+ * <ol>
+ *
+ *   <li>
+ *     <b>Prevent accidental capture of shared mutable state</b>
+ *     <p>
+ *     <code>std::string</code> objects may be shared across threads,
+ *     resized, or modified concurrently. Allowing implicit construction
+ *     from such types would make it easy to pass mutable state into an
+ *     immutable abstraction without clearly signaling intent.
+ *     </p>
+ *   </li>
+ *
+ *   <li>
+ *     <b>Enforce an explicit semantic boundary</b>
+ *     <p>
+ *     Requiring an explicit conversion such as:
+ *     </p>
+ *     @code
+ *     static_cast&lt;const char*&gt;(buffer.data())
+ *     @endcode
+ *     <p>
+ *     forces the caller to acknowledge that the source memory is being
+ *     treated as a null-terminated C-style string and that a new immutable
+ *     copy will be created.
+ *     </p>
+ *   </li>
+ *
+ *   <li>
+ *     <b>Avoid ambiguous lifetime semantics</b>
+ *     <p>
+ *     Accepting <code>std::string</code> directly could encourage patterns
+ *     where ownership and thread-safety assumptions are unclear. The
+ *     restricted constructor ensures that initialization is a deliberate
+ *     conversion step rather than a convenience shortcut.
+ *     </p>
+ *   </li>
+ *
+ *   <li>
+ *     <b>Model a string, not a generic buffer</b>
+ *     <p>
+ *     <code>jh::immutable_str</code> represents textual string semantics.
+ *     Construction relies on <code>strlen()</code>, requires
+ *     null-termination, and does not treat input as arbitrary binary data.
+ *     This guarantees that the resulting object is a well-defined string.
+ *     </p>
+ *   </li>
+ *
+ * </ol>
+ *
+ * <h3>Summary</h3>
+ *
+ * <ul>
+ *   <li>Single-object construction is intentionally limited to <code>const char*</code>.</li>
+ *   <li>Implicit conversion from mutable containers is disallowed.</li>
+ *   <li>The restriction strengthens immutability and semantic clarity.</li>
+ * </ul>
+ *
+ */
 
 namespace example {
-    /**
-     * @brief Demonstrates basic usage of `immutable_str`
-     *
-     * - Directly creates an `immutable_str` from a **string literal**.
-     * - Simulates a real-world scenario where **a buffer is mutable** but converted into an immutable string.
-     */
-    void basic_usage() {
-        std::cout << "\U0001F539 Basic Usage:\n";
 
-        // Directly create an immutable string from a string literal
+    void example_basic_immutable_str() {
+
+        std::cout << "\n===== Basic immutable_str construction demo =====\n\n";
+
+        // Direct construction from const char*
+        // This is the primary and intentionally restricted single-object constructor.
         const jh::immutable_str imm_str1("Hello, Immutable World!");
-        std::cout << "Immutable String: " << imm_str1.view() << "\n";
 
-        // Simulating a real-world buffer scenario where data is mutable
+        std::cout << "Immutable String 1: " << imm_str1.view() << "\n";
+        std::cout << "Size: " << imm_str1.size() << "\n\n";
+
+        // Simulated mutable buffer (e.g., data received from external system)
         std::vector<char> buffer;
         const std::vector helper{'T', 'e', 's', 't', '\0'};
         buffer.insert(buffer.end(), helper.begin(), helper.end());
 
-        // Explicit cast to const char* to ensure immutability
-        const jh::immutable_str imm_str2(static_cast<const char *>(buffer.data()));
+        // Explicit cast to const char*
+        // This is required — implicit construction from std::string or other
+        // potentially shared mutable objects is intentionally disallowed.
+        const jh::immutable_str imm_str2(
+                static_cast<const char *>(buffer.data())
+        );
+
         std::cout << "Immutable from Buffer: " << imm_str2.view() << "\n";
+        std::cout << "Size: " << imm_str2.size() << "\n\n";
 
-        std::cout << "Size of imm_str1: " << imm_str1.size() << "\n";
-        std::cout << "Size of imm_str2: " << imm_str2.size() << "\n";
-    }
+        std::cout << "Hash imm_str1: " << imm_str1.hash() << "\n";
+        std::cout << "Hash imm_str2: " << imm_str2.hash() << "\n";
 
-    /**
-     * @brief Demonstrates hashing and comparison of immutable strings.
-     *
-     * - Uses `make_atomic()` to create **shared immutable strings**.
-     * - Tests whether **hash values and string contents match**.
-     */
-    void hashing_and_comparison() {
-        std::cout << "\n\U0001F539 Hashing & Comparison:\n";
-
-        // Creating shared immutable strings
-        const auto atomic1 = jh::make_atomic("Shared Immutable String");
-        const auto atomic2 = jh::make_atomic("Shared Immutable String");
-        const auto atomic3 = jh::make_atomic("Different String");
-
-        std::cout << "Hash match (atomic1 vs atomic2): " << (atomic1->hash() == atomic2->hash()) << "\n";
-        std::cout << "String match (atomic1 vs atomic2): " << (*atomic1 == *atomic2) << "\n";
-        std::cout << "String match (atomic1 vs atomic3): " << (*atomic1 == *atomic3) << "\n";
-    }
-
-    /**
-     * @brief Demonstrates the automatic trimming feature of `immutable_str`.
-     *
-     * - **When `auto_trim` is enabled**, leading/trailing spaces are removed:
-     *   ```cpp
-     *   jh::immutable_str::auto_trim = true;
-     *   jh::immutable_str str("  Trimmed  ");
-     *   std::cout << str.view();  // Output: "Trimmed"
-     *   ```
-     * - **When `auto_trim` is disabled**, spaces are preserved:
-     *   ```cpp
-     *   jh::immutable_str::auto_trim = false;
-     *   jh::immutable_str str("  Not Trimmed  ");
-     *   std::cout << str.view();  // Output: "  Not Trimmed  "
-     *   ```
-     */
-    void auto_trim_behavior() {
-        std::cout << "\n\U0001F539 Auto Trim Behavior:\n";
-
-        const jh::immutable_str trimmed("   Trimmed String   ");
-        const jh::immutable_str normal("Trimmed String");
-
-        std::cout << "Auto-trim enabled: " << trimmed.view() << "\n";
-        std::cout << "Trimmed equals normal: " << (trimmed == normal) << "\n";
-    }
-
-    /**
-     * @brief Demonstrates using `atomic_str_ptr` (`std::shared_ptr<immutable_str>`) in **hash containers**.
-     *
-     * - Stores **immutable strings as keys** in `std::unordered_map`.
-     * - Stores **unique immutable strings** in `std::unordered_set`.
-     */
-    void hash_container_usage() {
-        std::cout << "\n\U0001F539 Using `atomic_str_ptr` in Hash Containers:\n";
-
-        // Using immutable strings as keys in a hash map
-        std::unordered_map<jh::atomic_str_ptr, int, jh::atomic_str_hash, jh::atomic_str_eq> immutable_map;
-
-        const auto key1 = jh::make_atomic("Immutable Key 1");
-        const auto key2 = jh::make_atomic("Immutable Key 2");
-        const auto key3 = jh::make_atomic("Immutable Key 1"); // Same content as key1
-
-        immutable_map[key1] = 100;
-        immutable_map[key2] = 200;
-        immutable_map[key3] = 300; // Overwrites key1 since they have the same content
-
-        std::cout << "Map size: " << immutable_map.size() << "\n";
-        std::cout << "Value for '" << key1->view() << "': " << immutable_map[key1] << "\n";
-        std::cout << "Value for '" << key2->view() << "': " << immutable_map[key2] << "\n";
-
-        // Using immutable strings in a hash set
-        std::unordered_set<jh::atomic_str_ptr, jh::atomic_str_hash, jh::atomic_str_eq> immutable_set;
-
-        immutable_set.insert(jh::make_atomic("Unique String 1"));
-        immutable_set.insert(jh::make_atomic("Unique String 2"));
-        immutable_set.insert(jh::make_atomic("Unique String 1")); // Duplicate, should not be inserted again
-
-        std::cout << "Set size (should be 2): " << immutable_set.size() << "\n";
-    }
-
-    /**
-     * @brief Demonstrates safe construction from `std::string_view` with a mutex.
-     *
-     * - Ensures the **source data is properly synchronized** before creating an immutable string.
-     */
-    void safe_construct() {
-        std::cout << "\n\U0001F539 Safe Construction with `std::string_view`:\n";
-
-        std::mutex mtx;
-        const std::string shared_data = "Thread-safe string";
-
-        // Safe construction with mutex protection
-        const jh::atomic_str_ptr safe_str = jh::safe_from(shared_data, mtx);
-
-        std::cout << "Safely constructed immutable string: " << safe_str->view() << "\n";
-    }
-
-    /**
-     * @brief Demonstrates pooling of immutable strings.
-     *
-     * - Uses `jh::pool<immutable_str>` to avoid duplicate allocations.
-     * - Shows that **identical strings are pooled together**.
-     */
-    void pooling() {
-        std::cout << "\n\U0001F539 Pooling Immutable Strings:\n";
-
-        jh::observe_pool<jh::immutable_str> string_pool;
-
-        auto pooled1 = string_pool.acquire("Pooled String");
-        auto pooled2 = string_pool.acquire("Pooled String");
-        const auto pooled3 = string_pool.acquire("Different String");
-
-        std::cout << "Pooled1 == Pooled2: " << (pooled1 == pooled2) << "\n";
-        std::cout << "Pooled1 != Pooled3: " << (pooled1 != pooled3) << "\n";
-        std::cout << "Pool size: " << string_pool.size() << "\n";
-
-        pooled1.reset();
-        pooled2.reset();
-
-        string_pool.cleanup(); // Remove expired references
-        std::cout << "After cleanup, pool size: " << string_pool.size() << "\n";
-    }
-
-    /**
-     * @brief Demonstrates how to safely use `switch` with `jh::immutable_str` hashing.
-     * .
-     * ## Understanding `jh::immutable_str::hash()`
-     * - Just like `std::string` and `std::string_view`, `jh::immutable_str` provides a **runtime hash**.
-     * - The default hash function (`jh::immutable_str::hash()`) uses `std::hash<std::string_view>` internally.
-     * - Since this hash is **computed at runtime**, it is **not `constexpr`** and **cannot be directly used in `switch-case`**.
-     * .
-     * ## Why `std::unordered_map<size_t, size_t>` is Not Recommended
-     * - A common workaround is mapping hashes to unique identifiers in a `std::unordered_map<size_t, size_t>`.
-     * - This allows `switch` to work by providing **constexpr-compatible values**.
-     * - ❗ However, **hash collisions can occur**, potentially causing incorrect matches if different strings map to the same hash value.
-     * - While additional validation (`str_ptr->view() == "case"`) can mitigate this issue, it **is not a foolproof solution**.
-     * .
-     * ## Recommended Approach: Use `jh::atomic_str_ptr` as the Key
-     * - Instead of storing raw hashes (`size_t`), use `std::shared_ptr<jh::immutable_str>` (`jh::atomic_str_ptr`) as the key.
-     * - This approach **completely eliminates hash collisions** because keys are immutable string objects rather than numeric hash values.
-     * - `std::unordered_map<jh::atomic_str_ptr, size_t, jh::atomic_str_hash, jh::atomic_str_eq>` ensures **safe and precise matching**.
-     * - This method is both **efficient and scalable**, making it the preferred way to implement `switch`-like behavior.
-     */
-    void switch_case_usage(const char *str) {
-        jh::observe_pool<jh::immutable_str> string_pool;
-
-        /*
-         * Recommended method: Directly map atomic immutable strings to unique identifiers
-         * **Use independently created `make_atomic()` instead of `pool.acquire()`**
-         *
-         * ## Design Rationale:
-         * 1. **Avoid affecting object lifecycle in the pool**
-         *    - If `unordered_map` stores keys acquired from `pool.acquire()`, those objects
-         *      will persist in the pool, preventing proper cleanup.
-         *
-         * 2. **Ensure correct matching behavior**
-         *    - `unordered_map` should store unique immutable string objects for consistent key lookup.
-         *    - This ensures `atomic_str_ptr` comparison works correctly using `jh::atomic_str_hash` and `jh::atomic_str_eq`.
-         *
-         * 3. **Enable proper memory cleanup**
-         *    - By using `make_atomic()` directly, `unordered_map` does not retain references to pooled objects.
-         *    - This allows `string_pool.cleanup()` or auto-cleanup behaviors to properly release unreferenced objects.
-         */
-        static const auto immutable_map = std::unordered_map<jh::atomic_str_ptr, size_t, jh::atomic_str_hash, jh::atomic_str_eq>{
-            {jh::make_atomic("hello world"), 1},
-            {jh::make_atomic("example string"), 2},
-            {jh::make_atomic("another_string"), 3}
-        };
-
-        const auto it = immutable_map.find(str);
-
-        if (it == immutable_map.end()) {
-            std::cout << "String not matched" << std::endl;
-            return;
-        }
-
-        switch ((*it).second) {
-            case 1:
-                std::cout << "Matched String: 'hello world'" << std::endl;
-            break;
-            case 2:
-                std::cout << "Matched String: 'example string'" << std::endl;
-            break;
-            case 3:
-                std::cout << "Matched String: 'another_string'" << std::endl;
-            break;
-            default:
-                std::cout << "String not matched" << std::endl;
-        }
-    }
-
-    void immutable_str_matching() {
-        std::cout << "\n\U0001F539 Immutable String matching:\n";
-        switch_case_usage("hello world");
-        switch_case_usage("example string");
-        switch_case_usage("another_string");
-        switch_case_usage("some random string");
+        std::cout << "\n===== end basic immutable_str demo =====\n";
     }
 
 } // namespace example
 
 /**
+ * @page ImmutableStr_StringView_Constructor
+ *
+ * @brief Thread-safe <code>std::string_view</code>-based initialization.
+ *
+ * <h3>Constructor Form</h3>
+ *
+ * @code
+ * template &lt;jh::concepts::mutex_like M&gt;
+ * immutable_str(std::string_view sv, M& mtx);
+ * @endcode
+ *
+ * <p>
+ * This overload allows constructing an immutable string from any object
+ * convertible to <code>std::string_view</code>, together with a mutex
+ * that guards the underlying memory region.
+ * </p>
+ *
+ * <h3>Mutex Requirements</h3>
+ *
+ * <p>
+ * The mutex type must satisfy <code>jh::concepts::mutex_like</code>,
+ * meaning it supports either:
+ * </p>
+ *
+ * <ul>
+ *   <li><code>lock()</code>, <code>try_lock()</code>, <code>unlock()</code></li>
+ *   <li>or <code>lock_shared()</code>, <code>try_lock_shared()</code>, <code>unlock_shared()</code></li>
+ * </ul>
+ *
+ * <p>
+ * Internally, <code>jh::sync::const_lock</code>:
+ * </p>
+ *
+ * <ul>
+ *   <li>Prefers shared locking if available.</li>
+ *   <li>Falls back to exclusive locking otherwise.</li>
+ * </ul>
+ *
+ * <p>
+ * All standard library mutex types are supported
+ * (<code>std::mutex</code>, <code>std::shared_mutex</code>, etc.).
+ * Custom mutex types are also supported if they satisfy the concept.
+ * </p>
+ *
+ * <h3>Null Mutex Mode</h3>
+ *
+ * <p>
+ * If the program is strictly single-threaded or the memory is
+ * permanently immutable, you may use:
+ * </p>
+ *
+ * @code
+ * #include &lt;jh/typed&gt;
+ * jh::typed::null_mutex
+ * @endcode
+ *
+ * <p>
+ * This performs no locking and is optimized away entirely.
+ * </p>
+ *
+ * <h3>Embedded Null Check</h3>
+ *
+ * <p>
+ * The constructor verifies that:
+ * </p>
+ *
+ * @code
+ * ::strnlen(sv.data(), sv.size()) == sv.size()
+ * @endcode
+ *
+ * <p>
+ * If embedded <code>'\0'</code> characters exist,
+ * it throws:
+ * </p>
+ *
+ * @code
+ * std::logic_error(
+ *   "jh::immutable_str does not support string views containing embedded null characters.");
+ * @endcode
+ *
+ * <h3>Supported Sources</h3>
+ *
+ * <ul>
+ *   <li><code>std::string</code> (implicit conversion to <code>std::string_view</code>)</li>
+ *   <li><code>std::string_view</code></li>
+ *   <li><code>jh::pod::string_view</code> (explicit conversion required)</li>
+ * </ul>
+ *
+ * <p>
+ * <code>jh::pod::string_view</code> provides:
+ * </p>
+ *
+ * <ul>
+ *   <li>Explicit <code>operator std::string_view()</code></li>
+ *   <li><code>to_std()</code> helper for named conversion</li>
+ * </ul>
+ *
+ * <p>
+ * This design preserves overload clarity and avoids unintended
+ * implicit conversions.
+ * </p>
+ *
+ */
+
+#include <jh/typed>
+#include <jh/pod>
+
+namespace example {
+
+    void example_string_view_initialization() {
+
+        std::cout << "\n===== string_view-based immutable_str demo =====\n\n";
+
+        // 1. From std::string (implicit conversion to std::string_view)
+        std::string dynamic = "   ConfigValue   ";
+        std::mutex mtx;
+
+        // std::string implicitly converts to std::string_view
+        jh::immutable_str imm1(dynamic, mtx);
+
+        std::cout << "From std::string (trimmed): [" << imm1.view() << "]\n";
+        std::cout << "Size: " << imm1.size() << "\n\n";
+
+        // 2. From substring view (partial region)
+        auto pos = dynamic.find("Config");
+        std::string_view sub(dynamic.data() + pos, 11); // "ConfigValue"
+
+        jh::immutable_str imm2(sub, mtx);
+
+        std::cout << "From substring view: [" << imm2.view() << "]\n";
+        std::cout << "Size: " << imm2.size() << "\n\n";
+
+        // 3. Using jh::typed::null_mutex (single-thread, user guaranteed safety)
+        jh::immutable_str imm3(
+                std::string_view("   SingleThreadValue   "),
+                jh::typed::null_mutex
+        );
+        std::cout << "Using null_mutex: [" << imm3.view() << "]\n";
+        std::cout << "Size: " << imm3.size() << "\n\n";
+
+        // 4. From jh::pod::string_view
+        {
+            using namespace jh::pod::literals;
+
+            // literal form
+            jh::pod::string_view psv = "ExamplePSV"_psv;
+
+            // explicit conversion required
+            jh::immutable_str imm4(
+                    static_cast<std::string_view>(psv),
+                    jh::typed::null_mutex
+            );
+            std::cout << "From jh::pod literal: [" << imm4.view() << "]\n";
+            std::cout << "Size: " << imm4.size() << "\n\n";
+        }
+        {
+            // pointer + length construction (POD-safe)
+            const char raw[] = "RawBufferPSV";
+            std::cout << std::size(raw) << " bytes in raw buffer (including null terminator)\n";
+            jh::pod::string_view psv(raw, std::size(raw) - 1);
+
+            jh::immutable_str imm5(
+                    psv.to_std(),   // named conversion helper
+                    jh::typed::null_mutex
+            );
+            std::cout << "From jh::pod (ptr,len): [" << imm5.view() << "]\n";
+            std::cout << "Size: " << imm5.size() << "\n\n";
+        }
+
+        // 5. Attempt to construct from string_view with embedded nulls (should throw)
+        try {
+
+            std::cout << "Attempting to construct from string_view with embedded nulls: \"Bad\\0View\"\n";
+            std::string_view bad_view("Bad\0View", 8);
+            jh::immutable_str imm_bad(bad_view, mtx);
+        } catch (const std::logic_error &e) {
+            std::cout << "Caught expected exception for embedded nulls: " << e.what() << "\n\n";
+        }
+
+        std::cout << "\n===== end string_view-based immutable_str demo =====\n";
+    }
+
+} // namespace example
+
+/**
+ * @page ImmutableStr_Shared_Factories
+ *
+ * @brief Shared ownership helpers: <code>make_atomic</code> and <code>safe_from</code>.
+ *
+ * <p>
+ * In many engineering scenarios, immutable strings are shared across
+ * subsystems, caches, registries, or long-lived configuration objects.
+ * For this purpose, the JH Toolkit provides two convenience helpers
+ * that return:
+ * </p>
+ *
+ * @code
+ * using jh::atomic_str_ptr = std::shared_ptr&lt;jh::immutable_str&gt;;
+ * @endcode
+ *
+ * <h3>Factory Functions</h3>
+ *
+ * @code
+ * inline atomic_str_ptr make_atomic(const char* str);
+ *
+ * template <jh::concepts::mutex_like M>
+ * inline atomic_str_ptr safe_from(std::string_view sv, M& mtx);
+ * @endcode
+ *
+ * <p>
+ * These helpers are thin wrappers over <code>std::make_shared</code>.
+ * They exist for semantic clarity and API symmetry.
+ * </p>
+ *
+ * <h3>Equivalence</h3>
+ *
+ * <ul>
+ *   <li><code>make_atomic(str)</code> is equivalent to:<br/>
+ *       <code>std::make_shared&lt;jh::immutable_str&gt;(str)</code></li>
+ *
+ *   <li><code>safe_from(sv, mtx)</code> is equivalent to:<br/>
+ *       <code>std::make_shared&lt;jh::immutable_str&gt;(sv, mtx)</code></li>
+ * </ul>
+ *
+ * <p>
+ * No additional behavior is introduced. The functions exist to:
+ * </p>
+ *
+ * <ul>
+ *   <li>Make intent explicit (shared immutable string).</li>
+ *   <li>Improve readability in configuration-heavy code.</li>
+ *   <li>Provide API symmetry with non-shared constructors.</li>
+ * </ul>
+ *
+ */
+
+namespace example {
+
+    void example_shared_factories() {
+
+        // All hashes are computed lazily on first call to hash() and then cached for O(1) subsequent retrieval.
+        // The hash is based on std::hash<std::string_view> of the string content,
+        // The compiler should be able to use std::hash<std::string_view>, unstable compiler versions
+        // such as LLVM 17 and 18 may not be able to link to std::hash<std::string_view> normally,
+        // LLVM 20 is recommended as the best LLVM version for use with the JH Toolkit, (LLVM 16 also works)
+        // for best compatibility with the JH Toolkit.
+
+        std::cout << "\n===== shared immutable_str factory demo =====\n\n";
+
+        // 1. make_atomic (const char*)
+        jh::atomic_str_ptr shared1 = jh::make_atomic("SharedValue");
+
+        // jh::atomic_str_ptr is an alias for std::shared_ptr<jh::immutable_str>,
+        // indicating the ptr is atomic, so the pointer can be used as an atomic shared string across threads.
+
+        std::cout << "make_atomic: [" << shared1->view() << "]\n";
+        std::cout << "use_count: " << shared1.use_count() << "\n\n";
+
+        // Copy shared pointer
+        auto shared2 = shared1; // NOLINT
+        // simulated sharing across threads by copying the shared pointer
+
+        std::cout << "After copy, use_count: " << shared1.use_count() << "\n";
+        std::cout << "Pointers equal: "
+                  << (shared1.get() == shared2.get() ? "true" : "false")
+                  << "\n\n";
+
+        // 2. safe_from (std::string_view + mutex)
+        std::string dynamic = "   ThreadSafeShared   ";
+        std::mutex mtx;
+
+        // using auto will deduce the type as jh::atomic_str_ptr, which is std::shared_ptr<jh::immutable_str>
+        auto shared3 =
+                jh::safe_from(std::string_view(dynamic), mtx);
+
+        std::cout << "safe_from (trimmed): [" << shared3->view() << "]\n";
+        std::cout << "use_count: " << shared3.use_count() << "\n\n";
+
+        // 3. null_mutex variant
+        auto shared4 =
+                jh::safe_from(std::string_view("   NoLockNeeded   "),
+                              jh::typed::null_mutex);
+        // using auto is preferable as the deduced type is clear from the context
+
+        std::cout << "safe_from with null_mutex: ["
+                  << shared4->view() << "]\n\n";
+
+        std::cout << "Hash shared1: " << shared1->hash() << "\n"; // hash of "SharedValue"
+        std::cout << "Hash shared2: " << shared2->hash()
+                  << " (should be same as the above)\n"; // should be the same as shared1
+        std::cout << "Hash shared3: " << shared3->hash() << "\n"; // hash of "ThreadSafeShared"
+        std::cout << "Hash shared4: " << shared4->hash() << "\n"; // hash of "NoLockNeeded"
+
+        std::cout << "\n===== end shared immutable_str factory demo =====\n";
+    }
+
+} // namespace example
+
+/**
+ * @page ImmutableStr_Atomic_Pointer
+ *
+ * @brief Rationale for <code>jh::atomic_str_ptr</code>.
+ *
+ * <p>
+ * <code>jh::atomic_str_ptr</code> is defined as:
+ * </p>
+ *
+ * @code
+ * using atomic_str_ptr = std::shared_ptr&lt;jh::immutable_str&gt;;
+ * @endcode
+ *
+ * <h3>Why This Behaves as an Atomic String Handle</h3>
+ *
+ * <ul>
+ *   <li><code>jh::immutable_str</code> is strictly immutable after construction.</li>
+ *   <li>The underlying character buffer cannot be modified.</li>
+ *   <li>No mutation API exists.</li>
+ * </ul>
+ *
+ * <p>
+ * Because the managed object is immutable, a
+ * <code>std::shared_ptr&lt;jh::immutable_str&gt;</code>
+ * effectively acts as an atomic handle to a stable value.
+ * </p>
+ *
+ * <p>
+ * The pointer itself may be replaced, but the string object
+ * it references can never enter a partially modified state.
+ * </p>
+ *
+ * <h3>Thread-Safety Model</h3>
+ *
+ * <ul>
+ *   <li><code>std::shared_ptr</code> maintains an internal atomic
+ *       reference-count control block.</li>
+ *   <li>Copying, destruction, and ownership transfer are thread-safe.</li>
+ *   <li>The managed <code>immutable_str</code> object is read-safe
+ *       without additional synchronization.</li>
+ * </ul>
+ *
+ * <h3>Atomic Access (ISO Standard)</h3>
+ *
+ * <p>
+ * The ISO C++ standard does <b>not</b> define
+ * <code>std::atomic&lt;std::shared_ptr&lt;T&gt;&gt;</code>. This syntax is should <b>never</b> be used
+ * in production code, as it is not portable and may not compile on all platforms or with all compilers.
+ * </p>
+ *
+ * <p>
+ * Atomic access to <code>std::shared_ptr</code> is specified
+ * exclusively through free functions:
+ * </p>
+ *
+ * @code
+ * std::atomic_load(...)
+ * std::atomic_store(...)
+ * std::atomic_exchange(...)
+ * std::atomic_compare_exchange_*(...)
+ * @endcode
+ *
+ * <p>
+ * These are defined in:
+ * <br>
+ * C++20 &sect;23.11.2.6 — shared_ptr atomic access
+ * <br>
+ * As a result, std::shared_ptr can be considered an atomic handle to an immutable object
+ * when used with the appropriate atomic access functions.
+ * </p>
+ *
+ * <h3>Design Outcome</h3>
+ *
+ * <ul>
+ *   <li>The string content is permanently immutable.</li>
+ *   <li>Ownership changes are atomic at the control-block level.</li>
+ *   <li>Pointer replacement is the only state transition.</li>
+ *   <li>No intermediate mutation state is observable.</li>
+ * </ul>
+ *
+ * <p>
+ * <code>jh::atomic_str_ptr</code> therefore represents a strongly safe,
+ * immutable runtime string handle suitable for concurrent systems.
+ * </p>
+ */
+
+/**
+ * @page ImmutableStr_Observe_Pool
+ *
+ * @brief Deduplication using <code>jh::observe_pool&lt;jh::immutable_str&gt;</code>.
+ *
+ * <p>
+ * The JH Toolkit provides <code>jh::observe_pool&lt;T&gt;</code> as a
+ * structural deduplication facility.
+ * </p>
+ *
+ * <p>
+ * When used with <code>jh::immutable_str</code>, identical string content
+ * will map to a single shared immutable instance.
+ * </p>
+ *
+ * <p>
+ * The pool exposes:
+ * </p>
+ *
+ * @code
+ * acquire(Args&&...)
+ * @endcode
+ *
+ * <p>
+ * The argument list matches the constructor of <code>T</code>.
+ * The return type is:
+ * </p>
+ *
+ * @code
+ * std::shared_ptr<T>
+ * @endcode
+ *
+ * <p>
+ * For <code>jh::immutable_str</code>, no additional include is required.
+ * The pool integration is bundled as a companion facility.
+ * </p>
+ *
+ * <h3>Behavior</h3>
+ *
+ * <ul>
+ *   <li>Regular construction of identical strings produces distinct instances.</li>
+ *   <li>Pool-based acquisition deduplicates by content.</li>
+ *   <li><code>.c_str()</code> addresses become identical for equal content.</li>
+ * </ul>
+ *
+ * <h3>Platform Note (Windows)</h3>
+ *
+ * <p>
+ * On Windows, especially when using MinGW toolchains with MSVCRT/UCRT,
+ * subtle runtime visibility gaps may appear under high contention.
+ * </p>
+ *
+ * <p>
+ * Since <code>observe_pool::acquire()</code> is relatively heavy,
+ * this effect can become amplified in high-thread-count scenarios.
+ * </p>
+ *
+ * <p>
+ * Recommendation:
+ * </p>
+ *
+ * <ul>
+ *   <li>Prefer single-threaded or low-thread-count usage on Windows.</li>
+ *   <li>Avoid extreme contention patterns.</li>
+ * </ul>
+ *
+ * <p>
+ * See also: <code>jh::observe_pool</code> documentation.
+ * </p>
+ */
+
+#include <memory>
+#include <cstdint>
+
+namespace example {
+
+    void example_observe_pool() {
+
+        std::cout << "\n===== observe_pool<immutable_str> demo =====\n\n";
+
+        // Regular factory construction (no deduplication)
+        auto a1 = jh::make_atomic("DedupTest");
+        auto a2 = jh::make_atomic("DedupTest");
+
+        std::cout << "[Regular construction]\n";
+        std::cout << "a1 address: "
+                  << reinterpret_cast<std::uintptr_t>(
+                          std::to_address(a1->c_str()))
+                  << "\n";
+        std::cout << "a2 address: "
+                  << reinterpret_cast<std::uintptr_t>(
+                          std::to_address(a2->c_str()))
+                  << "\n";
+
+        std::cout << "Same address? "
+                  << (a1->c_str() == a2->c_str() ? "true" : "false")
+                  << "\n\n";
+
+        // reinterpret_cast<std::uintptr_t>(std::to_address(ptr)) is the only
+        // recommended way to print the actual memory address of the string content,
+        // as the pointer itself is not guaranteed to be stable or meaningful across different instances.
+        // static_cast<const void*>(ptr) is not recommended as it may
+        // not compile or may not provide the intended address representation, which is an antipattern in C++20
+
+        // Pool-based acquisition (deduplicated)
+        jh::observe_pool<jh::immutable_str> pool;
+
+        auto p1 = pool.acquire("DedupTest");
+        auto p2 = pool.acquire("DedupTest");
+
+        std::cout << "[observe_pool acquisition]\n";
+        std::cout << "p1 address: "
+                  << reinterpret_cast<std::uintptr_t>(
+                          std::to_address(p1->c_str()))
+                  << "\n";
+        std::cout << "p2 address: "
+                  << reinterpret_cast<std::uintptr_t>(
+                          std::to_address(p2->c_str()))
+                  << "\n";
+
+        std::cout << "Same address? "
+                  << (p1->c_str() == p2->c_str() ? "true" : "false")
+                  << "\n\n";
+
+        std::cout << "use_count p1: " << p1.use_count() << "\n";
+        std::cout << "use_count p2: " << p2.use_count() << "\n";
+
+        std::cout << "\n===== end observe_pool demo =====\n";
+    }
+
+}
+
+/**
+ * @page ImmutableStr_Hash_Equality
+ *
+ * @brief Transparent hashing and equality for <code>atomic_str_ptr</code>.
+ *
+ * <p>
+ * The JH Toolkit provides:
+ * </p>
+ *
+ * <ul>
+ *   <li><code>jh::atomic_str_hash</code></li>
+ *   <li><code>jh::atomic_str_eq</code></li>
+ * </ul>
+ *
+ * <p>
+ * These functors enable content-based comparison of
+ * <code>jh::atomic_str_ptr</code> inside unordered containers.
+ * </p>
+ *
+ * <h3>Key Properties</h3>
+ *
+ * <ul>
+ *   <li>Hash is derived from string content, not pointer address.</li>
+ *   <li>Equality compares underlying string values.</li>
+ *   <li>Supports heterogeneous lookup with <code>const char*</code>
+ *       and string literals.</li>
+ *   <li>Respects <code>JH_IMMUTABLE_STR_AUTO_TRIM</code> at compile time.</li>
+ *   <li>Uses <code>is_transparent</code> to enable
+ *       <code>find(lit)</code> where <code>lit</code> is a string literal predefined as <code>const char*</code>.</li>
+ * </ul>
+ *
+ * @section ImmutableStr_Windows_Concurrency Windows Concurrency Note
+ *
+ * <p>
+ * When using <code>jh::atomic_str_hash</code>,
+ * <code>jh::atomic_str_eq</code>, or
+ * <code>jh::observe_pool&lt;jh::immutable_str&gt;</code>
+ * under Windows, additional care is recommended.
+ * </p>
+ *
+ * <h3>Background</h3>
+ *
+ * <ul>
+ *   <li><code>std::shared_ptr</code> maintains an internal atomic
+ *       reference-count control block.</li>
+ *   <li>Container-level synchronization (external mutexes) does not
+ *       guarantee ordering alignment with that internal atomic state.</li>
+ *   <li>On Windows, particularly when using MinGW toolchains in
+ *       combination with MSVCRT or UCRT, subtle visibility gaps
+ *       may appear under heavy contention.</li>
+ *   <li>Operations such as <code>observe_pool::acquire()</code>,
+ *       content-based hashing, and heterogeneous equality comparison
+ *       are relatively heavy and can amplify this behavior.</li>
+ * </ul>
+ *
+ * <h3>Recommendation</h3>
+ *
+ * <ul>
+ *   <li>Prefer single-threaded usage on Windows when practical.</li>
+ *   <li>If multi-threaded, keep thread counts modest.</li>
+ *   <li>Avoid extreme high-frequency concurrent insertion and lookup patterns.</li>
+ *   <li>Reduce contention pressure where possible.</li>
+ * </ul>
+ *
+ * <p>
+ * This note does not imply undefined behavior in standard-conforming
+ * environments. Rather, it reflects practical engineering experience
+ * with Windows runtime/toolchain interactions under stress conditions.
+ * </p>
+ *
+ * <p>
+ * See also: <code>jh::observe_pool</code> documentation.
+ * </p>
+ */
+
+namespace example {
+
+    void example_hash_and_equality() {
+
+        std::cout << "\n===== atomic_str_hash / atomic_str_eq demo =====\n\n";
+
+        using Map = std::unordered_map<
+                jh::atomic_str_ptr,
+                int,
+                jh::atomic_str_hash,
+                jh::atomic_str_eq>;
+
+        Map registry;
+
+        registry[jh::make_atomic("alpha")] = 1;
+        registry[jh::make_atomic("beta")] = 2;
+
+        auto alpha = "alpha";
+        // cannot write the literal directly in find() because it would not be decayed
+        // to const char* and would not match the heterogeneous lookup, so we need to assign
+        // it to a variable of type const char* first
+
+        // Heterogeneous lookup using string literal
+        if (registry.find(alpha) != registry.end()) {
+            std::cout << "Found 'alpha'\n";
+        }
+
+        // Lookup using const char* (explicitly declared type)
+        const char *key = "beta";
+        auto it = registry.find(key);
+        if (it != registry.end()) {
+            std::cout << "Found '" << key
+                      << "' with value = " << it->second << "\n";
+        }
+
+        // Whitespace-trimmed comparison (if auto_trim = true)
+        if (registry.contains(static_cast<const char*>("  alpha  "))) {
+            std::cout << "Whitespace-trimmed lookup works\n";
+        }
+
+        // using registry.find("  alpha  ") or registry.contains("  alpha  ") directly would not work
+        // because the literal would not be decayed to const char* and would not match the heterogeneous lookup,
+        // so we need to assign it to a variable of type const char* first
+
+        std::cout << "\n===== end hash / equality demo =====\n";
+    }
+}
+
+/**
+ * @page ImmutableStr_Interface
+ *
+ * @brief Access interfaces of <code>jh::immutable_str</code>.
+ *
+ * <p>
+ * <code>jh::immutable_str</code> exposes read-only accessors that
+ * provide different levels of interoperability.
+ * </p>
+ *
+ * <h3>Available Accessors</h3>
+ *
+ * <ul>
+ *   <li><code>c_str()</code> — returns internal <code>const char*</code>.</li>
+ *   <li><code>str()</code> — returns a copied <code>std::string</code>.</li>
+ *   <li><code>view()</code> — returns <code>std::string_view</code>.</li>
+ *   <li><code>pod_view()</code> — returns <code>jh::pod::string_view</code>.</li>
+ * </ul>
+ *
+ * <h3>Semantics</h3>
+ *
+ * <ul>
+ *   <li><code>c_str()</code> exposes the internal immutable buffer.
+ *       The memory must not be modified.</li>
+ *   <li><code>str()</code> creates an owning copy suitable for
+ *       full string manipulation.</li>
+ *   <li><code>view()</code> provides zero-copy interoperability
+ *       with the standard library.</li>
+ *   <li><code>pod_view()</code> provides a lightweight POD-compatible
+ *       string view abstraction.</li>
+ * </ul>
+ *
+ * <h3>Printing Behavior</h3>
+ *
+ * <ul>
+ *   <li>If only <code>&lt;jh/immutable_str&gt;</code> is included,
+ *       <code>jh::pod::string_view</code> does not provide stream output.</li>
+ *
+ *   <li>If <code>&lt;jh/pod&gt;</code> is additionally included,
+ *       debug-print support is enabled.</li>
+ *
+ *   <li>Debug print format is intentionally distinct:
+ *       <code>string_view"..."</code></li>
+ *
+ *   <li>This differs from <code>std::string_view</code> output and is
+ *       designed to make debugging explicit.</li>
+ *
+ *   <li>For normal string printing, use:
+ *       <code>imm.pod_view().to_std()</code> or <code>imm.view()</code>.</li>
+ * </ul>
+ *
+ * <h3>Design Principle</h3>
+ *
+ * <p>
+ * <code>jh::immutable_str</code> does not provide substring extraction,
+ * concatenation, mutation, or any transformation APIs.
+ * </p>
+ *
+ * <p>
+ * It models a semantically immutable unit of meaningful text.
+ * </p>
+ *
+ * <p>
+ * If string manipulation is required, obtain:
+ * </p>
+ *
+ * <ul>
+ *   <li>A <code>std::string_view</code> via <code>view()</code>, or</li>
+ *   <li>A copied <code>std::string</code> via <code>str()</code>.</li>
+ * </ul>
+ *
+ * <p>
+ * All transformation logic should occur outside the immutable abstraction.
+ * </p>
+ */
+
+namespace example {
+
+    void example_interface_access() {
+
+        std::cout << "\n===== immutable_str interface demo =====\n\n";
+
+        jh::immutable_str imm("InterfaceExample");
+
+        // 1. c_str()
+        const char* raw = imm.c_str();
+        std::cout << "c_str(): " << raw << "\n";
+        // using const_cast on raw is UB, the underlying memory is truly immutable and must not be modified.
+
+        // 2. view()
+        std::string_view sv = imm.view();
+        std::cout << "view(): " << sv << "\n";
+
+        // 3. str() — copy
+        std::string copied = imm.str();
+        copied += "_modified";
+        std::cout << "str() copy modified: " << copied << "\n";
+        std::cout << "Original immutable_str after copy modification: " << imm.view() << "\n";
+        // unmodified, demonstrating immutability
+
+        // 4. pod_view()
+        auto psv = imm.pod_view();
+
+        // Debug printing requires <jh/pod>
+        std::cout << "pod_view(): " << psv << "\n";
+
+        // Normal printing equivalent to view()
+        std::cout << "pod_view().to_std(): "
+                  << psv.to_std() << "\n";
+
+        std::cout << "\n===== end interface demo =====\n";
+    }
+
+} // namespace example
+/**
  * @brief Main entry point to run all examples.
  */
 int main() {
-    example::basic_usage();
-    example::hashing_and_comparison();
-    example::auto_trim_behavior();
-    example::hash_container_usage();
-    example::safe_construct();
-    example::pooling();
-    example::immutable_str_matching();
+    // Compile-time verification of trimming policy.
+    //
+    // This static assertion ensures that the translation unit is compiled
+    // with the expected JH_IMMUTABLE_STR_AUTO_TRIM configuration.
+    //
+    // In large industrial codebases, macro values may be overridden
+    // unintentionally via build flags or transitive includes.
+    // By asserting against immutable_str::auto_trim, we guarantee that
+    // the effective compile-time policy matches the intended value.
+    //
+    // If the macro is incorrectly defined (or inconsistently defined across
+    // translation units), compilation will fail immediately.
+    //
+    // This prevents subtle runtime inconsistencies in hash/equality behavior
+    // and ensures deterministic trimming semantics across the program.
+    static_assert(jh::immutable_str::auto_trim == true); // or false, depending on the intended configuration
+    example::example_basic_immutable_str();
+    example::example_string_view_initialization();
+    example::example_shared_factories();
+    example::example_observe_pool();
+    example::example_hash_and_equality();
+    example::example_interface_access();
     return 0;
 }

--- a/examples/example_ordered_map.cpp
+++ b/examples/example_ordered_map.cpp
@@ -1,0 +1,941 @@
+/**
+ * @file example_ordered_map.cpp
+ * @brief Example demonstrating the usage of <code>jh/ordered_map</code> and <code>jh/ordered_set</code>.
+ *
+ * <p>
+ * This file demonstrates how to use <code>jh/ordered_map</code> and <code>jh/ordered_set</code>
+ * and serves as a reference example for both developers and AI systems
+ * learning how to use this library.
+ * </p>
+ *
+ * <p>
+ * The canonical include form is:
+ * </p>
+ *
+ * @code
+ * #include &lt;jh/ordered_map&gt;
+ * @endcode
+ *
+ * <p>
+ * All symbols used in this example are exported under the
+ * <code>jh::</code> namespace.
+ * </p>
+ *
+ * <p>
+ * For complete API documentation, refer to
+ * <code>jh/core/ordered_map.h</code>. The Doxygen comments in that
+ * header define the official semantics of the component.
+ * </p>
+ *
+ * <p>
+ * <code>jh::ordered_map</code> and <code>jh::ordered_set</code> are ordered associative containers
+ * implemented as a contiguous AVL tree. They address several issues with standard containers:
+ * </p>
+ *
+ * <ul>
+ *   <li><code>std::unordered_*</code> series have high bucket overhead and hash collision costs</li>
+ *   <li><code>std::map</code>/<code>std::set</code> have high fragmentation and poor cache locality</li>
+ * </ul>
+ *
+ * <p>
+ * The design provides:
+ * </p>
+ *
+ * <ul>
+ *   <li>Contiguous storage in a single <code>std::vector</code></li>
+ *   <li>Index-based tree links instead of pointers</li>
+ *   <li>Cache-friendly traversal</li>
+ *   <li>O(1) <code>clear()</code> under PMR</li>
+ *   <li>Fast bulk construction from sorted data</li>
+ * </ul>
+ *
+ * <p>
+ * This example focuses on practical usage patterns, including:
+ * <ul>
+ *   <li>Basic operations (insert, find, erase)</li>
+ *   <li>Range operations (lower_bound, upper_bound, equal_range)</li>
+ *   <li>Bulk construction from sorted data</li>
+ *   <li>Hash-based lookup optimization</li>
+ *   <li>Integration with PMR allocators</li>
+ * </ul>
+ * </p>
+ *
+ * <p>
+ * <b>Key Type Considerations:</b>
+ * </p>
+ *
+ * <p>
+ * It is recommended to avoid using heavy types as keys. The implementation is not fully transparent
+ * for xvalues or prvalues, which can lead to unspecified behavior
+ * with <code>operator&lt;</code>. This means temporary copies may be created during comparisons.
+ * </p>
+ *
+ * <p>
+ * Types like <code>std::string</code> are generally acceptable, but excessively heavy key types
+ * should be avoided to maintain performance.
+ * </p>
+ */
+
+#include <jh/ordered_map>
+#include "ensure_output.h"
+
+#if IS_WINDOWS
+static EnsureOutput ensure_output_setup;
+#endif
+
+/**
+ * @page OrderedMap_Basic_Usage Basic Usage Patterns
+ *
+ * <h3>Overview</h3>
+ *
+ * This section demonstrates basic operations with <code>jh::ordered_map</code> and <code>jh::ordered_set</code>.
+ *
+ * <h3>Key Operations</h3>
+ *
+ * <ul>
+ *   <li>Insertion</li>
+ *   <li>Lookup</li>
+ *   <li>Erasure</li>
+ *   <li>Iteration</li>
+ * </ul>
+ *
+ * <h3>Important Notes</h3>
+ *
+ * <ul>
+ *   <li>All iterators are invalidated on erase</li>
+ *   <li>Insertions may also relocate nodes</li>
+ *   <li>Iterators are index-based, not pointer-based</li>
+ * </ul>
+ */
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <algorithm>
+
+namespace example {
+
+    void example_basic_operations() {
+        std::cout << "\n===== Basic ordered_map operations =====\n\n";
+
+        // Create an ordered_map
+        jh::ordered_map<std::string, int> map{};
+
+        // Insert elements using emplace for key-value pairs
+        map.emplace("apple", 3);
+        map.emplace("banana", 7);
+        map.emplace("cherry", 5);
+        map.emplace("date", 11);
+
+        std::cout << "Map size: " << map.size() << "\n";
+
+        // Lookup
+        auto it = map.find(std::string("banana"));
+        if (it != map.end()) {
+            std::cout << "Found banana: " << it->second << "\n";
+        }
+
+        // Iteration
+        std::cout << "All elements:\n";
+        for (const auto &[key, value]: map) {
+            std::cout << key << " \u2192 " << value << "\n";
+        }
+
+        // Erase
+        map.erase("cherry");
+        std::cout << "\nAfter erasing cherry:\n";
+        for (const auto &[key, value]: map) {
+            std::cout << key << " \u2192 " << value << "\n";
+        }
+
+        // Element access with operator[]
+        map["elderberry"] = 13;
+        std::cout << "\nAfter adding elderberry:\n";
+        for (const auto &[key, value]: map) {
+            std::cout << key << " \u2192 " << value << "\n";
+        }
+
+        std::cout << "\n===== end basic operations =====\n";
+    }
+
+    void example_range_operations() {
+        std::cout << "\n===== Range operations (lower_bound, upper_bound, equal_range) =====\n\n";
+
+        // Create an ordered_map
+        jh::ordered_map<std::string, int> map;
+
+        // Insert elements
+        map.emplace("apple", 3);
+        map.emplace("banana", 7);
+        map.emplace("cherry", 5);
+        map.emplace("date", 11);
+
+        // example of how to do piecewise_construct
+        map.emplace(
+                std::piecewise_construct,
+                std::forward_as_tuple("elderberry"),
+                std::forward_as_tuple(13)
+        );
+
+        // lower_bound - first element >= key
+        auto lower = map.lower_bound("cherry");
+        if (lower != map.end()) {
+            std::cout << "lower_bound(\"cherry\"): " << lower->first << " \u2192 " << lower->second << "\n";
+        }
+
+        // upper_bound - first element > key
+        auto upper = map.upper_bound("cherry");
+        if (upper != map.end()) {
+            std::cout << "upper_bound(\"cherry\"): " << upper->first << " \u2192 " << upper->second << "\n";
+        }
+
+        // equal_range - [lower_bound, upper_bound)
+        auto range = map.equal_range("cherry");
+        std::cout << "equal_range(\"cherry\"): ";
+        for (auto it = range.first; it != range.second; ++it) {
+            std::cout << it->first << " \u2192 " << it->second << " ";
+        }
+        std::cout << "\n";
+
+        // Note: For ordered_map, equal_range typically contains at most one element
+        // since keys are unique, but it's still a required interface for associative containers
+
+        // Demonstrate with a key that doesn't exist
+        auto range_nonexistent = map.equal_range("grape");
+        std::cout << "equal_range(\"grape\"): ";
+        if (range_nonexistent.first == range_nonexistent.second) {
+            std::cout << "empty range";
+        }
+        std::cout << "\n";
+
+        std::cout << "\n===== end range operations =====\n";
+    }
+
+    void example_insert_variants() {
+        std::cout << "\n===== Insert variants =====\n\n";
+
+        // Create an ordered_map
+        jh::ordered_map<std::string, int> map;
+
+        // 1. emplace - for separate key and value
+        map.emplace("apple", 3);
+        std::cout << "After emplace(\"apple\", 3): size = " << map.size() << "\n";
+
+        // 2. insert - for std::pair
+        std::pair<std::string, int> banana_pair("banana", 7);
+        map.insert(banana_pair);
+        std::cout << "After insert(std::pair): size = " << map.size() << "\n";
+
+        // 3. insert - for std::tuple
+        auto cherry_tuple = std::make_tuple(std::string{"cherry"}, 5);
+        map.insert(cherry_tuple);
+        std::cout << "After insert(std::tuple): size = " << map.size() << "\n";
+
+        // 4. insert_or_assign
+        auto [it, inserted] = map.insert_or_assign(std::string{"date"}, 11);
+        std::cout << "After insert_or_assign(\"date\", 11): inserted = " << (inserted ? "true" : "false") << "\n";
+
+        // Insert_or_assign on existing key
+        auto [it2, inserted2] = map.insert_or_assign(std::string{"apple"}, 10);
+        std::cout << "After insert_or_assign(\"apple\", 10): inserted = " << (inserted2 ? "true" : "false")
+                  << ", new value = " << it2->second << "\n";
+
+        // Display all elements
+        std::cout << "\nAll elements:\n";
+        for (const auto &[key, value]: map) {
+            std::cout << key << " \u2192 " << value << "\n";
+        }
+
+        std::cout << "\n===== end insert variants =====\n";
+    }
+}
+
+
+/**
+ * @page OrderedMap_Insert_Semantics Insert / Emplace / Insert-Or-Assign Semantics
+ *
+ * <h3>Overview</h3>
+ *
+ * This section explains the construction and type-matching rules for
+ * <code>emplace</code>, <code>insert</code>, and <code>insert_or_assign</code>
+ * in <code>jh::ordered_map</code>.
+ *
+ * <h3>emplace</h3>
+ *
+ * <p>
+ * <code>emplace</code> constructs a <code>std::pair&lt;Key, Value&gt;</code>
+ * directly from the provided arguments. Its behavior follows the constructors
+ * of <code>std::pair</code>.
+ * </p>
+ *
+ * <ul>
+ *   <li>Accepts any arguments that can be used to construct <code>Key</code> and <code>Value</code></li>
+ *   <li>Allows implicit conversions (e.g. <code>const char*</code> &rarr; <code>std::string</code>)</li>
+ *   <li>Supports <code>std::piecewise_construct</code> for separate construction of key and value</li>
+ * </ul>
+ *
+ * <p>
+ * Therefore, passing types that are not exactly <code>Key</code> or <code>Value</code>,
+ * but are constructible into them, is valid.
+ * </p>
+ *
+ * <h3>insert</h3>
+ *
+ * <p>
+ * <code>insert</code> accepts a "pair-like" object whose element types must match
+ * <code>Key</code> and <code>Value</code> <b>exactly</b> after removing cv-ref qualifiers.
+ * </p>
+ *
+ * <ul>
+ *   <li>Accepts <code>std::pair&lt;Key, Value&gt;</code></li>
+ *   <li>Accepts <code>std::tuple&lt;Key, Value&gt;</code></li>
+ *   <li>Accepts custom types with tuple-like bindings (<code>std::tuple_size</code>, <code>get&lt;I&gt;</code>)</li>
+ * </ul>
+ *
+ * <p>
+ * Unlike <code>emplace</code>, <code>insert</code> does <b>not</b> perform type construction.
+ * The types must already match exactly.
+ * </p>
+ *
+ * <p>
+ * Example:
+ * </p>
+ *
+ * <ul>
+ *   <li><code>std::pair&lt;std::string, int&gt;</code> &rarr; valid</li>
+ *   <li><code>std::pair&lt;const char*, int&gt;</code> &rarr; <b>invalid</b> for <code>ordered_map&lt;std::string, int&gt;</code></li>
+ * </ul>
+ *
+ * <h3>insert_or_assign</h3>
+ *
+ * <p>
+ * <code>insert_or_assign</code> requires the key and value to be of type
+ * <code>Key</code> and <code>Value</code> respectively.
+ * </p>
+ *
+ * <ul>
+ *   <li>Supports all value categories of <code>Key</code> and <code>Value</code>:
+ *     <ul>
+ *       <li>lvalue (mutable reference)</li>
+ *       <li>const lvalue (const reference)</li>
+ *       <li>xvalue (temporary moved object)</li>
+ *       <li>rvalue (pure temporary)</li>
+ *     </ul>
+ *   </li>
+ *   <li>Does <b>not</b> perform implicit construction</li>
+ * </ul>
+ *
+ * <p>
+ * Therefore, arguments must already be of type <code>Key</code> and <code>Value</code>.
+ * For example:
+ * </p>
+ *
+ * <ul>
+ *   <li><code>std::string</code> &rarr; valid</li>
+ *   <li><code>const char*</code> &rarr; <b>invalid</b> when <code>Key = std::string</code></li>
+ * </ul>
+ *
+ * <h3>Summary</h3>
+ *
+ * <ul>
+ *   <li><code>emplace</code>: most flexible, constructs in-place</li>
+ *   <li><code>insert</code>: requires exact type match (pair-like)</li>
+ *   <li><code>insert_or_assign</code>: requires exact <code>Key</code>/<code>Value</code> types</li>
+ * </ul>
+ */
+
+// Example of a custom pair-like type that can be inserted
+namespace example::simulated {
+    struct Product {
+        std::string name;
+        int price;
+    };
+
+    template<std::size_t I>
+    decltype(auto) get(Product &p) {
+        static_assert(I < 2);
+        if constexpr (I == 0) return (p.name);
+        else return (p.price);
+    }
+
+    template<std::size_t I>
+    decltype(auto) get(const Product &p) {
+        static_assert(I < 2);
+        if constexpr (I == 0) return (p.name);
+        else return (p.price);
+    }
+
+    template<std::size_t I>
+    decltype(auto) get(Product &&p) {
+        static_assert(I < 2);
+        if constexpr (I == 0) return std::move(p.name);
+        else return std::move(p.price);
+    }
+}
+// Specialize tuple traits for custom::Product
+namespace std {
+    template<>
+    struct tuple_size<example::simulated::Product> : std::integral_constant<std::size_t, 2> {
+    };
+
+    template<>
+    struct tuple_element<0, example::simulated::Product> {
+        using type = std::string;
+    };
+
+    template<>
+    struct tuple_element<1, example::simulated::Product> {
+        using type = int;
+    };
+}
+namespace example {
+
+    void example_custom_pair_like() {
+        std::cout << "\n===== Custom pair-like type insertion =====\n\n";
+
+        // Create an ordered_map
+        jh::ordered_map<std::string, int> map;
+
+        // Create custom pair-like objects
+        simulated::Product apple{"apple", 3};
+        simulated::Product banana{"banana", 7};
+
+        // Insert custom pair-like objects
+        map.insert(apple);
+        map.insert(banana);
+
+        // Display all elements
+        std::cout << "All elements from custom pair-like objects:\n";
+        for (const auto &[key, value]: map) {
+            std::cout << key << " \u2192 " << value << "\n";
+        }
+
+        std::cout << "\n===== end custom pair-like insertion =====\n";
+    }
+
+    void example_ordered_set() {
+        std::cout << "\n===== Basic ordered_set operations =====\n\n";
+
+        // Create an ordered_set
+        jh::ordered_set<int> set;
+
+        // Insert elements
+        set.insert(5);
+        set.insert(2);
+        set.insert(8);
+        set.insert(1);
+        set.insert(9);
+
+        // Lookup
+        auto it = set.find(8);
+        if (it != set.end()) {
+            std::cout << "Found 8 in set\n";
+        }
+
+        // Iteration (sorted order)
+        std::cout << "All elements (sorted):\n";
+        for (int value: set) {
+            std::cout << value << " ";
+        }
+        std::cout << "\n";
+
+        // Erase
+        set.erase(5);
+        std::cout << "After erasing 5:\n";
+        for (int value: set) {
+            std::cout << value << " ";
+        }
+        std::cout << "\n";
+
+        std::cout << "\n===== end ordered_set operations =====\n";
+    }
+
+}
+
+/**
+ * @page OrderedMap_From_Sorted Bulk Construction from Sorted Data
+ *
+ * <h3>Overview</h3>
+ *
+ * This section demonstrates the <code>from_sorted</code> method for bulk construction
+ * from pre-sorted data. This method provides O(N) construction time with no rotations.
+ *
+ * <h3>Benefits</h3>
+ *
+ * <ul>
+ *   <li>Perfect AVL shape</li>
+ *   <li>No rotations</li>
+ *   <li>Near O(N) construction</li>
+ *   <li>Best possible iteration locality</li>
+ * </ul>
+ *
+ * <h3>Recommended Pipeline</h3>
+ *
+ * @code
+ * std::stable_sort(v.begin(), v.end());
+ * v.erase(std::unique(v.begin(), v.end()), v.end());
+ * auto m = jh::ordered_map&lt;K,V&gt;::from_sorted(v);
+ * @endcode
+ */
+
+namespace example {
+
+    void example_from_sorted() {
+        std::cout << "\n===== from_sorted construction =====\n\n";
+
+        // Create and populate a vector
+        std::vector<std::pair<std::string, int>> data = {
+                {"apple",      3},
+                {"banana",     7},
+                {"cherry",     5},
+                {"date",       11},
+                {"elderberry", 13},
+                {"fig",        17}
+        };
+
+        // Sort and deduplicate
+        std::stable_sort(data.begin(), data.end());
+        data.erase(std::unique(data.begin(), data.end()), data.end());
+
+        // Construct from sorted data
+        auto map = jh::ordered_map<std::string, int>::from_sorted(data);
+
+        // Verify the result
+        std::cout << "Constructed from sorted data:\n";
+        for (const auto &[key, value]: map) {
+            std::cout << key << " \u2192 " << value << "\n";
+        }
+
+        std::cout << "\n===== end from_sorted construction =====\n";
+    }
+
+}
+
+/**
+ * @page OrderedMap_Hash_Optimization Hash-Based Lookup Optimization
+ *
+ * <h3>Overview</h3>
+ *
+ * This section demonstrates how to use <code>jh::ordered_set</code> with full hash values
+ * to create a more efficient hash table alternative.
+ *
+ * <h3>Motivation</h3>
+ *
+ * <ul>
+ *   <li><code>std::unordered_map</code> has high bucket overhead</li>
+ *   <li>Hash collisions can lead to poor performance</li>
+ *   <li><code>jh::ordered_set</code> provides O(log N) lookup with better cache locality</li>
+ * </ul>
+ *
+ * <h3>Implementation</h3>
+ *
+ * By storing entries as <code>{full_hash, key, value}</code> in an <code>ordered_set</code>,
+ * we can perform efficient hash-based lookup using <code>lower_bound</code>.
+ */
+
+#include <memory>
+
+namespace example {
+
+    // Entry structure for hash-based lookup
+    struct HashEntry {
+        std::size_t hash;
+        std::string key;
+        std::shared_ptr<int> value;
+
+        // Comparison operator for ordered_set
+        bool operator<(const HashEntry &other) const {
+            if (hash != other.hash) {
+                return hash < other.hash;
+            }
+            return key < other.key;
+        }
+    };
+
+    void example_hash_optimization() {
+        std::cout << "\n===== Hash-based lookup optimization =====\n\n";
+
+        // Create ordered_set for hash-based lookup
+        jh::ordered_set<HashEntry> hash_set;
+
+        // Helper function to create hash entry
+        auto make_entry = [](const std::string &key, int value) {
+            return HashEntry{std::hash<std::string>{}(key), key,
+                             std::make_shared<int>(value)};
+        };
+
+        // Insert entries
+        hash_set.insert(make_entry("apple", 3));
+        hash_set.insert(make_entry("banana", 7));
+        hash_set.insert(make_entry("cherry", 5));
+        hash_set.insert(make_entry("date", 11));
+
+        // Lookup function
+        auto lookup = [&](const std::string &key) -> std::shared_ptr<int> {
+            std::size_t hash = std::hash<std::string>{}(key);
+            HashEntry probe{hash, key, nullptr};
+
+            auto it = hash_set.lower_bound(probe);
+            if (it != hash_set.end() && it->hash == hash && it->key == key) {
+                return it->value;
+            }
+            return nullptr;
+        };
+
+        // Test lookup
+        std::vector<std::string> keys = {"banana", "cherry", "grape"};
+        for (const auto &key: keys) {
+            auto value = lookup(key);
+            if (value) {
+                std::cout << "Found " << key << " \u2192 " << *value << "\n";
+            } else {
+                std::cout << "Not found: " << key << "\n";
+            }
+        }
+
+        std::cout << "\n===== end hash-based lookup =====\n";
+    }
+
+    // Alternative: {full_hash, index} to point to another container
+    void example_hash_index() {
+        std::cout << "\n===== Hash index with external storage =====\n\n";
+
+        // External storage
+        std::vector<std::pair<std::string, int>> values = {
+                {"apple",  3},
+                {"banana", 7},
+                {"cherry", 5},
+                {"date",   11}
+        };
+
+        // Hash index structure
+        struct HashIndexEntry {
+            std::size_t hash;
+            std::size_t index;
+
+            bool operator<(const HashIndexEntry &other) const {
+                return hash < other.hash;
+            }
+        };
+
+        // Create hash index
+        jh::ordered_set<HashIndexEntry> hash_index;
+
+        // Populate index
+        for (std::size_t i = 0; i < values.size(); ++i) {
+            std::size_t hash = std::hash<std::string>{}(values[i].first);
+            hash_index.insert({hash, i});
+        }
+
+        // Lookup function
+        auto lookup = [&](const std::string &key) -> std::optional<int> {
+            std::size_t hash = std::hash<std::string>{}(key);
+            HashIndexEntry probe{hash, 0};
+
+            auto it = hash_index.lower_bound(probe);
+            while (it != hash_index.end() && it->hash == hash) {
+                const auto &[stored_key, stored_value] = values[it->index];
+                if (stored_key == key) {
+                    return stored_value;
+                }
+                ++it;
+            }
+            return std::nullopt;
+        };
+
+        // Test lookup
+        std::vector<std::string> keys = {"banana", "cherry", "grape"};
+        for (const auto &key: keys) {
+            auto value = lookup(key);
+            if (value) {
+                std::cout << "Found " << key << " \u2192 " << *value << "\n";
+            } else {
+                std::cout << "Not found: " << key << "\n";
+            }
+        }
+
+        std::cout << "\n===== end hash index =====\n";
+    }
+
+}
+
+/**
+ * @page OrderedMap_PMR_Integration PMR Allocator Integration
+ *
+ * <h3>Overview</h3>
+ *
+ * This section demonstrates how <code>jh::ordered_map</code> works with PMR allocators,
+ * particularly the O(1) <code>clear()</code> behavior.
+ *
+ * <h3>Benefits with PMR</h3>
+ *
+ * <ul>
+ *   <li>O(1) <code>clear()</code> operation</li>
+ *   <li>Deterministic memory behavior</li>
+ *   <li>Reduced allocator churn</li>
+ *   <li>Better integration with arena allocators</li>
+ * </ul>
+ */
+
+#include <memory_resource>
+
+namespace example {
+
+    void example_pmr_integration() {
+        std::cout << "\n===== PMR allocator integration =====\n\n";
+
+        // Create a monotonic buffer resource
+        std::byte buffer[4096];
+        std::pmr::monotonic_buffer_resource pool(buffer, sizeof(buffer));
+
+        // Create ordered_map with PMR allocator
+        using PMRMap = jh::ordered_map<std::string, int, std::pmr::polymorphic_allocator<std::byte>>;
+        PMRMap map(&pool);
+
+        // Insert elements using emplace for key-value pairs
+        map.emplace("apple", 3);
+        map.emplace("banana", 7);
+        map.emplace("cherry", 5);
+
+        std::cout << "Initial size: " << map.size() << "\n";
+
+        // Clear the map (O(1) with PMR)
+        map.clear();
+        std::cout << "Size after clear: " << map.size() << "\n";
+
+        // Reuse the same map
+        map.emplace("date", 11);
+        map.emplace("elderberry", 13);
+
+        std::cout << "Size after reinsertion: " << map.size() << "\n";
+        for (const auto &[key, value]: map) {
+            std::cout << key << " \u2192 " << value << "\n";
+        }
+
+        std::cout << "\n===== end PMR integration =====\n";
+    }
+
+}
+
+/**
+ * @page OrderedMap_Performance_Scenarios Performance Scenarios
+ *
+ * <h3>Overview</h3>
+ *
+ * This section demonstrates performance-oriented usage patterns for <code>jh::ordered_map</code>.
+ *
+ * <h3>Recommended Patterns</h3>
+ *
+ * <ul>
+ *   <li>Bulk construction from sorted data</li>
+ *   <li>Periodic rebuild for optimal locality</li>
+ *   <li>PMR for efficient memory management</li>
+ * </ul>
+ */
+
+namespace example {
+
+    void example_performance_patterns() {
+        std::cout << "\n===== Performance patterns =====\n\n";
+
+        // Simulate data collection
+        std::vector<std::pair<std::string, int>> data;
+        data.reserve(100);
+        for (int i = 0; i < 100; ++i) {
+            data.emplace_back("key" + std::to_string(i), i);
+        }
+
+        // Sort and deduplicate
+        std::stable_sort(data.begin(), data.end());
+        data.erase(std::unique(data.begin(), data.end()), data.end());
+
+        // Build from sorted data (optimal)
+        auto map = jh::ordered_map<std::string, int>::from_sorted(data);
+        std::cout << "Built map with " << map.size() << " elements\n";
+
+        // Simulate some modifications
+        for (int i = 100; i < 110; ++i) {
+            map.emplace("key" + std::to_string(i), i);
+        }
+        std::cout << "After additions: " << map.size() << " elements\n";
+
+        // Rebuild for optimal locality
+        map = jh::ordered_map<std::string, int>::from_sorted(std::move(map));
+        std::cout << "After rebuild: " << map.size() << " elements\n";
+
+        // Demonstrate fast clear
+        map.clear();
+        std::cout << "After clear: " << map.size() << " elements\n";
+
+        std::cout << "\n===== end performance patterns =====\n";
+    }
+
+}
+
+/**
+ * @page OrderedMap_Ranges_Integration ordered_map with jh::ranges
+ *
+ * <h3>Overview</h3>
+ *
+ * This section demonstrates the recommended way to construct a
+ * <code>jh::ordered_map</code> from a <code>jh::ranges</code> pipeline.
+ *
+ * <p>
+ * The key idea is:
+ * </p>
+ *
+ * <ul>
+ *   <li>Use ranges to generate structured data (tuple / pair-like)</li>
+ *   <li>Materialize into a contiguous container (e.g. <code>std::vector</code>)</li>
+ *   <li>Sort and deduplicate</li>
+ *   <li>Construct using <code>ordered_map::from_sorted</code></li>
+ * </ul>
+ *
+ * <p>
+ * This approach provides:
+ * </p>
+ *
+ * <ul>
+ *   <li>O(N) construction time</li>
+ *   <li>Perfect AVL tree shape</li>
+ *   <li>Optimal cache locality</li>
+ * </ul>
+ *
+ * <h3>Important Note</h3>
+ *
+ * <p>
+ * It is <b>NOT recommended</b> to construct <code>ordered_map</code> using
+ * <code>jh::ranges::collect</code> or repeated insertion from a range:
+ * </p>
+ *
+ * @code
+ * // NOT recommended
+ * auto map = range | jh::ranges::collect&lt;jh::ordered_map&lt;K,V&gt;&gt;();
+ * @endcode
+ *
+ * <p>
+ * This leads to O(N log N) complexity and unnecessary AVL rotations.
+ * </p>
+ *
+ * <p>
+ * Instead, always prefer:
+ * </p>
+ *
+ * @code
+ * // Recommended pipeline
+ * auto vec = range | ... | collect&lt;std::vector&lt;std::pair&lt;K,V&gt;&gt;&gt;();
+ * std::stable_sort(...);
+ * vec.erase(std::unique(...), vec.end());
+ * auto map = jh::ordered_map&lt;K,V&gt;::from_sorted(vec);
+ * @endcode
+ *
+ * <h3>Example</h3>
+ *
+ * <p>
+ * The following example demonstrates a full pipeline:
+ * </p>
+ *
+ * <ul>
+ *   <li>enumerate + zip to combine multiple sequences</li>
+ *   <li>flatten nested tuples</li>
+ *   <li>transform into key-value pairs</li>
+ *   <li>build ordered_map efficiently</li>
+ * </ul>
+ */
+
+
+#include <jh/ranges_ext>
+#include <jh/views>
+#include <sstream>
+#include <jh/runtime_arr>
+
+namespace example {
+
+    void example_ordered_map_ranges() {
+        std::cout << "\n===== ordered_map with ranges =====\n\n";
+
+        // ------------------------------------------------------
+        // Prepare input sequences
+        // ------------------------------------------------------
+        jh::runtime_arr<int> ids(5);
+        jh::runtime_arr<std::string> names(5);
+        jh::runtime_arr<int> values(5);
+
+        for (auto [i, x]: ids | jh::ranges::views::enumerate(1))
+            x = static_cast<int>(i * 10);
+
+        for (auto [i, x]: values | jh::ranges::views::enumerate())
+            x = static_cast<int>((i + 1) * 100);
+
+        names[0] = "Alice";
+        names[1] = "Bob";
+        names[2] = "Carol";
+        names[3] = "Dave";
+        names[4] = "Eve";
+
+        // ------------------------------------------------------
+        // Step 1: Build vector from ranges pipeline
+        // ------------------------------------------------------
+        auto vec =
+                ids
+                | jh::ranges::views::enumerate(100)
+                | jh::ranges::views::zip_pipe(names, values)
+                | jh::ranges::views::flatten()
+                | jh::ranges::views::transform([](auto &&t) {
+                    auto [idx, id, name, value] = t;
+                    return std::pair{
+                            id,
+                            name + ":" + std::to_string(value)
+                    };
+                })
+                | jh::ranges::collect<std::vector<std::pair<int, std::string>>>();
+
+        // ------------------------------------------------------
+        // Step 2: Sort and deduplicate
+        // ------------------------------------------------------
+        std::stable_sort(vec.begin(), vec.end(),
+                         [](const auto &a, const auto &b) {
+                             return a.first < b.first;
+                         });
+
+        vec.erase(std::unique(vec.begin(), vec.end(),
+                              [](const auto &a, const auto &b) {
+                                  return a.first == b.first;
+                              }),
+                  vec.end());
+
+        // ------------------------------------------------------
+        // Step 3: Construct ordered_map (O(N))
+        // ------------------------------------------------------
+        auto map = jh::ordered_map<int, std::string>::from_sorted(vec);
+
+        // ------------------------------------------------------
+        // Verify result
+        // ------------------------------------------------------
+        std::cout << "Constructed ordered_map:\n";
+        for (const auto &[k, v]: map) {
+            std::cout << k << " \u2192 " << v << "\n";
+        }
+
+        std::cout << "\n===== end ordered_map with ranges =====\n";
+    }
+
+} // namespace example
+
+/**
+ * @brief Main entry point to run all examples.
+ */
+int main() {
+    example::example_basic_operations();
+    example::example_ordered_set();
+    example::example_range_operations();
+    example::example_insert_variants();
+    example::example_custom_pair_like();
+    example::example_from_sorted();
+    example::example_hash_optimization();
+    example::example_hash_index();
+    example::example_pmr_integration();
+    example::example_performance_patterns();
+    example::example_ordered_map_ranges();
+    return 0;
+}

--- a/examples/example_runtime_arr.cpp
+++ b/examples/example_runtime_arr.cpp
@@ -330,7 +330,7 @@ static EnsureOutput ensure_output_setup;
  * index = r * cols + c
  * @endcode
  *
- * This mirrors NumPy’s default C-order layout.
+ * This mirrors NumPy's default C-order layout.
  *
  *
  * <h4>POD Acceleration</h4>
@@ -368,7 +368,8 @@ static EnsureOutput ensure_output_setup;
  * Here we demonstrate usage examples for <code>runtime_arr</code>.
  * Since it prohibits copying, you must perform a deep copy as follows:
  * <ul>
- *     <li>either opt for reference copy <code>auto& b = a</code></li>
+ *     <li>either construct with (<code>begin()</code>,<code>end()</code>)
+ *     iterators from an existing container,</li>
  *     <li>or use <code>jh::runtime_arr&lt;T&gt;b(a.size());</code> combined with
  *         explicit copying via <code>std::copy</code>.</li>
  * </ul>
@@ -438,11 +439,7 @@ namespace example::simulated {
         Matrix(const Matrix &other)
                 : rows_(other.rows_),
                   cols_(other.cols_),
-                  data_(other.size()) {
-            std::copy(other.raw(),
-                      other.raw() + other.size(),
-                      raw());
-        }
+                  data_(other.data_.begin(), other.data_.end()) {}
 
         Matrix &operator=(const Matrix &other) {
             if (this == &other)
@@ -666,7 +663,911 @@ namespace example {
 
 }
 
+/**
+ * @page runtime_arr_basic_usage Recommended API Usage Patterns
+ *
+ * <h3>Overview</h3>
+ *
+ * The following examples demonstrate common and recommended ways to use
+ * <code>jh::runtime_arr</code> directly as a container.
+ *
+ * These examples focus on practical usage patterns that mirror
+ * <code>std::vector</code> initialization semantics while respecting
+ * the structural immutability of <code>runtime_arr</code>.
+ *
+ * <h3>Key Differences from std::vector</h3>
+ *
+ * <ul>
+ *   <li>The size is fixed at construction.</li>
+ *   <li>Copying is intentionally disabled.</li>
+ *   <li>Moving is supported.</li>
+ *   <li>Elements remain mutable.</li>
+ * </ul>
+ *
+ * Initialization syntax is intentionally designed to feel familiar
+ * to users of <code>std::vector</code>.
+ *
+ */
+
+#include <numeric>
+
+namespace example {
+
+    void example_runtime_arr_basic_usage() {
+        std::cout << "\n===== runtime_arr basic usage =====\n\n";
+
+        /* =====================================================
+           1. Size-based construction
+           ===================================================== */
+
+        jh::runtime_arr<int> a(5);
+
+        std::cout << "size-based construction:\n";
+
+        for (std::size_t i = 0; i < a.size(); ++i)
+            a[i] = static_cast<int>(i * 10);
+
+        for (auto v: a)
+            std::cout << v << " ";
+
+        std::cout << "\n\n";
+
+
+        /* =====================================================
+           2. Initializer-list construction
+           (same syntax as std::vector)
+           ===================================================== */
+
+        jh::runtime_arr<int> b{1, 2, 3, 4, 5};
+
+        std::cout << "initializer list construction:\n";
+
+        for (auto v: b)
+            std::cout << v << " ";
+
+        std::cout << "\n\n";
+
+
+        /* =====================================================
+           3. Single-element initialization
+           ===================================================== */
+
+        jh::runtime_arr<int> single{42};
+
+        std::cout << "single element:\n";
+        std::cout << single[0] << "\n\n";
+
+
+        /* =====================================================
+           4. Construction from std::vector (move)
+           ===================================================== */
+
+        std::vector<int> vec{10, 20, 30, 40};
+
+        jh::runtime_arr<int> c(std::move(vec));
+
+        std::cout << "constructed from std::vector (move):\n";
+
+        for (auto v: c)
+            std::cout << v << " ";
+
+        std::cout << "\n\n";
+
+
+        /* =====================================================
+           5. Move conversion back to std::vector
+           ===================================================== */
+        /**
+         * <h4>Move conversion to <code>std::vector</code></h4>
+         *
+         * Because the conversion operator is declared as:
+         *
+         * @code
+         * operator std::vector<T>() &&
+         * @endcode
+         *
+         * the conversion is only available for rvalues. This enforces
+         * explicit ownership transfer and prevents accidental copying.
+         *
+         * <b>Correct usage:</b>
+         *
+         * @code
+         * jh::runtime_arr&lt;int&gt; c1{1,2,3,4,5};
+         * jh::runtime_arr&lt;int&gt; c2{1,2,3,4,5};
+         *
+         * std::vector&lt;int&gt; vec2{std::move(c1)};
+         *
+         * auto vec3 = std::vector&lt;int&gt;{std::move(c2)};
+         * @endcode
+         *
+         * <b>Incorrect usage (will not compile as intended):</b>
+         *
+         * @code
+         * jh::runtime_arr&lt;int&gt; c{1,2,3,4,5};
+         *
+         * std::vector&lt;int&gt; vec = std::move(c);
+         * // ERROR: copy-initialization does not use this conversion as intended
+         * @endcode
+         *
+         * In practice, prefer direct construction:
+         *
+         * @code
+         * std::vector&lt;int&gt; vec{std::move(c)};
+         * @endcode
+         */
+        std::vector<int> vec2{std::move(c)};
+
+        std::cout << "moved back into std::vector:\n";
+
+        for (auto v: vec2)
+            std::cout << v << " ";
+
+        std::cout << "\n\n";
+
+
+        /* =====================================================
+           6. Explicit deep copy pattern
+           ===================================================== */
+
+        jh::runtime_arr<int> src{1, 2, 3, 4, 5};
+
+        jh::runtime_arr<int> dst(src.size());
+
+        std::copy(src.begin(), src.end(), dst.begin());
+
+        std::cout << "manual deep copy:\n";
+
+        for (auto v: dst)
+            std::cout << v << " ";
+
+        std::cout << "\n\n";
+
+
+        /* =====================================================
+           7. Range algorithm compatibility
+           ===================================================== */
+
+        jh::runtime_arr<int> r{1, 2, 3, 4, 5};
+
+        int sum = std::accumulate(r.begin(), r.end(), 0);
+
+        std::cout << "sum via std::algorithm = "
+                  << sum << "\n\n";
+
+
+        /* =====================================================
+           8. POD fast initialization
+           ===================================================== */
+
+        jh::runtime_arr<int> fast(
+                1024,
+                jh::runtime_arr<int>::uninitialized
+        );
+
+        for (std::size_t i = 0; i < fast.size(); ++i)
+            fast[i] = static_cast<int>(i);
+
+        std::cout << "POD uninitialized allocation filled manually\n";
+
+        std::cout << "\n===== end runtime_arr usage =====\n";
+    }
+
+}
+
+/**
+ * @page runtime_arr_static_hash_index Static Hash Index Built from runtime_arr
+ *
+ * <h3>Overview</h3>
+ *
+ * In many real-world systems, key-value data is collected dynamically during
+ * initialization. A typical approach uses:
+ *
+ * @code
+ * std::unordered_map<K, V>
+ * @endcode
+ *
+ * However, once initialization completes the dataset often becomes immutable.
+ *
+ * At that point we may prefer:
+ *
+ * <ul>
+ *   <li>No bucket structure</li>
+ *   <li>No rehashing</li>
+ *   <li>No resizing</li>
+ *   <li>Predictable contiguous memory</li>
+ *   <li>Fast read-only lookup</li>
+ * </ul>
+ *
+ * A practical approach is to convert the hash table into a compact
+ * static lookup structure.
+ *
+ *
+ * <h3>Construction Strategy</h3>
+ *
+ * Step 1 — Move the unordered_map contents into data_,
+ * a <code>jh::runtime_arr&lt;std::pair&lt;K, V&gt;&gt;</code>:
+ *
+ * Step 2 — Build an index table containing:
+ *
+ * @code
+ * entry { full_hash_of_key, index }
+ * @endcode
+ *
+ * Step 3 — Sort the index table by `(hash, index)`:
+ *
+ * @code
+ * std::stable_sort(entries.begin(), entries.end());
+ * @endcode
+ *
+ * Step 4 — Move the sorted index into a <code>jh::runtime_arr&lt;entry&gt;</code>.
+ *
+ *
+ * <h3>Lookup Algorithm</h3>
+ *
+ * Lookup becomes:
+ *
+ * @code
+ * hash(key)
+ * ↓
+ * lower_bound(entries, (hash,0))
+ * ↓
+ * scan forward while hashes match
+ * @endcode
+ *
+ * This yields complexity:
+ *
+ * @code
+ * O(log N + k)
+ * @endcode
+ *
+ * where <code>k</code> is the number of hash collisions.
+ *
+ *
+ * <h3>Why This Can Be Faster Than std::unordered_map</h3>
+ *
+ * <ul>
+ *   <li>No bucket indirection</li>
+ *   <li>Fully contiguous memory</li>
+ *   <li>Better cache locality</li>
+ *   <li>No rehash operations</li>
+ * </ul>
+ *
+ * In many workloads (configuration tables, registries, DSL interpreters,
+ * static dictionaries) this approach performs significantly better than
+ * <code>std::unordered_map</code>.
+ */
+
+#include <unordered_map>
+#include <vector>
+#include <jh/concepts> // for jh::hash deduction
+#include <algorithm>
+#include <string>
+
+namespace example::simulated {
+
+    template<typename K, typename V>
+    class StaticHashIndex {
+
+        struct entry {
+            std::size_t hash;
+            std::size_t index;
+
+            auto operator<=>(const entry &) const noexcept = default;
+        };
+
+    public:
+        StaticHashIndex(std::unordered_map<K, V> &&map) :
+                data_{
+                        std::make_move_iterator(map.begin()),
+                        std::make_move_iterator(map.end())
+                } {
+
+            std::vector<entry> idx;
+            idx.reserve(data_.size());
+
+            std::hash<K> hasher;
+
+            for (std::size_t i = 0; i < data_.size(); ++i)
+                idx.emplace_back(hasher(data_[i].first), i);
+
+            std::stable_sort(idx.begin(), idx.end());
+
+            entries_ = jh::runtime_arr<entry>(std::move(idx));
+        }
+
+        [[nodiscard]] const V *find(const K &key) const {
+            jh::hash<K> hasher{};
+            // jh::hash is an auto-deducer that deduces hasher type for K
+            // The priority of jh::hash deduction is:
+            // std::hash<K> > hash(key) from ADL > key.hash() member function, else fails to compile
+            // This is more flexible for user-defined or third-party types that may not have
+            // std::hash specializations but do have custom hash functions available via ADL or member functions.
+            // introduced from <jh/concepts> header
+            std::size_t h = hasher(key);
+
+            entry probe{h, 0};
+
+            auto it = std::lower_bound(
+                    entries_.begin(),
+                    entries_.end(),
+                    probe
+            );
+
+            while (it != entries_.end() && it->hash == h) {
+
+                const auto &kv = data_[it->index];
+
+                if (kv.first == key)
+                    return &kv.second;
+
+                ++it;
+            }
+
+            return nullptr;
+        }
+
+    private:
+
+        jh::runtime_arr<std::pair<K, V>> data_{};
+        jh::runtime_arr<entry> entries_{};
+    };
+
+} // namespace example::simulated
+
+
+namespace example {
+
+    void example_static_hash_index_runtime_arr() {
+        using simulated::StaticHashIndex;
+
+        std::cout << "\n===== static hash index demo =====\n\n";
+
+        std::unordered_map<std::string, int> table;
+
+        table.emplace("apple", 3);
+        table.emplace("banana", 7);
+        table.emplace("pear", 5);
+        table.emplace("orange", 9);
+
+        const StaticHashIndex<std::string, int> index(std::move(table));
+
+        const std::string queries[] = {
+                "apple",
+                "pear",
+                "orange",
+                "grape"
+        };
+
+        for (const auto &key: queries) {
+
+            const int *value = index.find(key);
+
+            if (value)
+                std::cout << key << " → " << *value << "\n";
+            else
+                std::cout << key << " → (not found)\n";
+        }
+
+        std::cout << "\n===== end static hash index demo =====\n";
+    }
+
+}
+
+/**
+ * @page runtime_arr_ranges_interop Interoperability with std::ranges and std::span
+ *
+ * <h3>Overview</h3>
+ *
+ * This example demonstrates how <code>jh::runtime_arr&lt;T&gt;</code>
+ * interacts with C++20 <code>std::ranges</code> algorithms and
+ * with <code>std::span</code>.
+ *
+ * <p>
+ * The generic <code>runtime_arr&lt;T&gt;</code> is an owning fixed-size container.
+ * It is not a view and it is intentionally non-copyable.
+ * Therefore, when view-like slicing behavior is needed,
+ * the canonical bridge is:
+ * </p>
+ *
+ * @code
+ * arr.as_span()
+ * @endcode
+ *
+ * <p>
+ * which produces a lightweight non-owning <code>std::span&lt;T&gt;</code>
+ * over the same storage.
+ * </p>
+ *
+ * <h3>What This Example Shows</h3>
+ *
+ * <ul>
+ *   <li>Direct use of <code>runtime_arr&lt;T&gt;</code> with
+ *       <code>std::ranges</code> algorithms.</li>
+ *   <li>Use of <code>.as_span()</code> as a range/view bridge.</li>
+ *   <li>Use of <code>std::span::subspan()</code> for slicing.</li>
+ *   <li>Propagation of writes performed through span-based subranges.</li>
+ * </ul>
+ *
+ * <h3>Important Note</h3>
+ *
+ * <p>
+ * Since <code>runtime_arr</code> is move-only and not itself a view,
+ * many view-oriented interactions are most naturally expressed
+ * through <code>std::span</code>.
+ * In practice, <code>std::span</code> is the recommended adapter
+ * for this purpose.
+ * </p>
+ */
+
+#include <ranges>
+#include <span>
+#include <algorithm>
+
+namespace example {
+
+    void example_runtime_arr_ranges_interop() {
+        std::cout << "\n===== runtime_arr ranges interop =====\n\n";
+
+        /* =====================================================
+           1. runtime_arr as input to std::ranges algorithms
+           ===================================================== */
+
+        jh::runtime_arr<int> data{1, 2, 3, 4, 5, 6, 7, 8};
+
+        const auto even_count = std::ranges::count_if(
+                data,
+                [](int x) { return x % 2 == 0; }
+        );
+
+        std::cout << "even element count in runtime_arr = "
+                  << even_count << "\n";
+
+        const auto found = std::ranges::find(data, 5);
+
+        std::cout << "value 5 "
+                  << (found != data.end() ? "found" : "not found")
+                  << " in runtime_arr\n\n";
+
+
+        /* =====================================================
+           2. Obtain a span view from runtime_arr
+           ===================================================== */
+
+        std::span<int> whole = data.as_span();
+
+        const auto gt_four = std::ranges::count_if(
+                whole,
+                [](int x) { return x > 4; }
+        );
+
+        std::cout << "elements > 4 in span view = "
+                  << gt_four << "\n\n";
+
+
+        /* =====================================================
+           3. Slice with subspan()
+           ===================================================== */
+
+        std::span<int> middle = whole.subspan(2, 4);
+
+        std::cout << "middle subspan values: ";
+        std::ranges::for_each(middle, [](int v) {
+            std::cout << v << ' ';
+        });
+        std::cout << "\n\n";
+
+
+        /* =====================================================
+           4. Modify through subspan using std::ranges::transform
+           ===================================================== */
+
+        std::ranges::transform(
+                middle,
+                middle.begin(),
+                [](int x) { return x * 10; }
+        );
+
+        std::cout << "runtime_arr after transforming middle subspan: ";
+        std::ranges::for_each(data, [](int v) {
+            std::cout << v << ' ';
+        });
+        std::cout << "\n\n";
+
+
+        /* =====================================================
+           5. Build a filtered view from span
+           ===================================================== */
+
+        auto even_view = whole | std::views::filter([](int x) {
+            return x % 2 == 0;
+        });
+
+        std::cout << "even elements through span-based filter view: ";
+        for (int v: even_view)
+            std::cout << v << ' ';
+        std::cout << "\n\n";
+
+
+        /* =====================================================
+           6. Construct runtime_arr from an iterator range
+           ===================================================== */
+
+        std::vector<int> source{10, 20, 30, 40, 50};
+
+        jh::runtime_arr<int> copied(source.begin(), source.end());
+
+        std::cout << "copied runtime_arr values: ";
+        std::ranges::for_each(copied, [](int v) {
+            std::cout << v << ' ';
+        });
+        std::cout << "\n";
+
+        std::cout << "\n===== end ranges interop demo =====\n";
+    }
+
+}
+/**
+ * @page runtime_arr_allocator_interop Allocator Interoperability
+ *
+ * <h3>Overview</h3>
+ *
+ * <code>jh::runtime_arr&lt;T, Alloc&gt;</code> supports allocator-based
+ * construction in a manner similar to standard containers.
+ *
+ * The allocator parameter is optional.
+ * When omitted, <code>typed::monostate</code> is used internally,
+ * and memory is allocated using:
+ *
+ * <ul>
+ *   <li><code>new[]</code></li>
+ *   <li><code>delete[]</code></li>
+ * </ul>
+ *
+ * When a user allocator is supplied, <code>runtime_arr</code>
+ * resolves how to use it at compile time.
+ *
+ * The resolution rule is:
+ *
+ * <ol>
+ *   <li>If the allocator directly provides
+ *       <code>allocate(n)</code> and
+ *       <code>deallocate(ptr,n)</code>,
+ *       it is used directly.</li>
+ *
+ *   <li>If the allocator follows the STL allocator model,
+ *       <code>std::allocator_traits::rebind_alloc&lt;T&gt;</code>
+ *       is used automatically.</li>
+ * </ol>
+ *
+ * This allows seamless interoperability with
+ * standard allocator types such as:
+ *
+ * <ul>
+ *   <li><code>std::allocator</code></li>
+ *   <li><code>std::pmr::polymorphic_allocator</code></li>
+ * </ul>
+ *
+ * Unlike <code>std::vector</code>, the allocator is only used
+ * during construction because <code>runtime_arr</code> never
+ * performs reallocation or resizing.
+ *
+ * <h3>Example</h3>
+ *
+ * See:
+ *
+ * <ul>
+ *   <li><code>example::example_runtime_arr_allocator_interop()</code></li>
+ * </ul>
+ */
+
+#include <memory_resource>
+
+namespace example {
+
+    void example_runtime_arr_allocator_interop() {
+
+        std::cout << "\n===== runtime_arr allocator interop =====\n\n";
+
+        /* =====================================================
+           1. std::allocator
+           ===================================================== */
+
+        {
+            std::cout << "std::allocator example:\n";
+
+            std::allocator<int> alloc{};
+
+            jh::runtime_arr<int, std::allocator<int>>
+                    arr(6, alloc);
+
+            for (std::size_t i = 0; i < arr.size(); ++i)
+                arr[i] = static_cast<int>(i * 3);
+
+            for (auto v: arr)
+                std::cout << v << " ";
+
+            std::cout << "\n\n";
+        }
+
+
+        /* =====================================================
+           2. pmr::polymorphic_allocator
+           ===================================================== */
+
+        {
+            std::cout << "pmr::polymorphic_allocator example:\n";
+
+            std::byte buffer[1024];
+
+            std::pmr::monotonic_buffer_resource pool{
+                    buffer, sizeof(buffer)};
+
+            std::pmr::polymorphic_allocator<int> alloc{&pool};
+
+            jh::runtime_arr<int,
+                    std::pmr::polymorphic_allocator<int>>
+                    arr(8, alloc);
+
+            for (std::size_t i = 0; i < arr.size(); ++i)
+                arr[i] = static_cast<int>(i);
+
+            for (auto v: arr)
+                std::cout << v << " ";
+
+            std::cout << "\n\n";
+        }
+
+
+        /* =====================================================
+           3. vector → runtime_arr with allocator
+           ===================================================== */
+
+        {
+            std::cout << "vector → runtime_arr with allocator:\n";
+
+            std::vector<int> src{10, 20, 30, 40};
+
+            std::pmr::monotonic_buffer_resource pool{};
+
+            std::pmr::polymorphic_allocator<int> alloc{&pool};
+
+            jh::runtime_arr<int,
+                    std::pmr::polymorphic_allocator<int>>
+                    arr(std::move(src), alloc);
+
+            for (auto v: arr)
+                std::cout << v << " ";
+
+            std::cout << "\n\n";
+        }
+        /* =====================================================
+           4. iterator range + allocator construction
+           ===================================================== */
+
+        {
+            std::cout << "iterator range + allocator:\n";
+
+            std::vector<int> source{5, 10, 15, 20, 25};
+
+            std::pmr::monotonic_buffer_resource pool{};
+
+            std::pmr::polymorphic_allocator<int> alloc{&pool};
+
+            jh::runtime_arr<
+                    int,
+                    std::pmr::polymorphic_allocator<int>
+            > arr(source.begin(), source.end(), alloc);
+
+            for (auto v: arr)
+                std::cout << v << " ";
+
+            std::cout << "\n\n";
+        }
+
+        std::cout << "===== end allocator interop =====\n";
+    }
+
+}
+
+/**
+ * @page runtime_arr_bool_specialization runtime_arr<bool> Specialization
+ *
+ * <h3>Overview</h3>
+ *
+ * The type <code>jh::runtime_arr&lt;bool&gt;</code> is a specialized
+ * container that stores boolean values in a bit-packed form.
+ *
+ * Instead of allocating one byte per element, the container
+ * compresses elements into a sequence of machine words
+ * (<code>uint64_t</code>).
+ *
+ * This reduces memory usage by a factor of eight compared to
+ * a byte-based representation.
+ *
+ *
+ * <h3>Key Characteristics</h3>
+ *
+ * The bit-packed specialization differs from the generic
+ * <code>runtime_arr&lt;T&gt;</code> in several ways:
+ *
+ * <ul>
+ *   <li>Elements are stored as packed bits.</li>
+ *   <li>No <code>data()</code> function is provided.</li>
+ *   <li>The container does not model a contiguous range.</li>
+ *   <li>Iterators return proxy values rather than raw references.</li>
+ * </ul>
+ *
+ * Access to individual elements is provided through:
+ *
+ * <ul>
+ *   <li><code>set(index)</code></li>
+ *   <li><code>unset(index)</code></li>
+ *   <li><code>test(index)</code></li>
+ *   <li><code>operator[]</code></li>
+ * </ul>
+ *
+ * The underlying storage can also be inspected using:
+ *
+ * <ul>
+ *   <li><code>raw_data()</code></li>
+ *   <li><code>raw_word_count()</code></li>
+ * </ul>
+ *
+ *
+ * <h3>Flat Boolean Variant</h3>
+ *
+ * Some applications require a standard contiguous container
+ * where each element occupies one byte.
+ *
+ * This behavior can be obtained using:
+ *
+ * @code
+ * jh::runtime_arr<bool, jh::runtime_arr_helper::bool_flat_alloc>
+ * @endcode
+ *
+ * In this configuration the container behaves like a normal
+ * contiguous array and supports operations such as
+ * <code>as_span()</code>.
+ *
+ *
+ * <h3>Use Cases</h3>
+ *
+ * Bit-packed boolean arrays are commonly used in:
+ *
+ * <ul>
+ *   <li>visited-node flags in graph algorithms</li>
+ *   <li>occupancy grids</li>
+ *   <li>filter masks</li>
+ *   <li>feature flags</li>
+ * </ul>
+ *
+ *
+ * <h3>Example</h3>
+ *
+ * See:
+ *
+ * <ul>
+ *   <li><code>example::example_runtime_arr_bool()</code></li>
+ * </ul>
+ */
+
+namespace example {
+
+    void example_runtime_arr_bool() {
+
+        std::cout << "\n===== runtime_arr<bool> examples =====\n\n";
+
+        /* =====================================================
+           1. bit-packed runtime_arr<bool>  (default)
+           ===================================================== */
+
+        {
+            std::cout << "[bit-packed bool array]\n";
+
+            jh::runtime_arr<bool> bits(16);
+
+            // --- set operations ---
+            bits.set(1);
+            bits.set(3);
+            bits.set(5, true);
+
+            // --- unset ---
+            bits.unset(3);
+
+            // --- operator[] proxy ---
+            bits[7] = true;
+
+            // --- at() with bounds check ---
+            bits.at(9) = true;
+
+            // --- read values ---
+            std::cout << "values:\n";
+            for (std::uint64_t i = 0; i < bits.size(); ++i)
+                std::cout << bits.test(i) << " ";
+
+            std::cout << "\n";
+
+            // --- iterator traversal ---
+            std::cout << "iterator traversal:\n";
+            for (bool v: bits)
+                std::cout << v << " ";
+
+            std::cout << "\n";
+
+            // --- raw storage inspection ---
+            std::cout << "raw words: " << bits.raw_word_count() << "\n";
+
+            auto *raw = bits.raw_data();
+            for (std::uint64_t i = 0; i < bits.raw_word_count(); ++i)
+                std::cout << "word[" << i << "] = " << raw[i] << "\n";
+
+            // --- reset ---
+            bits.reset_all();
+
+            std::cout << "after reset_all():\n";
+            for (bool v: bits)
+                std::cout << v << " ";
+
+            std::cout << "\n\n";
+        }
+
+
+        /* =====================================================
+           2. flat bool array (no compression)
+           ===================================================== */
+
+        {
+            std::cout << "[flat bool array]\n";
+
+            using flat_bool_arr =
+                    jh::runtime_arr<
+                            bool,
+                            jh::runtime_arr_helper::bool_flat_alloc
+                    >;
+
+            flat_bool_arr arr(10);
+
+            arr[0] = true;
+            arr[3] = true;
+            arr[5] = true;
+
+            // direct span access
+            auto span = arr.as_span();
+
+            std::cout << "values:\n";
+            for (bool v: span)
+                std::cout << v << " ";
+
+            std::cout << "\n";
+
+            // modify through span
+            span[1] = true;
+
+            std::cout << "after span write:\n";
+            for (bool v: arr)
+                std::cout << v << " ";
+            std::cout << "\n";
+            // --- reset ---
+            arr.reset_all();
+
+            std::cout << "after reset_all():\n";
+            for (bool v: arr)
+                std::cout << v << " ";
+
+            std::cout << "\n\n";
+        }
+
+        std::cout << "===== end runtime_arr<bool> =====\n";
+    }
+
+}
+
 int main() {
     example::example_matrix_runtime_arr();
+    example::example_runtime_arr_basic_usage();
+    example::example_static_hash_index_runtime_arr();
+    example::example_runtime_arr_ranges_interop();
+    example::example_runtime_arr_allocator_interop();
+    example::example_runtime_arr_bool();
     return 0;
 }

--- a/examples/example_runtime_arr.cpp
+++ b/examples/example_runtime_arr.cpp
@@ -1,0 +1,672 @@
+/**
+ * @file example_runtime_arr.cpp
+ * @brief Example demonstrating the usage of <code>&lt;jh/runtime_arr&gt;</code>.
+ *
+ * <p>
+ * This file demonstrates how to use <code>&lt;jh/runtime_arr&gt;</code>
+ * and serves as a reference example for both developers and AI systems
+ * learning how to use this library.
+ * </p>
+ *
+ * <p>
+ * The canonical include form is:
+ * </p>
+ *
+ * @code
+ * #include &lt;jh/runtime_arr&gt;
+ * @endcode
+ *
+ * <p>
+ * All symbols used in this example are exported under the
+ * <code>jh::</code> namespace.
+ * </p>
+ *
+ * <p>
+ * For complete API documentation, refer to
+ * <code>jh/core/runtime_arr.h</code>. The Doxygen comments in that
+ * header define the official semantics of the component.
+ * </p>
+ *
+ *
+ * <h3>Historical Background and Practical Motivation</h3>
+ *
+ * <p>
+ * The design of <code>jh::runtime_arr</code> originated from
+ * real-world attempts to migrate Python-based numerical and
+ * data-processing systems into modern C++20.
+ * </p>
+ *
+ * <p>
+ * In Python (for example, using NumPy), arrays are typically:
+ * </p>
+ *
+ * <ul>
+ *   <li>Allocated with a fixed shape at initialization time.</li>
+ *   <li>Contiguously stored.</li>
+ *   <li>Non-resizable in ordinary numerical workflows.</li>
+ * </ul>
+ *
+ * <p>
+ * Conceptually:
+ * </p>
+ *
+ * @code{.py}
+ * data = np.zeros((N,))
+ * @endcode
+ *
+ * <p>
+ * The shape is fixed; the container does not grow.
+ * </p>
+ *
+ *
+ * <h3>Why Not std::vector?</h3>
+ *
+ * <p>
+ * Although <code>std::vector&lt;T&gt;</code> can be used with a fixed
+ * size, it is semantically a resizable container.
+ * </p>
+ *
+ * <p>
+ * Even if user code never calls <code>push_back()</code> or
+ * <code>resize()</code>, the type system does not encode the
+ * non-resizable invariant.
+ * </p>
+ *
+ * <p>
+ * In complex industrial systems:
+ * </p>
+ *
+ * <ul>
+ *   <li>Call chains are deep.</li>
+ *   <li>Business logic is layered.</li>
+ *   <li>Containers cross translation-unit boundaries.</li>
+ * </ul>
+ *
+ * <p>
+ * Compilers must conservatively assume that a
+ * <code>std::vector</code> may change size.
+ * </p>
+ *
+ * <p>
+ * Advanced compilers (e.g., modern LLVM/Clang) can sometimes
+ * infer non-growth properties through interprocedural analysis.
+ * However:
+ * </p>
+ *
+ * <ul>
+ *   <li>This increases analysis complexity.</li>
+ *   <li>Optimization success depends on inlining depth.</li>
+ *   <li>Less aggressive toolchains may fail to derive the invariant.</li>
+ * </ul>
+ *
+ * <p>
+ * What was needed was a semantic equivalent of:
+ * </p>
+ *
+ * <ul>
+ *   <li>A runtime-sized array.</li>
+ *   <li>Heap-allocated.</li>
+ *   <li>Never resizable.</li>
+ *   <li>Deterministic lifetime.</li>
+ * </ul>
+ *
+ *
+ * <h3>Why Not Just std::unique_ptr&lt;T[]&gt;?</h3>
+ *
+ * <p>
+ * The traditional pattern:
+ * </p>
+ *
+ * @code
+ * std::unique_ptr&lt;T[]&gt;
+ * @endcode
+ *
+ * <p>
+ * provides:
+ * </p>
+ *
+ * <ul>
+ *   <li>Heap allocation.</li>
+ *   <li>Clear ownership.</li>
+ *   <li>No resizing.</li>
+ * </ul>
+ *
+ * <p>
+ * But it is not a container:
+ * </p>
+ *
+ * <ul>
+ *   <li>No <code>begin()</code>/<code>end()</code>.</li>
+ *   <li>No range compatibility.</li>
+ *   <li>No allocator policy surface.</li>
+ *   <li>No container traits.</li>
+ * </ul>
+ *
+ * <p>
+ * <code>jh::runtime_arr</code> encapsulates this model and
+ * lifts it to a first-class container abstraction.
+ * </p>
+ *
+ *
+ * <h3>Allocator Model</h3>
+ *
+ * <p>
+ * Unlike most containers in the JH Toolkit, the default allocator
+ * of <code>runtime_arr</code> is not <code>std::allocator</code>.
+ * </p>
+ *
+ * <p>
+ * The default allocator type is:
+ * </p>
+ *
+ * @code
+ * jh::typed::monostate
+ * // A "monostate" placeholder representing no allocator, logic defined by runtime_arr itself
+ * @endcode
+ *
+ * <p>
+ * Under <code>jh::typed::monostate</code>, allocation does not
+ * follow the behavior of <code>std::allocator</code>.
+ * </p>
+ *
+ * <p>
+ * Instead, a specialized allocation path is used that avoids
+ * allocator_traits indirection and simplifies ownership semantics.
+ * </p>
+ *
+ * <p>
+ * This design choice reduces template depth and clarifies
+ * compiler analysis paths.
+ * </p>
+ *
+ *
+ * <h3>POD Acceleration Philosophy</h3>
+ *
+ * <p>
+ * For POD-like types:
+ * </p>
+ *
+ * <ul>
+ *   <li>Construction may skip per-element initialization.</li>
+ *   <li>Reset operations reduce to <code>std::memset</code>.</li>
+ *   <li>No destructor loops are required.</li>
+ * </ul>
+ *
+ * <p>
+ * This is achieved using SFINAE and C++20 concepts to prune
+ * unnecessary behavior at compile time.
+ * </p>
+ *
+ *
+ * <h3>Dual-Mode Build Model</h3>
+ *
+ * <p>
+ * The component supports both:
+ * </p>
+ *
+ * <ul>
+ *   <li><code>jh::jh-toolkit</code> — header-only mode.</li>
+ *   <li><code>jh::jh-toolkit-static</code> — static-optimized mode.</li>
+ * </ul>
+ *
+ *
+ * <h3>Special Case: runtime_arr&lt;bool&gt;</h3>
+ *
+ * <p>
+ * The <code>bool</code> specialization behaves differently
+ * from the general <code>runtime_arr&lt;T&gt;</code>.
+ * </p>
+ *
+ * <p>
+ * The bit-packed variant:
+ * </p>
+ *
+ * <ul>
+ *   <li>Stores elements as packed bits (<code>uint64_t[]</code> backing).</li>
+ *   <li>Does not expose <code>data()</code>.</li>
+ *   <li>Does not provide <code>std::span</code> access.</li>
+ *   <li>Does not model a standard contiguous range.</li>
+ *   <li>Does not expose raw pointer iterators.</li>
+ * </ul>
+ *
+ * <p>
+ * Access is performed through index-based bit manipulation.
+ * Operations such as <code>set()</code> and <code>test()</code>
+ * are provided.
+ * </p>
+ *
+ * <p>
+ * This behavior is closer to <code>std::vector&lt;bool&gt;</code>
+ * or <code>std::bitset</code> than to a normal contiguous container.
+ * </p>
+ *
+ * <p>
+ * Because bit manipulation introduces additional instructions,
+ * the static build target precompiles this specialization
+ * with aggressive optimization flags (e.g., -O3) to mitigate
+ * the performance cost.
+ * </p>
+ *
+ * <p>
+ * A conjugate variant:
+ * </p>
+ *
+ * @code
+ * jh::runtime_arr&lt;bool, jh::runtime_arr_helper::bool_flat_alloc&gt;
+ * @endcode
+ *
+ * <p>
+ * uses byte-based storage and behaves like a normal
+ * contiguous container.
+ * </p>
+ *
+ *
+ * <h3>Design Objective</h3>
+ *
+ * <p>
+ * The overarching objective of <code>runtime_arr</code> is to:
+ * </p>
+ *
+ * <ul>
+ *   <li>Encode non-resizable invariants at the type level.</li>
+ *   <li>Reduce alias-analysis uncertainty.</li>
+ *   <li>Clarify compiler optimization paths.</li>
+ *   <li>Provide deterministic heap-based fixed-size storage.</li>
+ * </ul>
+ *
+ * <p>
+ * It represents a semantic category distinct from
+ * <code>std::vector</code>, modeling a runtime-sized but
+ * structurally immutable container.
+ * </p>
+ *
+ */
+
+#include <jh/runtime_arr>
+#include "ensure_output.h"
+
+#if IS_WINDOWS
+static EnsureOutput ensure_output_setup;
+#endif
+
+/**
+ * @page Runtime-Sized Immutable Matrix Backed by jh::runtime_arr
+ *
+ * <h3>Overview</h3>
+ *
+ * This module demonstrates how to construct a runtime-sized,
+ * non-resizable matrix abstraction using <code>jh::runtime_arr</code>.
+ *
+ * The objective is to reproduce the common NumPy-style usage pattern:
+ *
+ * @code{.py}
+ * import numpy as np
+ * A = np.zeros((rows, cols))
+ * @endcode
+ *
+ * where:
+ *
+ * <ul>
+ *   <li>The shape is fixed at construction time.</li>
+ *   <li>The storage is contiguous.</li>
+ *   <li>The container does not grow.</li>
+ * </ul>
+ *
+ * <h3>Design Principles</h3>
+ *
+ * <h4>Shape Immutability</h4>
+ *
+ * Unlike <code>std::vector</code>, the matrix backbone
+ * (<code>jh::runtime_arr</code>) does not support resizing.
+ *
+ * The non-growth invariant is encoded at the type level.
+ *
+ *
+ * <h4>Deterministic Contiguous Layout</h4>
+ *
+ * The matrix uses row-major storage:
+ *
+ * @code
+ * index = r * cols + c
+ * @endcode
+ *
+ * This mirrors NumPy’s default C-order layout.
+ *
+ *
+ * <h4>POD Acceleration</h4>
+ *
+ * For arithmetic types, construction and destruction
+ * are simplified, allowing efficient bulk operations.
+ *
+ *
+ * <h3>Conceptual Structure</h3>
+ *
+ * @code
+ * template<typename T>
+ * class matrix {
+ *     const std::size_t rows_;
+ *     const std::size_t cols_;
+ *     jh::runtime_arr<T> data_;
+ * };
+ * @endcode
+ *
+ *
+ * <h3>Industrial Context</h3>
+ *
+ * This simplified pattern originated from Python-to-C++ migration efforts
+ * where fixed-shape numerical buffers were required for:
+ *
+ * <ul>
+ *   <li>Image processing pipelines</li>
+ *   <li>Scientific computation</li>
+ *   <li>GPU upload staging buffers</li>
+ * </ul>
+ *
+ * The invariant that "this buffer will never grow"
+ * simplifies compiler optimization and alias analysis.
+ *
+ * Here we demonstrate usage examples for <code>runtime_arr</code>.
+ * Since it prohibits copying, you must perform a deep copy as follows:
+ * <ul>
+ *     <li>either opt for reference copy <code>auto& b = a</code></li>
+ *     <li>or use <code>jh::runtime_arr&lt;T&gt;b(a.size());</code> combined with
+ *         explicit copying via <code>std::copy</code>.</li>
+ * </ul>
+ *
+ */
+
+#include <iostream>
+#include <iomanip>
+#include <concepts>
+#include <jh/pod>
+
+namespace example::simulated {
+
+    /* =========================================================
+       Concept Constraint
+       ========================================================= */
+
+    template<typename T>
+    concept MatrixElement =
+    jh::pod::pod_like<T> && requires(T a, T b) {
+        { a + b } -> std::same_as<T>;
+        { a * b } -> std::same_as<T>;
+        { a += b } -> std::same_as<T &>;
+    };
+
+
+    /* =========================================================
+       Matrix
+       ========================================================= */
+
+    template<MatrixElement T>
+    class Matrix {
+    public:
+
+        /* ================= Constructors ================= */
+
+        Matrix(std::size_t rows, std::size_t cols)
+                : rows_(rows),
+                  cols_(cols),
+                  data_(rows * cols) {
+        }
+
+        Matrix(std::initializer_list<std::initializer_list<T>> init)
+                : rows_(init.size()),
+                  cols_(init.size() ? init.begin()->size() : 0),
+                  data_(rows_ * cols_) {
+            std::size_t r = 0;
+
+            for (const auto &row: init) {
+
+                if (row.size() != cols_)
+                    throw std::runtime_error(
+                            "Matrix initializer rows must have equal size");
+
+                std::size_t c = 0;
+                for (const auto &value: row) {
+                    data_[r * cols_ + c] = value;
+                    ++c;
+                }
+
+                ++r;
+            }
+        }
+
+        /* ================= Copy ================= */
+
+        Matrix(const Matrix &other)
+                : rows_(other.rows_),
+                  cols_(other.cols_),
+                  data_(other.size()) {
+            std::copy(other.raw(),
+                      other.raw() + other.size(),
+                      raw());
+        }
+
+        Matrix &operator=(const Matrix &other) {
+            if (this == &other)
+                return *this;
+
+            if (rows_ != other.rows_ || cols_ != other.cols_)
+                throw std::invalid_argument(
+                        "Matrix copy assignment requires identical dimensions");
+
+            std::copy(other.raw(),
+                      other.raw() + other.size(),
+                      raw());
+
+            return *this;
+        }
+
+        /* ================= Move ================= */
+
+        Matrix(Matrix &&) noexcept = default;
+
+        Matrix &operator=(Matrix &&) noexcept = default;
+
+        ~Matrix() = default;
+
+
+        /* ================= Observers ================= */
+
+        [[nodiscard]] std::size_t rows() const noexcept { return rows_; }
+
+        [[nodiscard]] std::size_t cols() const noexcept { return cols_; }
+
+        [[nodiscard]] std::size_t size() const noexcept { return rows_ * cols_; }
+
+        [[nodiscard]] T *raw() noexcept { return data_.data(); }
+
+        [[nodiscard]] const T *raw() const noexcept { return data_.data(); }
+
+
+        /* ================= Element Access ================= */
+
+        T &operator()(std::size_t r, std::size_t c) {
+            return data_[r * cols_ + c];
+        }
+
+        const T &operator()(std::size_t r, std::size_t c) const {
+            return data_[r * cols_ + c];
+        }
+
+
+        /* ================= Addition ================= */
+
+        [[nodiscard]] Matrix operator+(const Matrix &other) const {
+            if (rows_ != other.rows_ || cols_ != other.cols_)
+                throw std::invalid_argument(
+                        "Matrix dimensions must match for addition");
+
+            Matrix result(rows_, cols_);
+
+            std::transform(raw(),
+                           raw() + size(),
+                           other.raw(),
+                           result.raw(),
+                           [](T a, T b) { return a + b; });
+
+            return result;
+        }
+
+        Matrix &operator+=(const Matrix &other) {
+            if (rows_ != other.rows_ || cols_ != other.cols_)
+                throw std::invalid_argument(
+                        "Matrix dimensions must match for addition");
+
+            std::transform(raw(),
+                           raw() + size(),
+                           other.raw(),
+                           raw(),
+                           [](T a, T b) { return a + b; });
+
+            return *this;
+        }
+
+
+        /* ================= Multiplication ================= */
+
+        Matrix operator*(const Matrix &other) const {
+            if (cols_ != other.rows_)
+                throw std::invalid_argument(
+                        "Matrix dimensions incompatible for multiplication");
+
+            Matrix result(rows_, other.cols_);
+
+            for (std::size_t i = 0; i < rows_; ++i)
+                for (std::size_t k = 0; k < cols_; ++k)
+                    for (std::size_t j = 0; j < other.cols_; ++j)
+                        result(i, j) +=
+                                (*this)(i, k) * other(k, j);
+
+            return result;
+        }
+
+        /* ================= Fast Power ================= */
+
+        [[nodiscard]] Matrix pow(std::size_t exponent) const {
+            if (rows_ != cols_)
+                throw std::invalid_argument(
+                        "Matrix exponentiation requires square matrix");
+
+            Matrix result = identity(rows_);
+            Matrix base(*this);  // deep copy
+
+            while (exponent > 0) {
+
+                if (exponent & 1)
+                    result = result * base;
+
+                base = base * base;
+                exponent >>= 1;
+            }
+
+            return result;
+        }
+
+
+        /* ================= Identity ================= */
+
+        static Matrix identity(std::size_t n) {
+            Matrix I(n, n);
+
+            for (std::size_t i = 0; i < n; ++i)
+                I(i, i) = static_cast<T>(1);
+
+            return I;
+        }
+
+    private:
+        const std::size_t rows_{};
+        const std::size_t cols_{};
+        jh::runtime_arr<T> data_{};
+    };
+
+} // namespace example::simulated
+
+namespace example {
+
+    void example_matrix_runtime_arr() {
+
+        using simulated::Matrix;
+
+        std::cout << "\n===== Runtime-sized immutable matrix demo =====\n\n";
+
+        /* =========================
+           1. Matrix Multiplication
+           ========================= */
+
+        Matrix<double> A{
+                {1, 2, 3},
+                {4, 5, 6}
+        };
+
+        Matrix<double> B{
+                {7,  8},
+                {9,  10},
+                {11, 12}
+        };
+
+        auto C = A * B;
+
+        std::cout << "A (2x3) * B (3x2) = C (2x2)\n\n";
+
+        for (std::size_t r = 0; r < C.rows(); ++r) {
+            for (std::size_t c = 0; c < C.cols(); ++c)
+                std::cout << std::setw(8) << C(r, c);
+            std::cout << "\n";
+        }
+
+        /* =========================
+           2. Matrix Addition
+           ========================= */
+
+        Matrix<double> D{
+                {1, 1},
+                {1, 1}
+        };
+
+        auto E = C + D;
+
+        std::cout << "\nC + D = E\n\n";
+
+        for (std::size_t r = 0; r < E.rows(); ++r) {
+            for (std::size_t c = 0; c < E.cols(); ++c)
+                std::cout << std::setw(8) << E(r, c);
+            std::cout << "\n";
+        }
+
+        /* =========================
+           3. Square Matrix Fast Power
+           ========================= */
+
+        Matrix<unsigned long long> F{
+                {1, 1},
+                {1, 0}
+        };
+
+        std::size_t exponent = 20;
+
+        auto G = F.pow(exponent);
+
+        std::cout << "\nFibonacci matrix ^ " << exponent << "\n\n";
+
+        for (std::size_t r = 0; r < G.rows(); ++r) {
+            for (std::size_t c = 0; c < G.cols(); ++c)
+                std::cout << std::setw(8) << G(r, c);
+            std::cout << "\n";
+        }
+
+        std::cout << "\nF(" << exponent << ") = "
+                  << G(0, 1) << "\n";
+
+        std::cout << "\n===== end matrix demo =====\n";
+    }
+
+}
+
+int main() {
+    example::example_matrix_runtime_arr();
+    return 0;
+}

--- a/examples/process_lock/example_writer.cpp
+++ b/examples/process_lock/example_writer.cpp
@@ -36,6 +36,7 @@
 #include "jh/synchronous/ipc/process_mutex.h"
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <thread>
 
 using namespace std::chrono_literals;

--- a/include/jh/concurrent/flat_pool.h
+++ b/include/jh/concurrent/flat_pool.h
@@ -30,14 +30,6 @@
  * lightweight reference-counted handles (<code>flat_pool::ptr</code>) bound to stable indices.
  * </p>
  *
- * <p>
- * Unlike pointer-based interning containers, <code>flat_pool</code> does <b>not</b> rely on
- * <code>std::shared_ptr</code> for ownership, synchronization, or lifetime control. All concurrency
- * guarantees are enforced exclusively through the pool's internal locking strategy. As a result,
- * the behavior of the pool is independent of platform-specific <code>shared_ptr</code>
- * implementations (including Windows-specific locking behavior).
- * </p>
- *
  * <h3>Key-Based Identity Model</h3>
  * <p>
  * Object identity is defined entirely by an external <code>Key</code> type. The key must be:
@@ -144,7 +136,7 @@
  *     </ul>
  *   </li>
  *   <li>
- *     <b><code>pointer_pool</code></b>:
+ *     <b><code>pointer_pool</code> (<code>observe_pool</code>)</b>:
  *     <ul>
  *       <li>Pointer-driven identity (Generally, comparisons of internal objects are proxied using
  *           <code>jh::weak_ptr_hash</code> and <code>jh::weak_ptr_eq</code>.)
@@ -182,6 +174,23 @@
  * then a pointer-based pool should be used instead.
  * </p>
  *
+ * @note
+ * On Windows platforms (MinGW-w64 / MinGW-clang with UCRT or MSVCRT),
+ * <code>flat_pool</code> exhibits race anomalies far less frequently than
+ * <code>pointer_pool</code>, but such anomalies are not entirely eliminated.
+ * <br>
+ * Even with additional fences introduced for Windows builds, rare
+ * reordering effects may still occur under extreme concurrency,
+ * especially when high parallel pressure is combined with test
+ * frameworks or debug-mode allocators. In such scenarios, unexpected
+ * ordering behavior may break internal safety assumptions.
+ * <br>
+ * The <code>&lt;jh/pool&gt;</code> module is primarily designed and validated
+ * for POSIX systems. Windows is treated as a secondary platform.
+ * <br>
+ * On Windows, usage is recommended only for single-threaded or
+ * low-contention multi-threaded workloads.
+ *
  * @version <pre>1.4.x</pre>
  * @date <pre>2025</pre>
  */
@@ -206,6 +215,7 @@
 #include "jh/core/ordered_map.h"
 #include "jh/conceptual/hashable.h"
 #include "jh/synchronous/control_buf.h"
+#include "jh/synchronous/strong_mutex.h"
 
 namespace jh::conc {
     namespace detail {
@@ -527,13 +537,13 @@ namespace jh::conc {
         std::size_t emplace(KArg &&k) requires jh::typed::monostate_t<Value> {
             // shared lock the entries_ for lookup
             {
-                std::shared_lock lk(entry_mtx_);
+                jh::sync::posix_smtx_shared_lock lk(entry_mtx_);
                 auto attempt = find_idx_no_lock(k);
                 if (attempt != static_cast<std::size_t>(-1)) return attempt;
             }
             // not found -> acquire exclusive locks
-            std::unique_lock entry_lock(entry_mtx_);
-            std::unique_lock storage_lock(pool_mtx_);
+            jh::sync::posix_smtx_unique_lock entry_lock(entry_mtx_);
+            jh::sync::posix_smtx_unique_lock storage_lock(pool_mtx_);
 
             // revalidate under exclusive locks to avoid race
             auto attempt = find_idx_no_lock(k);
@@ -597,13 +607,13 @@ namespace jh::conc {
         std::size_t emplace(KArg &&k, std::tuple<Args...> args_tuple)requires (!jh::typed::monostate_t<Value>) {
             // shared lock the entries_ for lookup
             {
-                std::shared_lock lk(entry_mtx_);
+                jh::sync::posix_smtx_shared_lock lk(entry_mtx_);
                 auto attempt = find_idx_no_lock(k);
                 if (attempt != static_cast<std::size_t>(-1)) return attempt;
             }
             // not found -> acquire exclusive locks
-            std::unique_lock entry_lock(entry_mtx_);
-            std::unique_lock storage_lock(pool_mtx_);
+            jh::sync::posix_smtx_unique_lock entry_lock(entry_mtx_);
+            jh::sync::posix_smtx_unique_lock storage_lock(pool_mtx_);
 
             // revalidate under exclusive locks to avoid race
             auto attempt = find_idx_no_lock(k);
@@ -665,7 +675,7 @@ namespace jh::conc {
          *         is out of range or refers to an unoccupied slot.
          */
         bool add_ref(size_t index) {
-            std::shared_lock lk(pool_mtx_);
+            jh::sync::posix_smtx_shared_lock lk(pool_mtx_);
             if (index >= occupation_.size() || occupation_[index] == 0)
                 return false;
             refcounts_[index].fetch_add(1);
@@ -701,11 +711,11 @@ namespace jh::conc {
          */
         void release_ref(size_t index) {
             {
-                std::shared_lock lk(pool_mtx_);
+                jh::sync::posix_smtx_shared_lock lk(pool_mtx_);
                 if (refcounts_[index].fetch_sub(1) > 1)
                     return;
             }
-            std::unique_lock storage_lock(pool_mtx_);
+            jh::sync::posix_smtx_unique_lock storage_lock(pool_mtx_);
 
             if (refcounts_[index].load() != 0) return;
 
@@ -1227,7 +1237,7 @@ namespace jh::conc {
          * Unlike <code>acquire()</code>, this function never inserts new entries.
          */
         ptr find(const Key &key) {
-            std::shared_lock lk(entry_mtx_);
+            jh::sync::posix_smtx_shared_lock lk(entry_mtx_);
             auto idx = find_idx_no_lock(key);
             if (idx == static_cast<std::size_t>(-1)) return ptr{nullptr};
             return ptr(this, idx);
@@ -1361,7 +1371,7 @@ namespace jh::conc {
          *         </ol>
          */
         std::pair<std::size_t, std::size_t> occupancy_rate() {
-            std::shared_lock lk(pool_mtx_);
+            jh::sync::posix_smtx_shared_lock lk(pool_mtx_);
             return {storage_.capacity(), entries_.size()};
         }
 
@@ -1381,8 +1391,8 @@ namespace jh::conc {
          * </p>
          */
         void resize_pool() {
-            std::unique_lock entry_lock(entry_mtx_);
-            std::unique_lock pool_lock(pool_mtx_);
+            jh::sync::posix_smtx_unique_lock entry_lock(entry_mtx_);
+            jh::sync::posix_smtx_unique_lock pool_lock(pool_mtx_);
 
             // 1. Find last occupied slot
             auto rit = std::find_if(occupation_.rbegin(), occupation_.rend(),

--- a/include/jh/concurrent/flat_pool.h
+++ b/include/jh/concurrent/flat_pool.h
@@ -1424,7 +1424,7 @@ namespace jh::conc {
             storage_.shrink_to_fit();
             occupation_.resize(new_cap);
             occupation_.shrink_to_fit();
-            entries_.shrink_to_fit();
+            entries_ = jh::ordered_set<entry_key>::from_sorted(std::move(entries_));
             refcounts_.resize(new_cap);
             refcounts_.shrink_to_fit();
         }

--- a/include/jh/concurrent/flat_pool.h
+++ b/include/jh/concurrent/flat_pool.h
@@ -175,21 +175,29 @@
  * </p>
  *
  * @note
- * On Windows platforms (MinGW-w64 / MinGW-clang with UCRT or MSVCRT),
- * <code>flat_pool</code> exhibits race anomalies far less frequently than
- * <code>pointer_pool</code>, but such anomalies are not entirely eliminated.
+ * The implementation of <code>flat_pool</code> is algorithmically
+ * data-race-free (DRF) and does not rely on undefined behavior
+ * under the ISO C++ memory model.
  * <br>
- * Even with additional fences introduced for Windows builds, rare
- * reordering effects may still occur under extreme concurrency,
- * especially when high parallel pressure is combined with test
- * frameworks or debug-mode allocators. In such scenarios, unexpected
- * ordering behavior may break internal safety assumptions.
+ * Additional <code>std::atomic_thread_fence(std::memory_order_seq_cst)</code>
+ * barriers are introduced on Windows builds to strengthen ordering at
+ * the language level. This removes ISO-level UB risks and preserves
+ * correctness within the C++ abstract machine.
  * <br>
- * The <code>&lt;jh/pool&gt;</code> module is primarily designed and validated
- * for POSIX systems. Windows is treated as a secondary platform.
+ * However, Windows runtime and system-level synchronization primitives
+ * (e.g. SRWLock-based <code>std::shared_mutex</code> implementations)
+ * do not necessarily provide POSIX-equivalent global ordering behavior.
+ * Under extreme multi-core contention, rare visibility or reordering
+ * phenomena may still be observed.
  * <br>
- * On Windows, usage is recommended only for single-threaded or
- * low-contention multi-threaded workloads.
+ * Such behavior is not a violation of the C++ standard and does not
+ * indicate undefined behavior in <code>flat_pool</code>; rather, it reflects
+ * platform-level memory ordering characteristics outside the control
+ * of the library.
+ * <br>
+ * Accordingly, while API correctness is preserved, Windows builds
+ * are not guaranteed to exhibit the same high-pressure stability
+ * characteristics as POSIX systems.
  *
  * @version <pre>1.4.x</pre>
  * @date <pre>2025</pre>
@@ -1084,6 +1092,11 @@ namespace jh::conc {
             /// @brief Compares the handle against <code>nullptr</code>.
             bool operator==(std::nullptr_t) {
                 return pool_ == nullptr;
+            }
+
+            /// @brief Returns true if the handle is non-null.
+            explicit operator bool() const noexcept {
+                return pool_ != nullptr;
             }
 
             /**

--- a/include/jh/concurrent/flat_pool.h
+++ b/include/jh/concurrent/flat_pool.h
@@ -223,7 +223,7 @@
 #include "jh/core/ordered_map.h"
 #include "jh/conceptual/hashable.h"
 #include "jh/synchronous/control_buf.h"
-#include "jh/synchronous/strong_mutex.h"
+#include "jh/synchronous/strong_lock.h"
 
 namespace jh::conc {
     namespace detail {

--- a/include/jh/concurrent/flat_pool.h
+++ b/include/jh/concurrent/flat_pool.h
@@ -1120,7 +1120,7 @@ namespace jh::conc {
             }
         };
 
-        friend class flat_pool::ptr;
+        friend struct flat_pool::ptr;
 
         /**
          * @brief Retrieves or creates a pooled object associated with a key (set-like).

--- a/include/jh/concurrent/observe_pool.h
+++ b/include/jh/concurrent/observe_pool.h
@@ -172,31 +172,20 @@ namespace jh {
      * content-based <code>operator==</code>.
      *
      * @note
-     * <strong>Usage guidance:</strong>
+     * <strong>Platform guidance:</strong>
      * <br>
-     * <code>jh::observe_pool</code> relies on <code>std::shared_ptr</code> /
-     * <code>std::weak_ptr</code> for object tracking. This inevitably introduces
-     * heap fragmentation and reference-counting overhead. It is therefore intended
-     * only for types that are <b>neither copyable nor movable</b>, and for workloads
-     * where the total number of live objects and concurrency level remain modest.
-     * Excessive object counts or high parallel pressure may lead to allocation
-     * jitter and degraded performance.
+     * All concurrent pools under <code>&lt;jh/pool&gt;</code> are designed
+     * primarily for POSIX platforms and rely on POSIX-style ordering
+     * semantics for their performance characteristics.
      * <br>
-     * On Windows platforms using the Universal CRT (including MinGW variants),
-     * <code>std::shared_ptr</code> is not reliably thread-safe under contention.
-     * Practical limits are significantly lower than on other platforms; it is
-     * recommended to keep concurrency within approximately <b>4 threads</b> and
-     * the total number of live pooled objects within roughly <b>2k</b>.
+     * Windows (MinGW-w64 / MinGW-clang with UCRT or MSVCRT) is treated
+     * as a secondary platform. API compatibility is provided, but
+     * concurrency guarantees are not equivalent to POSIX builds.
+     * High-contention workloads are not recommended on Windows.
      * <br>
-     * If the managed type is at least copyable or movable, prefer
-     * <code>jh::resource_pool&lt;T&gt;</code>. If a stable key can be used to identify
-     * objects, prefer <code>jh::resource_pool&lt;K, V&gt;</code>. When a key is available
-     * but the value type is neither copyable nor movable, using
-     * <code>jh::resource_pool&lt;K, std::shared_ptr&lt;V&gt;&gt;</code> is often a better
-     * alternative: hashing and equality are applied only to the key, avoiding
-     * expensive object-level comparisons and large-scale rehash jitter during
-     * resizing.
-     * </p>
+     * If your final deployment target is a POSIX system (Linux / Darwin),
+     * the pool implementations may be used as intended under full
+     * concurrency.
      */
     template<typename T>
     using observe_pool =

--- a/include/jh/concurrent/occ_box.h
+++ b/include/jh/concurrent/occ_box.h
@@ -122,6 +122,62 @@
 
 #pragma once
 
+/**
+ * @brief Enable transactional multi-commit support for <code>occ_box</code>.
+ *
+ * <p><b>Default:</b> 1 (enabled)</p>
+ *
+ * <p>
+ * If not defined manually, it defaults to:
+ * </p>
+ * <pre>
+ * #define JH_OCC_ENABLE_MULTI_COMMIT 1
+ * </pre>
+ *
+ * <p>
+ * If overriding manually in source code, it <b>must be defined before any
+ * inclusion of the library public header</b> (i.e. <code>&lt;jh/concurrency&gt;</code>)
+ * within the translation unit.
+ * </p>
+ *
+ * <p><b>Configuration methods:</b></p>
+ * <ul>
+ *   <li>
+ *     Source-level (before any include of the library header):
+ *     <pre>
+ *     #define JH_OCC_ENABLE_MULTI_COMMIT 0
+ *     </pre>
+ *   </li>
+ *   <li>
+ *     CMake:
+ *     <pre>
+ *     target_compile_definitions(target PRIVATE JH_OCC_ENABLE_MULTI_COMMIT=0)
+ *     </pre>
+ *   </li>
+ *   <li>
+ *     Compiler flag:
+ *     <pre>
+ *     -DJH_OCC_ENABLE_MULTI_COMMIT=0
+ *     </pre>
+ *   </li>
+ * </ul>
+ *
+ * <p><b>When set to 1:</b></p>
+ * <ul>
+ *   <li>Enables <code>apply_to()</code> transactional operations.</li>
+ *   <li>Allows multiple <code>occ_box</code> instances to commit atomically
+ *       as a single transaction (multi-commit).</li>
+ *   <li>Single-box logic and correctness guarantees remain unchanged.</li>
+ *   <li>Adds a small additional read-path overhead (one extra atomic load).</li>
+ * </ul>
+ *
+ * <p><b>When set to 0:</b></p>
+ * <ul>
+ *   <li><code>apply_to()</code> is not compiled.</li>
+ *   <li>Only single-box OCC is available.</li>
+ *   <li>No transactional coordination overhead is introduced.</li>
+ * </ul>
+ */
 #ifndef JH_OCC_ENABLE_MULTI_COMMIT
 #define JH_OCC_ENABLE_MULTI_COMMIT 1
 #endif

--- a/include/jh/concurrent/pointer_pool.h
+++ b/include/jh/concurrent/pointer_pool.h
@@ -185,6 +185,8 @@
 #include <memory>
 #include <shared_mutex>
 
+#include "jh/synchronous/strong_mutex.h"
+
 
 namespace jh::conc {
 
@@ -211,7 +213,9 @@ namespace jh::conc {
      *       or explicit cleanup calls.</li>
      *   <li><b>Adaptive capacity:</b> The container may grow or shrink depending on occupancy thresholds
      *       evaluated during insertion.</li>
-     *   <li><b>Thread-safe:</b> Lookups and insertions coordinate through <code>std::shared_mutex</code>.</li>
+     *   <li>
+     *     <b>Thread-safe:</b> Lookups and insertions coordinate through <code>std::shared_mutex</code>.
+     *   </li>
      *   <li><b>Discard-friendly:</b> Temporary objects are cheap to abandon when a matching instance exists.</li>
      * </ul>
      *
@@ -237,17 +241,22 @@ namespace jh::conc {
      * <code>jh::observe_pool</code>, these are automatically derived from <code>std::hash&lt;T&gt;()</code> or
      * adl <code>hash(t)</code> or <code>t.hash()</code>, and <code>operator==()</code> to ensure consistent behavior.
      *
-     * @warning
-     * On Windows environments based on the Universal CRT (including MinGW variants),
-     * <code>std::shared_ptr</code> and <code>std::weak_ptr</code> may exhibit incorrect reference-count
-     * synchronization under high concurrency. As a result, <code>weak_ptr::lock()</code> may succeed
-     * against an object whose underlying <code>shared_ptr</code> has already been destroyed, leading to
-     * invalid access or crashes even under otherwise correct usage. Additionally, insertion of
-     * <code>std::weak_ptr</code> into <code>std::unordered_*</code> containers on these platforms incurs
-     * significant jitter.
+      * @warning
+     * On Windows (MinGW-w64 / MinGW-clang with UCRT or MSVCRT),
+     * high-concurrency behavior may exhibit rare ordering anomalies.
      * <br>
-     * Due to these platform-specific defects, high-pressure concurrent use of
-     * <code>pointer_pool</code> is not recommended on Windows UCRT-based toolchains.
+     * On certain Windows runtime combinations, the interaction between
+     * the Windows lock model and MinGW threading may cause rare reordering
+     * effects under extreme contention, even when using
+     * <code>std::memory_order_seq_cst</code>.
+     * <br>
+     * <code>pointer_pool</code> may expose these effects more visibly due
+     * to heavier synchronization paths, though the limitation applies to
+     * all concurrent pools in this module.
+     * <br>
+     * On Windows, use is recommended only for single-threaded or
+     * low-contention workloads. POSIX platforms remain the primary
+     * supported and validated targets.
      */
     template<typename T, typename Hash, typename Eq>
     requires(
@@ -334,7 +343,7 @@ namespace jh::conc {
          * in both the old and new pool, but this is acceptable for deduplication use.
          */
         pointer_pool(pointer_pool &&other) noexcept {
-            std::unique_lock write_lock(other.pool_mutex_);
+            jh::sync::posix_smtx_unique_lock write_lock(other.pool_mutex_);
             pool_ = std::move(other.pool_);
             capacity_.store(other.capacity_.load());
             other.pool_.clear();  // Ensure valid empty state after move.
@@ -502,7 +511,7 @@ namespace jh::conc {
          * @return The number of stored weak_ptrs (including expired ones).
          */
         [[nodiscard]] std::uint64_t size() const {
-            std::shared_lock read_lock(pool_mutex_);
+            jh::sync::posix_smtx_shared_lock read_lock(pool_mutex_);
             return pool_.size();
         }
 
@@ -546,7 +555,7 @@ namespace jh::conc {
          * </ul>
          */
         void clear() {
-            std::unique_lock write_lock(pool_mutex_);
+            jh::sync::posix_smtx_unique_lock write_lock(pool_mutex_);
             pool_.clear();
             capacity_.store(MIN_RESERVED_SIZE);
         }
@@ -576,7 +585,7 @@ namespace jh::conc {
             if (pool_.size() >= capacity_.load()) {
                 expand_and_cleanup(); // This function is already acquiring the lock.
             }
-            std::unique_lock write_lock(pool_mutex_); // Lock for pool access.
+            jh::sync::posix_smtx_unique_lock write_lock(pool_mutex_); // Lock for pool access.
 
             auto [it, inserted] = pool_.insert(obj);
             if (!inserted) return it->lock();

--- a/include/jh/concurrent/pointer_pool.h
+++ b/include/jh/concurrent/pointer_pool.h
@@ -241,22 +241,29 @@ namespace jh::conc {
      * <code>jh::observe_pool</code>, these are automatically derived from <code>std::hash&lt;T&gt;()</code> or
      * adl <code>hash(t)</code> or <code>t.hash()</code>, and <code>operator==()</code> to ensure consistent behavior.
      *
-      * @warning
-     * On Windows (MinGW-w64 / MinGW-clang with UCRT or MSVCRT),
-     * high-concurrency behavior may exhibit rare ordering anomalies.
+     * @warning
+     * On Windows platforms (MinGW-w64 / MinGW-clang with UCRT or MSVCRT),
+     * additional <code>std::atomic_thread_fence(std::memory_order_seq_cst)</code>
+     * barriers are inserted to strengthen ordering at the language level.
+     * This eliminates ISO-level UB risks and preserves correctness within
+     * the C++ abstract machine.
      * <br>
-     * On certain Windows runtime combinations, the interaction between
-     * the Windows lock model and MinGW threading may cause rare reordering
-     * effects under extreme contention, even when using
-     * <code>std::memory_order_seq_cst</code>.
+     * However, certain Windows runtime and system-level synchronization
+     * implementations (e.g. SRWLock-backed <code>std::shared_mutex</code>)
+     * do not necessarily provide POSIX-equivalent global ordering behavior.
+     * Under extreme multi-core contention, rare visibility or reordering
+     * phenomena may still be observed.
      * <br>
-     * <code>pointer_pool</code> may expose these effects more visibly due
-     * to heavier synchronization paths, though the limitation applies to
-     * all concurrent pools in this module.
+     * These effects are platform characteristics rather than violations of
+     * the C++ standard and do not indicate undefined behavior in the pool
+     * implementations. <code>pointer_pool</code> may expose such behavior
+     * more readily due to heavier synchronization and hash-table interaction,
+     * but the underlying limitation applies to all concurrent pools in
+     * this module.
      * <br>
-     * On Windows, use is recommended only for single-threaded or
-     * low-contention workloads. POSIX platforms remain the primary
-     * supported and validated targets.
+     * Windows builds are therefore considered compatible but not validated
+     * for extreme high-contention workloads. POSIX platforms remain the
+     * primary supported and reference environments.
      */
     template<typename T, typename Hash, typename Eq>
     requires(

--- a/include/jh/concurrent/pointer_pool.h
+++ b/include/jh/concurrent/pointer_pool.h
@@ -185,7 +185,7 @@
 #include <memory>
 #include <shared_mutex>
 
-#include "jh/synchronous/strong_mutex.h"
+#include "jh/synchronous/strong_lock.h"
 
 
 namespace jh::conc {

--- a/include/jh/core/immutable_str.h
+++ b/include/jh/core/immutable_str.h
@@ -189,6 +189,63 @@
 
 #pragma once
 
+/**
+ * @brief Controls whether <code>jh::immutable_str</code> performs automatic
+ *        leading/trailing ASCII whitespace trimming.
+ *
+ * <p><b>Default:</b> <code>true</code></p>
+ *
+ * <p>If not defined manually, it defaults to:</p>
+ * <pre>
+ * #define JH_IMMUTABLE_STR_AUTO_TRIM true
+ * </pre>
+ *
+ * <p>
+ * If overriding manually, it <b>must be defined before any inclusion</b>
+ * of <code>&lt;jh/immutable_str&gt;</code> in the translation unit.
+ * </p>
+ *
+ * <p><b>Configuration methods:</b></p>
+ * <ul>
+ *   <li>
+ *     Source-level (before include):
+ *     <pre>
+ *     #define JH_IMMUTABLE_STR_AUTO_TRIM false
+ *     </pre>
+ *   </li>
+ *   <li>
+ *     CMake:
+ *     <pre>
+ *     target_compile_definitions(target PRIVATE JH_IMMUTABLE_STR_AUTO_TRIM=false)
+ *     </pre>
+ *   </li>
+ *   <li>
+ *     Compiler flag:
+ *     <pre>
+ *     -DJH_IMMUTABLE_STR_AUTO_TRIM=false
+ *     </pre>
+ *   </li>
+ * </ul>
+ *
+ * <p><b>Important:</b></p>
+ * <ul>
+ *   <li>Must be a boolean literal: <code>true</code> or <code>false</code>
+ *       (not <code>1</code>/<code>0</code>).</li>
+ *   <li>Acts as a type-level compile-time policy parameter via
+ *       <code>static constexpr bool immutable_str::auto_trim</code>.</li>
+ *   <li>Branch selection is performed using <code>if constexpr</code>,
+ *       not preprocessor elimination.</li>
+ *   <li>In the static library target (<code>jh-toolkit-static</code>),
+ *       both code paths are compiled; user compilation activates the
+ *       selected branch.</li>
+ * </ul>
+ *
+ * <p><b>Behavior:</b></p>
+ * <ul>
+ *   <li><code>true</code>: remove leading/trailing ASCII whitespace at construction.</li>
+ *   <li><code>false</code>: preserve input exactly.</li>
+ * </ul>
+ */
 #ifndef JH_IMMUTABLE_STR_AUTO_TRIM
 #define JH_IMMUTABLE_STR_AUTO_TRIM true
 #endif
@@ -638,7 +695,7 @@ namespace jh {
          *
          * @code
          * #define JH_IMMUTABLE_STR_AUTO_TRIM false
-         * #include &lt;... all other includes ...&gt;
+         * #include &lt;jh/immutable_str&gt;
          * @endcode
          *
          * <p>

--- a/include/jh/core/ordered_map.h
+++ b/include/jh/core/ordered_map.h
@@ -1885,13 +1885,17 @@ namespace jh::avl {
             std::size_t cur = root;
             auto parent = static_cast<std::size_t>(-1);
 
+            K k = key; ///< temporary eager materialization
+
+            // The original argument is preserved for forwarding into storage.
+
             while (cur != static_cast<std::size_t>(-1)) {
                 parent = cur;
                 auto &node = nodes_[cur];
 
-                if (std::forward<KArg>(key) < node.key()) {
+                if (k < node.key()) {
                     cur = node.left;
-                } else if (node.key() < std::forward<KArg>(key)) {
+                } else if (node.key() < k) {
                     cur = node.right;
                 } else {
                     if constexpr ((!jh::typed::monostate_t<V>) && Assign) {
@@ -1907,7 +1911,7 @@ namespace jh::avl {
                     std::forward<VArg>(value),
                     parent);
             auto &p_node = nodes_[parent];
-            if (std::forward<KArg>(key) < p_node.key())
+            if (k < p_node.key())
                 p_node.left = idx;
             else
                 p_node.right = idx;
@@ -2212,8 +2216,11 @@ namespace jh::avl {
          *               <code>false</code> if an existing element was updated.</li>
          *         </ol>
          */
+        template<typename KArg, typename VArg>
+        requires std::is_same_v<std::remove_cvref_t<KArg>, typename node_type::key_type> &&
+                 std::is_same_v<std::remove_cvref_t<VArg>, typename node_type::value_type>
         std::pair<iterator, bool>
-        insert_or_assign(node_type::key_type &&k, node_type::value_type &&v) requires (!jh::typed::monostate_t<V>) {
+        insert_or_assign(KArg &&k, VArg &&v) requires (!jh::typed::monostate_t<V>) {
             return _insert_impl<true>(k, v);
         }
 

--- a/include/jh/core/runtime_arr.h
+++ b/include/jh/core/runtime_arr.h
@@ -208,7 +208,7 @@
  * @see jh::pod::pod_like
  * @see jh::typed::monostate
  *
- * @version <pre>1.3.x</pre>
+ * @version <pre>1.4.1</pre>
  * @date <pre>2025</pre>
  */
 
@@ -242,7 +242,8 @@ namespace jh {
         template<typename A, typename T>
         concept rebind_alloc_for =
         (!jh::typed::monostate_t<A>) && requires(std::uint64_t n) {
-            requires requires(typename std::allocator_traits<A>::template rebind_alloc<T> rebind){
+            requires requires
+                    (typename std::allocator_traits<A>::template rebind_alloc<T> rebind){
                 rebind.allocate(n);
                 rebind.deallocate(std::declval<T *>(), n);
             };
@@ -361,7 +362,8 @@ namespace jh {
      *   <li>Copy operations are deleted; moves are noexcept.</li>
      * </ul>
      */
-    template<typename T, typename Alloc = typed::monostate> requires detail::valid_rt_arr_allocator<T, Alloc>
+    template<typename T, typename Alloc = typed::monostate> requires
+    detail::valid_rt_arr_allocator<T, Alloc>
     class runtime_arr final {
         std::uint64_t size_{0};
 
@@ -446,8 +448,8 @@ namespace jh {
          * <p><strong>Note:</strong> The content of the allocated memory is indeterminate until written to.
          * Accessing any element before explicit initialization results in undefined behavior.</p>
          */
-        explicit runtime_arr(const std::uint64_t size, uninitialized_t) requires jh::pod::pod_like<T> &&
-                                                                                 typed::monostate_t<Alloc> {
+        explicit runtime_arr(const std::uint64_t size, uninitialized_t) requires
+        jh::pod::pod_like<T> && typed::monostate_t<Alloc> {
             size_ = size;
             T *ptr = static_cast<T *>(operator new[](sizeof(T) * size_));
             data_.reset(ptr);
@@ -561,7 +563,8 @@ namespace jh {
          *
          * @throws std::bad_alloc If allocator fails to provide storage.
          */
-        runtime_arr(std::initializer_list<T> init, const Alloc &alloc) requires (!jh::typed::monostate_t<Alloc>)
+        runtime_arr(std::initializer_list<T> init, const Alloc &alloc) requires
+        (!jh::typed::monostate_t<Alloc>)
                 : size_(init.size()) {
             allocator_type rebound = make_allocator_from(alloc);
             T *ptr = rebound.allocate(size_);
@@ -592,7 +595,8 @@ namespace jh {
          *   <li>Ensures allocator lifetime and destruction safety via lambda capture semantics.</li>
          * </ul>
          */
-        explicit runtime_arr(std::uint64_t size, const Alloc &alloc) requires (!typed::monostate_t<Alloc>)
+        explicit runtime_arr(std::uint64_t size, const Alloc &alloc) requires
+        (!typed::monostate_t<Alloc>)
                 : size_(size) {
             allocator_type rebound = make_allocator_from(alloc);
             T *ptr = rebound.allocate(size_);
@@ -652,15 +656,112 @@ namespace jh {
          */
         explicit runtime_arr(std::vector<T> &&vec) requires (typed::monostate_t<Alloc>)
                 : size_(vec.size()), data_(nullptr, default_deleter) {
-            if (!vec.empty()) {
-                T *ptr = new T[size_];
-                std::move(vec.begin(), vec.end(), ptr);
-                data_.reset(ptr);
-            }
+            if (size_ == 0)
+                return;
+
+            T *ptr = new T[size_];
+
+            std::uninitialized_move(vec.begin(), vec.end(), ptr);
+            // vec will NEVER be bool, so no need for specialization here
+
+            data_.reset(ptr);
         }
 
         /**
+         * @brief Constructs a runtime array by moving elements from a std::vector using a custom allocator.
+         *
+         * @param vec   Source vector whose elements will be moved.
+         * @param alloc Allocator instance used for allocation and deallocation.
+         *
+         * <ul>
+         *   <li>Enabled only when <code>Alloc != typed::monostate</code>.</li>
+         *   <li>Allocates storage using the provided allocator.</li>
+         *   <li>Elements are move-constructed from <code>vec</code>.</li>
+         *   <li>The allocator is captured by value in the deleter.</li>
+         * </ul>
+         */
+        template<class VecAlloc>
+        runtime_arr(std::vector<T, VecAlloc> &&vec, const Alloc &alloc) requires
+        (!typed::monostate_t<Alloc>)
+                : size_(vec.size()) {
+            allocator_type rebound = make_allocator_from(alloc);
+
+            if (size_ == 0) {
+                data_ = std::unique_ptr<T[], deleter_t>(nullptr, [](T *) {});
+                return;
+            }
+
+            T *ptr = rebound.allocate(size_);
+
+            try {
+
+                if constexpr (std::same_as<T, bool>) {
+                    // vector<bool> proxy -> bool
+                    for (std::uint64_t i = 0; i < size_; ++i)
+                        ptr[i] = static_cast<bool>(vec[i]);
+                } else {
+                    std::uninitialized_move(vec.begin(), vec.end(), ptr);
+                }
+
+            } catch (...) {
+                rebound.deallocate(ptr, size_);
+                throw;
+            }
+
+            data_ = std::unique_ptr<T[], deleter_t>(
+                    ptr,
+                    [rebound, size = size_](T *p) mutable {
+                        rebound.deallocate(p, size);
+                    }
+            );
+        }
+
+        /**
+         * @brief Constructs a runtime array by moving elements from a std::vector using its own allocator.
+         *
+         * @param vec Source vector whose elements will be moved.
+         *
+         * <ul>
+         *   <li>Enabled only when <code>Alloc != typed::monostate</code>.</li>
+         *   <li>The allocator is obtained from <code>vec.get_allocator()</code>.</li>
+         *   <li>Delegates to the constructor taking <code>(std::vector&lt;T, Alloc&gt;&amp;&amp;, const Alloc&amp;)</code>.</li>
+         *   <li>Elements are move-constructed from <code>vec</code>.</li>
+         *   <li>The allocator is captured by value in the deleter.</li>
+         * </ul>
+         *
+         * @note
+         * This overload forwards the allocator obtained from
+         * <code>vec.get_allocator()</code> to the constructor
+         * <code>runtime_arr(std::vector&lt;T, VecAlloc&gt;&amp;&amp;, const Alloc&amp;)</code>.
+         * <br>
+         * The overload is intentionally constrained with
+         * <code>std::same_as&lt;typename Alloc::value_type, T&gt;</code>.
+         * <br>
+         * Unlike <code>std::vector</code>, <code>jh::runtime_arr</code> accepts any
+         * allocator that can be rebound to <code>T</code>
+         * (via <code>std::allocator_traits::rebind_alloc</code>).<br>
+         * In contrast, most standard containers require the allocator's
+         * <code>value_type</code> to exactly match the stored element type.
+         * <br>
+         * Without this restriction the compiler could attempt to instantiate
+         * an invalid standard container such as:<br>
+         * <code>jh::runtime_arr&lt;int, std::allocator&lt;double&gt;&gt;</code> (valid)
+         * <br>
+         * <code>std::vector&lt;int, std::allocator&lt;double&gt;&gt;</code> (ill-formed).
+         * <br>
+         * The constraint therefore ensures that this convenience overload is only
+         * enabled when the allocator used by the source vector is itself valid for
+         * <code>std::vector&lt;T&gt;</code>.
+         */
+        runtime_arr(std::vector<T, Alloc> &&vec) requires
+        (!typed::monostate_t<Alloc> &&
+         !std::is_same_v<T, bool> &&
+         std::same_as<typename Alloc::value_type, T>)
+                : runtime_arr(std::move(vec), vec.get_allocator()) {}
+
+        /**
          * @brief Constructs a <code>runtime_arr&lt;T&gt;</code> from any valid forward iterator range.
+         *
          * @tparam ForwardIt Iterator type satisfying <code>jh::concepts::forward_iterator</code>.
          * @param first Beginning of the input range.
          * @param last End of the input range.
@@ -668,23 +769,60 @@ namespace jh {
          * <ul>
          *   <li>Enabled only when <code>Alloc == typed::monostate</code> and
          *       <code>T</code> is copy-constructible.</li>
-         *   <li>Allocates a contiguous buffer large enough to hold
-         *       <code>std::distance(first, last)</code> elements.</li>
-         *   <li>Copies (or moves, if wrapped with <code>std::make_move_iterator</code>)
-         *       elements from the source range into internal storage.</li>
-         *   <li>Ownership is managed via RAII (<code>std::unique_ptr</code> with custom deleter).</li>
+         *   <li>Elements in the range <code>[first, last)</code> are first materialized
+         *       into a temporary <code>std::vector&lt;T&gt;</code>.</li>
+         *   <li>The resulting vector is then moved into the resulting
+         *       <code>runtime_arr</code>.</li>
+         *   <li>Ownership of the final storage is managed via RAII
+         *       (<code>std::unique_ptr</code> with custom deleter).</li>
          * </ul>
          *
          * <strong>Behavior</strong>
          * <ul>
-         *   <li>If the range is empty, the resulting array is empty (<code>size() == 0</code>).</li>
-         *   <li>If <code>std::distance(first, last) &lt; 0</code>, an
-         *       <code>std::invalid_argument</code> exception is thrown.</li>
-         *   <li>Otherwise, <code>new[]</code> is used to allocate storage and
-         *       <code>std::copy()</code> (or <code>std::move()</code>) to fill it.</li>
+         *   <li>If the range is empty, the resulting array is empty
+         *       (<code>size() == 0</code>).</li>
+         *   <li>Element transfer follows the semantics of
+         *       <code>std::vector(first, last)</code>.</li>
+         *   <li>If iterators are wrapped with <code>std::make_move_iterator</code>,
+         *       elements are moved rather than copied.</li>
          * </ul>
          *
+         * @note
+         * This constructor requires <code>jh::concepts::forward_iterator</code>,
+         * which is intentionally slightly more permissive than
+         * <code>std::forward_iterator</code>. The requirement guarantees that the
+         * iterator range can be traversed multiple times without consuming the
+         * sequence.
+         * <br>
+         * Internally, a temporary <code>std::vector&lt;T&gt;</code> is used as a
+         * <em>semantic container</em> to delegate iterator handling, allocation,
+         * and exception safety to the standard library implementation.
+         * <br>
+         * In practice this temporary object is typically constructed directly in
+         * the caller's stack frame due to copy elision / NRVO, so no additional
+         * materialization step is introduced beyond what the vector constructor
+         * already performs.
+         *
+         * @warning
+         * The validity rules for the iterator range are identical to those of
+         * <code>std::vector(ForwardIt, ForwardIt)</code>.
+         * <br>
+         * If the range <code>[first, last)</code> is invalid (for example,
+         * <code>first</code> logically appears after <code>last</code>), the behavior
+         * is <b>undefined</b>.
+         * <br>
+         * No explicit <code>std::distance()</code> check is performed in order to
+         * avoid introducing an additional traversal of the range. Whether the
+         * distance is evaluated, validated, or inferred depends entirely on the
+         * internal strategy chosen by the standard library implementation for the
+         * detected iterator category.
+         * <br>
+         * This mirrors the behavior of <code>std::vector</code>, where some iterator
+         * categories may trigger a distance computation while others are processed
+         * in a single-pass insertion loop.
+         *
          * <strong>Examples</strong>
+         *
          * <p><strong>From STL containers:</strong></p>
          * @code
          * std::vector&lt;int&gt; v = {1, 2, 3};
@@ -693,58 +831,77 @@ namespace jh {
          * std::deque&lt;int&gt; d = {4, 5, 6};
          * jh::runtime_arr&lt;int&gt; b(d.begin(), d.end());   // copy
          *
-         * std::string s = "Hello, world!";
+         * std::string s = "Hello";
          * jh::runtime_arr&lt;char&gt; chars(
          *     std::make_move_iterator(s.begin()),
-         *     std::make_move_iterator(s.end()));        // moves underlying characters
+         *     std::make_move_iterator(s.end()));        // moves characters
          * @endcode
          *
          * <p><strong>From other iterator sources:</strong></p>
          * @code
-         * // Construct from raw array range
          * int raw[] = {10, 20, 30, 40};
          * jh::runtime_arr&lt;int&gt; arr(std::begin(raw), std::end(raw));
          *
-         * // Construct from std::span
          * std::span&lt;int&gt; sp(raw);
          * jh::runtime_arr&lt;int&gt; arr2(sp.begin(), sp.end());
          * @endcode
          *
          * <p>
-         * Applicable to any iterator pair that defines a finite, measurable range &mdash;
-         * e.g., pointers, container iterators, or spans.
-         * <strong>Single-pass input iterators</strong> (like <code>std::istream_iterator</code>)
-         * are <b>not supported</b>, since <code>std::distance()</code> requires
-         * multiple passes to compute the range size.
+         * Applicable to any iterator pair that defines a finite range, including
+         * pointers, container iterators, and spans.
+         * <strong>Single-pass input iterators</strong> (such as
+         * <code>std::istream_iterator</code>) are not supported, since this
+         * constructor requires forward-iterable ranges.
          * </p>
          *
          * <strong>Design rationale</strong>
          * <ul>
-         *   <li>This constructor acts as a <b>universal range importer</b>,
-         *       supporting all standard forward-iterable containers and algorithms.</li>
-         *   <li>It mirrors <code>std::vector(ForwardIt, ForwardIt)</code> semantics,
-         *       but without reallocation or capacity growth.</li>
-         *   <li>Using <code>jh::concepts::forward_iterator</code> ensures that
-         *       <code>std::distance()</code> is non-destructive and efficient.</li>
-         *   <li>When used with <code>std::make_move_iterator</code>,
-         *       move-constructible elements are efficiently transferred without extra copies.</li>
+         *   <li>This constructor acts as a <b>universal range importer</b> for
+         *       forward-iterable sources.</li>
+         *   <li>Using <code>std::vector</code> as an intermediate layer delegates
+         *       iterator handling, move semantics, and exception safety to the
+         *       standard library.</li>
+         *   <li>The final <code>runtime_arr</code> is constructed by moving the
+         *       temporary vector, avoiding manual range-copy logic.</li>
          * </ul>
          */
         template<typename ForwardIt>
-        runtime_arr(ForwardIt first, ForwardIt last) requires (typed::monostate_t<Alloc> &&
-                                                               jh::concepts::forward_iterator<ForwardIt> &&
-                                                               std::convertible_to<typename ForwardIt::value_type, value_type> &&
-                                                               std::is_copy_constructible_v<T>)
-                : data_(nullptr, default_deleter) {
-            const auto dist = std::distance(first, last);
+        runtime_arr(ForwardIt first, ForwardIt last) requires
+        (jh::concepts::forward_iterator<ForwardIt> &&
+         (typed::monostate_t<Alloc> || std::default_initializable<Alloc>)
+        ) {
+            std::vector<T> tmp(first, last);
 
-            if (dist < 0)
-                throw std::invalid_argument("Invalid iterator range");
-            size_ = static_cast<std::uint64_t>(dist);
+            if constexpr (typed::monostate_t<Alloc>) {
+                *this = runtime_arr(std::move(tmp));
+            } else {
+                *this = runtime_arr(std::move(tmp), Alloc{});
+            }
+        }
 
-            T *ptr = new T[size_];
-            std::copy(first, last, ptr);
-            data_.reset(ptr);
+        /**
+         * @brief Constructs a runtime array from a forward iterator range using a custom allocator.
+         *
+         * @tparam ForwardIt Forward iterator type.
+         * @param first Beginning of range.
+         * @param last  End of range.
+         * @param alloc Allocator instance used for allocation.
+         *
+         * <ul>
+         *   <li>Enabled only when <code>Alloc != typed::monostate</code>.</li>
+         *   <li>Allocates using the provided allocator.</li>
+         *   <li>Copies elements from the iterator range.</li>
+         * </ul>
+         */
+        template<typename ForwardIt>
+        runtime_arr(ForwardIt first, ForwardIt last, const Alloc &alloc) requires
+        (!typed::monostate_t<Alloc> &&
+         jh::concepts::forward_iterator<ForwardIt> && requires
+                 (ForwardIt f, ForwardIt l) {
+            std::vector<T>(f, l);
+        }) {
+            std::vector<T> tmp(first, last);
+            *this = runtime_arr(std::move(tmp), alloc);
         }
 
         /// @brief Returns iterator to the beginning.
@@ -1126,12 +1283,28 @@ namespace jh {
          * </ul>
          */
         struct bool_flat_alloc final {
-            /// @brief Allocate <code>n</code> bytes for a <code>bool</code> array (non-packed form).
-            static bool *allocate(std::uint64_t n) { return new bool[n]; }
 
-            /// @brief Deallocate a previously allocated <code>bool</code> array.
-            /// @note Parameter <code>p</code> must not be <code>const</code> &mdash; <code>delete[] const bool*</code> is undefined behavior.
-            static void deallocate(bool *p, std::uint64_t) { delete[] p; } // NOLINT
+            using value_type = bool;
+
+            bool_flat_alloc() = default;
+
+            template<class U> requires (std::same_as<U, bool>)
+            struct rebind {
+                using other = bool_flat_alloc;
+            };
+
+            [[nodiscard]] bool *allocate(std::size_t n) // NOLINT
+            {
+                return new bool[n];
+            }
+
+            void deallocate(bool *p, std::size_t) noexcept // NOLINT
+            {
+                delete[] p;
+            }
+
+            // allocator equality (stateless allocator)
+            bool operator==(const bool_flat_alloc &) const noexcept = default;
         };
 
     } // namespace runtime_arr_helper
@@ -1617,8 +1790,9 @@ namespace jh {
          * </ul>
          */
         template<typename ForwardIt>
-        runtime_arr(ForwardIt first, ForwardIt last) requires (jh::concepts::forward_iterator<ForwardIt> &&
-                                                               std::convertible_to<typename ForwardIt::value_type, value_type>) {
+        runtime_arr(ForwardIt first, ForwardIt last) requires
+        (jh::concepts::forward_iterator<ForwardIt> &&
+         std::convertible_to<typename ForwardIt::value_type, value_type>) {
             const auto dist = std::distance(first, last);
             if (dist < 0) throw std::invalid_argument("Invalid iterator range");
             size_ = static_cast<std::uint64_t>(dist);

--- a/include/jh/detail/uri_common.h
+++ b/include/jh/detail/uri_common.h
@@ -1,0 +1,199 @@
+/**
+ * @copyright
+ * Copyright 2025 JeongHan-Bae &lt;mastropseudo\@gmail.com&gt;
+ * <br>
+ * Licensed under the Apache License, Version 2.0 (the "License"); <br>
+ * you may not use this file except in compliance with the License.<br>
+ * You may obtain a copy of the License at<br>
+ * <br>
+ *     http://www.apache.org/licenses/LICENSE-2.0<br>
+ * <br>
+ * Unless required by applicable law or agreed to in writing, software<br>
+ * distributed under the License is distributed on an "AS IS" BASIS,<br>
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br>
+ * See the License for the specific language governing permissions and<br>
+ * limitations under the License.<br>
+ * <br>
+ * Full license: <a href="https://github.com/JeongHan-Bae/JH-Toolkit?tab=Apache-2.0-1-ov-file#readme">GitHub</a>
+ */
+/**
+ * @file uri_common.h
+ * @author JeongHan-Bae
+ * <a href="mailto:mastropseudo&#64;gmail.com">&lt;mastropseudo\@gmail.com&gt;</a>
+ * @brief Internal URI percent-encoding utilities and lookup tables.
+ *
+ * <p>
+ * This file provides the core low-level utilities used by the URI encoding
+ * and decoding implementation. It defines <code>constexpr</code> lookup tables,
+ * compile-time safe generators, and low-level unchecked encode/decode routines
+ * designed for high performance and predictable behavior.
+ * </p>
+ *
+ * <p>
+ * The utilities here implement the internal mechanics of percent-encoding
+ * as defined by URI standards. Characters not classified as valid URI
+ * characters are transformed into their <code>\%HH</code> hexadecimal
+ * representation during encoding, and decoded back to raw bytes during
+ * decoding.
+ * </p>
+ *
+ * <p><strong>Notes:</strong></p>
+ * <ul>
+ *   <li>This file is <strong>an internal component</strong>, <strong>not intended for external use</strong>.</li>
+ *   <li>All functions are declared with <code>constexpr</code> and <code>noexcept</code>,
+ *       allowing the compiler to perform aggressive optimization and
+ *       compile-time evaluation when possible.</li>
+ *   <li>Lookup tables are generated using <code>consteval</code> to guarantee
+ *       compile-time construction and eliminate runtime initialization cost.</li>
+ *   <li>All internal callers must guarantee input validity before invoking
+ *       these functions, ensuring no out-of-bound memory access and strict
+ *       semantic correctness.</li>
+ *   <li>The <code>size</code> arguments always represent
+ *       <strong>actual, valid buffer lengths</strong>.</li>
+ * </ul>
+ *
+ * <p><strong>Warning:</strong></p>
+ * <ul>
+ *   <li>External users must not directly include or invoke any interface
+ *       declared in this file.</li>
+ *   <li>The internal behavior and ABI may change without notice.</li>
+ *   <li>Direct use of these functions outside the intended internal
+ *       call chain is considered <strong>undefined behavior (UB)</strong>.</li>
+ * </ul>
+ *
+ * @version <pre>1.4.1</pre>
+ * @date <pre>2025</pre>
+ */
+
+
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+#include "jh/metax/char.h"
+#include "jh/pods/array.h"
+
+namespace jh::detail::uri_common {
+
+    static constexpr jh::pod::array hex_encode_table = {"0123456789ABCDEF"};
+
+    consteval jh::pod::array<std::uint8_t, 256> make_hex_decode_table() {
+        jh::pod::array<std::uint8_t, 256> t{};
+
+        for (std::size_t i = 0; i < 256; ++i)
+            t[i] = 0xFF;
+
+        for (std::size_t i = 0; i < 10; ++i)
+            t[static_cast<std::size_t>('0') + i] = static_cast<std::uint8_t>(i);
+
+        for (std::size_t i = 0; i < 6; ++i) {
+            t[static_cast<std::size_t>('A') + i] = static_cast<std::uint8_t>(10 + i);
+            t[static_cast<std::size_t>('a') + i] = static_cast<std::uint8_t>(10 + i);
+        }
+
+        return t;
+    }
+
+    static constexpr auto hex_decode_table = make_hex_decode_table();
+
+    template<jh::meta::any_char Char>
+    constexpr std::uint64_t calculate_encoded_length(const Char *src, std::uint64_t n) noexcept {
+        std::uint64_t non_uri_count = 0;
+
+        for (std::uint64_t i = 0; i < n; ++i) {
+            if (!jh::meta::is_uri_char(src[i]))
+                ++non_uri_count;
+        }
+
+        return n + 2 * non_uri_count;
+    }
+
+    template<jh::meta::any_char Char>
+    constexpr void uri_encode_unchecked(
+            const Char *src, std::uint64_t n,
+            std::uint8_t *dst, std::uint64_t m
+    ) noexcept {
+        std::uint64_t j = 0;
+
+        for (std::uint64_t i = 0; i < n; ++i) {
+            const Char c = src[i];
+
+            if (jh::meta::is_uri_char(c)) {
+                if (j < m)
+                    dst[j++] = static_cast<std::uint8_t>(c);
+            } else {
+                if (j + 3 <= m) {
+                    dst[j++] = '%';
+
+                    const auto encoded = static_cast<std::uint8_t>(c);
+
+                    dst[j++] = static_cast<std::uint8_t>(
+                            hex_encode_table[(encoded >> 4) & 0x0F]);
+
+                    dst[j++] = static_cast<std::uint8_t>(
+                            hex_encode_table[encoded & 0x0F]);
+                }
+            }
+        }
+    }
+
+    template<jh::meta::any_char Char>
+    constexpr std::uint64_t calculate_decoded_length(const Char *src, std::uint64_t n) noexcept {
+        std::uint64_t percent_count = 0;
+
+        for (std::uint64_t i = 0; i < n; ++i) {
+            const Char c = src[i];
+
+            if (c == '%') {
+                if (i + 2 >= n)
+                    return static_cast<std::uint64_t>(-1);
+
+                if (jh::meta::is_hex_char(src[i + 1]) &&
+                    jh::meta::is_hex_char(src[i + 2])) {
+
+                    ++percent_count;
+                    i += 2;
+                } else {
+                    return static_cast<std::uint64_t>(-1);
+                }
+            } else if (!jh::meta::is_uri_char(c)) {
+                return static_cast<std::uint64_t>(-1);
+            }
+        }
+
+        return n - 2 * percent_count;
+    }
+
+    template<jh::meta::any_char Char>
+    constexpr void uri_decode_unchecked(
+            const Char *src, std::uint64_t n,
+            std::uint8_t *dst, std::uint64_t m
+    ) noexcept {
+        std::uint64_t j = 0;
+
+        for (std::uint64_t i = 0; i < n; ++i) {
+            const Char c = src[i];
+
+            if (c == '%') {
+                if (i + 2 < n) {
+                    const auto hi =
+                            hex_decode_table[static_cast<std::uint8_t>(src[i + 1])];
+                    const auto lo =
+                            hex_decode_table[static_cast<std::uint8_t>(src[i + 2])];
+
+                    const auto decoded =
+                            static_cast<std::uint8_t>((hi << 4) | lo);
+
+                    if (j < m)
+                        dst[j++] = decoded;
+
+                    i += 2;
+                }
+            } else {
+                if (j < m)
+                    dst[j++] = static_cast<std::uint8_t>(c);
+            }
+        }
+    }
+
+} // namespace jh::detail::uri_common

--- a/include/jh/macros/platform.h
+++ b/include/jh/macros/platform.h
@@ -78,9 +78,13 @@
 
 #if defined(__GNUC__) && !defined(__clang__)
   #define IS_GCC 1
+  #define JH_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 #else
   #define IS_GCC 0
+  #define JH_GCC_VERSION 0
 #endif
+
+#define JH_GCC_LE_13 (IS_GCC && JH_GCC_VERSION < 140000)
 
 #if defined(_MSC_VER) && !defined(__clang__) && !defined(__GNUC__)
   #define IS_MSVC 1

--- a/include/jh/metax/adl_apply.h
+++ b/include/jh/metax/adl_apply.h
@@ -20,8 +20,7 @@
  * @file adl_apply.h
  * @brief ADL-enabled universal tuple application utility &mdash; extends <code>std::apply</code>
  *        to arbitrary tuple-like structures, including user-defined proxies and view elements.
- * @author
- *   JeongHan-Bae &lt;mastropseudo&#64;gmail.com&gt;
+ * @author JeongHan-Bae <a href="mailto:mastropseudo&#64;gmail.com">&lt;mastropseudo\@gmail.com&gt;</a>
  *
  * <p>
  * The <code>jh::meta::adl_apply</code> function is a generalized alternative to

--- a/include/jh/metax/char.h
+++ b/include/jh/metax/char.h
@@ -20,8 +20,7 @@
  * @file char.h
  * @brief Character-semantics concept and utilities &mdash; constexpr-safe character classification
  *        and transformation for 1-byte fundamental types.
- * @author
- *   JeongHan-Bae &lt;mastropseudo&#64;gmail.com&gt;
+ * @author JeongHan-Bae <a href="mailto:mastropseudo&#64;gmail.com">&lt;mastropseudo\@gmail.com&gt;</a>
  *
  * <p>
  * This header defines <code>jh::meta::any_char</code>, a C++20 concept identifying
@@ -175,7 +174,7 @@ namespace jh::meta {
 
     /// @brief Check if character is ASCII.
     template<any_char Char>
-    [[nodiscard]] static constexpr bool is_ascii(Char c) noexcept {
+    [[nodiscard]] constexpr bool is_ascii(Char c) noexcept {
         auto uc = static_cast<unsigned char>(c);
         return uc < 128;
     }
@@ -187,9 +186,16 @@ namespace jh::meta {
         return true;
     }
 
+    /// @brief Check if character is a valid URI character (unencoded).
+    template<any_char Char>
+    [[nodiscard]] constexpr bool is_uri_char(Char c) noexcept {
+        return is_alpha(c) || is_digit(c) ||
+               c == '-' || c == '.' || c == '_' || c == '~';
+    }
+
     /// @brief Validate ASCII: reject control chars and DEL, leave non-ASCII untouched.
     template<any_char Char>
-    [[nodiscard]] static constexpr bool is_valid_char(Char c) noexcept {
+    [[nodiscard]] constexpr bool is_valid_char(Char c) noexcept {
         auto uc = static_cast<unsigned char>(c);
         return !(uc < 32 || uc == 127);
     }

--- a/include/jh/metax/lookup_map.h
+++ b/include/jh/metax/lookup_map.h
@@ -281,7 +281,7 @@ namespace jh::meta {
              * @brief Convert jh::immutable_str.
              * @param s Source immutable string.
              */
-            [[maybe_unused]] static constexpr canonical_type to_canonical(const jh::immutable_str &s) noexcept {
+            [[maybe_unused]] static canonical_type to_canonical(const jh::immutable_str &s) noexcept {
                 return s.pod_view();
             }
 

--- a/include/jh/metax/lookup_map.h
+++ b/include/jh/metax/lookup_map.h
@@ -37,6 +37,152 @@
  *   <li>binary search on sorted hashes</li>
  *   <li>POD optimization into read-only memory</li>
  * </ul>
+ *
+ * <h4>Eliminating hash-switch boilerplate</h4>
+ * <p>
+ * A common pattern in large systems is manual hash-dispatch:
+ * </p>
+ *
+ * @code
+ * auto h = hash(input);
+ * switch (h) {
+ * case HASH_A:
+ *     if (input == A) { ... }
+ *     break;
+ * case HASH_B:
+ *     if (input == B) { ... }
+ *     break;
+ * }
+ * @endcode
+ *
+ * <p>
+ * This pattern duplicates hashing logic, requires manual collision guards,
+ * scatters string or object comparisons across branches, and grows linearly
+ * in maintenance cost as the number of cases increases.
+ * </p>
+ *
+ * <p>
+ * lookup_map removes this entire category of boilerplate. The table stores
+ * precomputed hashes and performs structured binary search followed by
+ * equality verification. The user never writes manual hash constants or
+ * collision checks.
+ * </p>
+ *
+ * <h4>Recommended architectural pattern</h4>
+ * <p>
+ * The container is intended to enforce a disciplined flow:
+ * </p>
+ *
+ * <ol>
+ *   <li>Normalize external input into a lightweight View type.</li>
+ *   <li>Use <code>lookup_map</code> with<code>&lt;TypeView, CommandEnum&gt;</code> for mapping.</li>
+ *   <li>Dispatch using CommandEnum in a centralized switch.</li>
+ * </ol>
+ *
+ * <p>
+ * For complex input types, define a corresponding TypeView. The View should:
+ * </p>
+ *
+ * <ul>
+ *   <li>Be lightweight and non-owning.</li>
+ *   <li>Represent only the identifying portion of the object.</li>
+ *   <li>Be hashable via <code>jh::hash&lt;TypeView&gt;</code>.
+ *   <br>
+ *   (The deduction is <code>std::hash&lt;T&gt;{}(t)</code> > ADL <code>hash(t)</code> >
+ *   no-param <code>t.hash()</code>, at least one should be provided for the View type.)
+ *   </li>
+ * </ul>
+ *
+ * <p>
+ * Then provide normalization through the extension layer:
+ * </p>
+ *
+ * @code
+ * struct TypeView { ... };
+ * // operator== and hash support for TypeView
+ *
+ * template&lt;&gt;
+ * struct key_traits&lt;TypeView&gt; {
+ *     using canonical_type = TypeView;
+ *     using apparent_type  = const Type &;
+ *
+ *     static constexpr TypeView
+ *     to_canonical(const Type & obj) noexcept {
+ *         return make_view(obj);
+ *     }
+ * };
+ * @endcode
+ *
+ * <p>
+ * After normalization, the mapping becomes purely structural:
+ * </p>
+ *
+ * @code
+ * constexpr auto table =
+ *     make_lookup_map&lt;HashMethod&gt;(
+ *     std:array{
+ *         std::pair{TypeView{...}, CommandEnum::A},
+ *         std::pair{TypeView{...}, CommandEnum::B},
+ *         ...
+ *         },
+ *         CommandEnum::UNKNOWN // Default
+ *     );
+ * @endcode
+ *
+ * If <code>jh::hash&lt;TypeView&gt;</code> can be deduced and is constexpr-safe,
+ * omit the HashMethod template argument:
+ *
+ * @code
+ * constexpr auto table =
+ *     make_lookup_map(
+ *     std:array{
+ *         std::pair{TypeView{...}, CommandEnum::A},
+ *         std::pair{TypeView{...}, CommandEnum::B},
+ *         ...
+ *         },
+ *         CommandEnum::UNKNOWN // Default
+ *     );
+ * @endcode
+ *
+ * Finally,
+ *
+ * @code
+ * CommandEnum cmd = table[input_object];
+ *
+ * switch (cmd) {
+ *     case CommandEnum::A:
+ *         handle_A(...);
+ *         break;
+ *     case CommandEnum::B:
+ *         handle_B(...);
+ *         break;
+ *     ...
+ *     case CommandEnum::UNKNOWN:
+ *     default:
+ *         handle_unknown(...);
+ *         break;
+ * }
+ * @endcode
+ *
+ * <h4>Philosophy</h4>
+ * <p>
+ * The goal is not to provide a generic container, but to formalize a
+ * deterministic dispatch pipeline:
+ * </p>
+ *
+ * <pre>External input
+ *     ->
+ * View normalization
+ *     ->
+ * Static mapping to CommandEnum
+ *     ->
+ * Centralized switch dispatch</pre>
+ *
+ * <p>
+ * This separates parsing from behavior, removes repetitive hash-switch
+ * patterns, reduces maintenance overhead, and encourages strongly typed
+ * dispatch instead of string-driven branching.
+ * </p>
  */
 
 #pragma once
@@ -49,8 +195,10 @@
 #include <string>
 #include <string_view>
 #include <cstddef>
+#include <cstdint>
 #include "jh/pods/array.h"
 #include "jh/pods/string_view.h"
+#include "jh/core/immutable_str.h"
 #include "jh/conceptual/hashable.h"
 #include "jh/metax/t_str.h"
 
@@ -107,7 +255,7 @@ namespace jh::meta {
              * @tparam N Literal length.
              * @param lit Null-terminated literal.
              */
-            template<size_t N>
+            template<std::size_t N>
             static constexpr canonical_type to_canonical(const char (&lit)[N]) noexcept {
                 return jh::pod::string_view::from_literal(lit);
             }
@@ -130,13 +278,21 @@ namespace jh::meta {
             }
 
             /**
+             * @brief Convert jh::immutable_str.
+             * @param s Source immutable string.
+             */
+            [[maybe_unused]] static constexpr canonical_type to_canonical(const jh::immutable_str &s) noexcept {
+                return s.pod_view();
+            }
+
+            /**
              * @brief Convert compile-time t_str literal.
              * @tparam N Size of t_str literal.
              * @param v Source t_str.
              */
-            template<uint16_t N>
+            template<std::uint16_t N>
             [[maybe_unused]] static constexpr canonical_type to_canonical(const jh::meta::t_str<N> &v) noexcept {
-                return {v.val(), v.size()};
+                return v.pod_view();
             }
 
             /**
@@ -233,15 +389,15 @@ namespace jh::meta {
      * @tparam K Canonical key type stored in the map.
      * @tparam V Value type associated with each key.
      * @tparam N Number of stored entries.
-     * @tparam Hash Hash functor producing <code>size_t</code>.
+     * @tparam Hash Hash functor producing <code>std::size_t</code>.
      *
      * @note Prefer compile-time construction with lightweight POD keys or full-lifetime
      *       string-view literals (e.g. <code>"..."_psv</code>) to ensure zero-overhead
      *       canonical conversions through <code>key_traits</code>.
      * </ul>
      */
-    template<typename K, typename V, size_t N, typename Hash> requires requires(K k) {
-        { Hash{}(k) } -> std::convertible_to<size_t>;
+    template<typename K, typename V, std::size_t N, typename Hash> requires requires(K k) {
+        { Hash{}(k) } -> std::convertible_to<std::size_t>;
     }
     struct lookup_map final {
 
@@ -252,7 +408,7 @@ namespace jh::meta {
          * Contains precomputed hash, the canonical key, and its associated value.
          */
         struct entry final {
-            size_t hash; ///< Precomputed hash.
+            std::size_t hash; ///< Precomputed hash.
             K key;       ///< Canonical key.
             V value;     ///< Stored value.
 
@@ -260,13 +416,13 @@ namespace jh::meta {
 
             constexpr bool operator==(const entry &rhs) const noexcept { return hash == rhs.hash; }
 
-            friend constexpr bool operator<(const entry &lhs, size_t rhs_hash) noexcept { return lhs.hash < rhs_hash; }
+            friend constexpr bool operator<(const entry &lhs, std::size_t rhs_hash) noexcept { return lhs.hash < rhs_hash; }
 
-            friend constexpr bool operator<(size_t lhs_hash, const entry &rhs) noexcept { return lhs_hash < rhs.hash; }
+            friend constexpr bool operator<(std::size_t lhs_hash, const entry &rhs) noexcept { return lhs_hash < rhs.hash; }
         };
 
-        static constexpr size_t entry_size = sizeof(entry);
-        static constexpr size_t total_size = entry_size * N;
+        static constexpr std::size_t entry_size = sizeof(entry);
+        static constexpr std::size_t total_size = entry_size * N;
 
         /**
          * @brief Storage type selected based on POD suitability.
@@ -305,13 +461,13 @@ namespace jh::meta {
                                       Hash hasher = {})
                 : entries({}), default_value(default_val) {
             if (std::is_constant_evaluated()) {
-                for (size_t i = 0; i < N; ++i)
+                for (std::size_t i = 0; i < N; ++i)
                     entries[i] = entry{hasher(init[i].first),
                                        (init[i].first),
                                        (init[i].second)};
 
-                for (size_t i = 0; i < N; ++i)
-                    for (size_t j = i + 1; j < N; ++j)
+                for (std::size_t i = 0; i < N; ++i)
+                    for (std::size_t j = i + 1; j < N; ++j)
                         if (entries[j].hash < entries[i].hash)
                             std::swap(entries[i], entries[j]);
             } else {
@@ -335,11 +491,11 @@ namespace jh::meta {
          * <code>std::lower_bound</code>.
          * </p>
          */
-        [[nodiscard]] constexpr size_t lower_bound_hash(size_t h) const noexcept {
+        [[nodiscard]] constexpr std::size_t lower_bound_hash(std::size_t h) const noexcept {
             if (std::is_constant_evaluated()) {
-                size_t l = 0, r = N;
+                std::size_t l = 0, r = N;
                 while (l < r) {
-                    size_t mid = (l + r) / 2;
+                    std::size_t mid = (l + r) / 2;
                     if (entries[mid].hash < h)
                         l = mid + 1;
                     else
@@ -349,10 +505,10 @@ namespace jh::meta {
             } else {
                 auto it = std::lower_bound(
                         entries.begin(), entries.end(), h,
-                        [](auto const &e, size_t hash_val) {
+                        [](auto const &e, std::size_t hash_val) {
                             return e.hash < hash_val;
                         });
-                return static_cast<size_t>(it - entries.begin());
+                return static_cast<std::size_t>(it - entries.begin());
             }
         }
 
@@ -371,10 +527,10 @@ namespace jh::meta {
             using traits = jh::meta::extension::key_traits<K>;
             Hash hasher{};
             auto key = traits::to_canonical(std::forward<KeyIn>(key_in));
-            size_t h = hasher(key);
+            std::size_t h = hasher(key);
 
-            size_t pos = lower_bound_hash(h);
-            for (size_t i = pos; i < N && entries[i].hash == h; ++i)
+            std::size_t pos = lower_bound_hash(h);
+            for (std::size_t i = pos; i < N && entries[i].hash == h; ++i)
                 if (entries[i].key == key)
                     return entries[i].value;
 
@@ -441,7 +597,7 @@ namespace jh::meta {
      * @tparam N Entry count.
      */
     template<typename Hash, typename K, typename V, std::size_t N> requires requires(K k) {
-        { Hash{}(k) } -> std::convertible_to<size_t>;
+        { Hash{}(k) } -> std::convertible_to<std::size_t>;
     }
     lookup_map(std::array<std::pair<K, V>, N> &&, V, Hash)
     -> lookup_map<K, V, N, Hash>;
@@ -467,7 +623,7 @@ namespace jh::meta {
      * <h4>Usage example</h4>
      * @code
      * struct MyHash {
-     *     constexpr size_t operator()(KeyType k) const noexcept {
+     *     constexpr std::size_t operator()(KeyType k) const noexcept {
      *         return ...; // constexpr-capable hashing
      *     }
      * };
@@ -495,7 +651,7 @@ namespace jh::meta {
      */
     template<typename Hash, typename K, typename V, std::size_t N>
     requires requires(K k) {
-        { Hash{}(k) } -> std::convertible_to<size_t>;
+        { Hash{}(k) } -> std::convertible_to<std::size_t>;
     }
     consteval auto make_lookup_map(
             const std::array<std::pair<K, V>, N> &init,

--- a/include/jh/metax/lookup_map.h
+++ b/include/jh/metax/lookup_map.h
@@ -19,8 +19,7 @@
 /**
  * @file lookup_map.h
  * @brief constexpr and runtime fixed-size hash lookup table.
- * @author
- *   JeongHan-Bae &lt;mastropseudo&#64;gmail.com&gt;
+ * @author JeongHan-Bae <a href="mailto:mastropseudo&#64;gmail.com">&lt;mastropseudo\@gmail.com&gt;</a>
  *
  * <h3>Overview</h3>
  * <p>

--- a/include/jh/metax/t_str.h
+++ b/include/jh/metax/t_str.h
@@ -61,12 +61,12 @@
 #pragma once
 
 #include <utility>
+#include <string>
 #include <string_view>
 #include <cstdint>
 #include "jh/pods/array.h"
 #include "jh/pods/string_view.h"
 #include "jh/metax/hash.h"
-#include "jh/detail/base64_common.h"
 
 namespace jh::meta {
     namespace detail {
@@ -75,6 +75,14 @@ namespace jh::meta {
 
         template<std::uint16_t N, std::uint16_t M>
         concept t_str_concat_legal = ((N - 1) + (M - 1) + 1 <= jh::pod::max_pod_array_bytes);
+
+        /// Check if a character is valid in a POSIX relative path.
+        consteval bool is_path_char(char c) noexcept {
+            return (c >= 'A' && c <= 'Z') ||
+                   (c >= 'a' && c <= 'z') ||
+                   (c >= '0' && c <= '9') ||
+                   c == '_' || c == '-' || c == '.' || c == '/';
+        }
     } // namespace detail
 
     /**
@@ -111,6 +119,7 @@ namespace jh::meta {
         /// @brief build from underlying buffer
         constexpr explicit t_str(const jh::pod::array<char, N> &arr) noexcept
                 : storage(arr) {}
+
     private:
 
         static constexpr jh::pod::array<char, N> make_array(const char(&src)[N]) {
@@ -138,8 +147,28 @@ namespace jh::meta {
          * It enables string literals to be passed directly
          * as non-type template parameters (NTTP) without requiring
          * additional wrappers.
+         *
+         * @note
+         * A user-defined literal such as <code>"..."_ts</code>
+         * cannot be supported due to a fundamental language limitation.
+         * <br>
+         * In C++, a user-defined literal operator receives
+         * <code>const char*</code> (and a length), but it cannot
+         * encode that length as a template argument <code>N</code>.
+         * <br>
+         * Since <code>t_str&lt;N&gt;</code> requires the string size
+         * (including the null terminator) to be part of the type,
+         * the size must be preserved at the type level.
+         * <br>
+         * Only a reference to a string literal
+         * <code>const char(&)[N]</code> retains the compile-time
+         * array bound required for correct template deduction.
+         * <br>
+         * Therefore, implicit construction from a string literal
+         * is the only fully standard and portable mechanism.
          */
-        constexpr t_str(const char(&lit)[N]) noexcept: storage(make_array(lit)) {} // NOLINT
+        constexpr t_str(const char(&lit)[N]) noexcept
+                : storage(make_array(lit)) {} // NOLINT
 
         /**
          * @brief Construct from a <code>char8_t</code>-based string literal (<code>u8""</code>).
@@ -177,6 +206,40 @@ namespace jh::meta {
          */
         [[nodiscard]] constexpr std::string_view view() const noexcept {
             return {storage.data, size()};
+        }
+
+        /**
+         * @brief Get a <code>jh::pod::string_view</code> over the stored string.
+         * @return A <code>pod::string_view</code> referencing the characters (excluding null terminator).
+         */
+        [[nodiscard]] constexpr jh::pod::string_view pod_view() const noexcept {
+            return {storage.data, size()};
+        }
+
+        /**
+         * @brief Get a <code>std::string</code> as a copy of the stored string.
+         * @return A <code>std::string</code> copying the template string.
+         *
+         * @note
+         * This function exists primarily for ergonomic reasons.
+         * When interoperating with runtime APIs that require
+         * <code>std::string</code> (e.g. concatenation or formatting),
+         * it avoids forcing users to repeatedly write:
+         *
+         * @code
+         * std::string{S.val()}
+         * std::string{S.view()}
+         * @endcode
+         *
+         * Instead, <code>S.str()</code> provides a concise and explicit
+         * conversion entry point.
+         *
+         * The function intentionally performs a copy and is meant
+         * only for runtime interop &mdash; it does not affect the
+         * compile-time nature of <code>t_str</code>.
+         */
+        [[nodiscard]] std::string str() const {
+            return std::string{view()};
         }
 
         /**
@@ -257,9 +320,7 @@ namespace jh::meta {
          * @return true if all characters are digits, false otherwise.
          */
         [[nodiscard]] constexpr bool is_digit() const noexcept {
-            for (std::uint64_t i = 0; i < size(); i++)
-                if (!jh::meta::is_digit(storage[i])) return false;
-            return true;
+            return pod_view().is_digit();
         }
 
         /**
@@ -288,47 +349,7 @@ namespace jh::meta {
          * </ul>
          */
         [[nodiscard]] constexpr bool is_number() const noexcept {
-            const std::uint64_t n = size();
-            if (n == 0) return false;
-
-            std::uint64_t i = 0;
-            if (storage[i] == '+' || storage[i] == '-') {
-                ++i;
-            }
-
-            bool has_digit = false;
-            bool seen_dot = false;
-            bool seen_exp = false;
-
-            for (; i < n; ++i) {
-                const char c = storage[i];
-
-                /// do NOT apply [[likely]] as this is constexpr
-                if (jh::meta::is_digit(c)) {
-                    has_digit = true;
-                    continue;
-                }
-
-                if (c == '.') {
-                    if (!has_digit || seen_dot || seen_exp) return false; // must have digit before '.'
-                    seen_dot = true;
-                    has_digit = false; // must see digit after '.'
-                    continue;
-                }
-
-                if (c == 'e' || c == 'E') {
-                    if (!has_digit || seen_exp) return false; // must have digit before 'e'
-                    seen_exp = true;
-                    has_digit = false; // must see digit after 'e'
-                    if (i + 1 < n && (storage[i + 1] == '+' || storage[i + 1] == '-')) {
-                        ++i; // skip optional sign after e/E
-                        // no leak risk, worst case reach '\0'
-                    }
-                    continue;
-                }
-                return false; // invalid character
-            }
-            return has_digit;
+            return pod_view().is_number();
         }
 
         /**
@@ -336,9 +357,7 @@ namespace jh::meta {
          * @return true if all characters are alphabetic, false otherwise.
          */
         [[nodiscard]] constexpr bool is_alpha() const noexcept {
-            for (std::uint64_t i = 0; i < size(); i++)
-                if (!jh::meta::is_alpha(storage[i])) return false;
-            return true;
+            return pod_view().is_alpha();
         }
 
         /**
@@ -346,9 +365,7 @@ namespace jh::meta {
          * @return true if all characters are alphanumeric, false otherwise.
          */
         [[nodiscard]] constexpr bool is_alnum() const noexcept {
-            for (std::uint64_t i = 0; i < size(); i++)
-                if (!jh::meta::is_alnum(storage[i])) return false;
-            return true;
+            return pod_view().is_alnum();
         }
 
         /**
@@ -356,19 +373,39 @@ namespace jh::meta {
          * @return true if all characters are in range 0-127, false otherwise.
          */
         [[nodiscard]] constexpr bool is_ascii() const noexcept {
-            for (std::uint64_t i = 0; i < size(); i++)
-                if (!jh::meta::is_ascii(storage[i])) return false;
-            return true;
+            return pod_view().is_ascii();
         }
 
         /**
          * @brief Check if all characters are printable 7-bit ASCII.
          * @return true if all characters are in range 32-126, false otherwise.
+         *
+         * @details
+         * Verifies that every character lies within the printable
+         * 7-bit ASCII range (decimal 32-126).
+         *
+         * @note
+         * Printable ASCII is a strict subset of 7-bit ASCII.
+         * Therefore: <code>is_printable_ascii()</code> implies <code>is_ascii()</code>
+         * <br>
+         * If this function returns true, calling @c is_ascii()
+         * again is redundant. When used inside a @c requires clause,
+         * do not combine the two checks.
+         * <br>
+         * This function only permits ASCII characters.
+         * If the intention is to validate fully printable text
+         * including multi-byte UTF-8 sequences, use @c is_legal()
+         * instead.
+         * @note
+         * @c is_legal() performs:
+         * <ul>
+         *  <li>UTF-8 structural validation</li>
+         *  <li>rejection of invalid UTF-8 byte combinations</li>
+         *  <li>rejection of illegal ASCII control characters</li>
+         * </ul>
          */
         [[nodiscard]] constexpr bool is_printable_ascii() const noexcept {
-            for (std::uint64_t i = 0; i < size(); i++)
-                if (!jh::meta::is_printable_ascii(storage[i])) return false;
-            return true;
+            return pod_view().is_printable_ascii();
         }
 
         /**
@@ -376,52 +413,7 @@ namespace jh::meta {
          * @return true if all characters are valid, false otherwise.
          */
         [[nodiscard]] constexpr bool is_legal() const noexcept {
-            std::uint64_t i = 0;
-            int remaining = 0;       // how many continuation bytes still expected
-            unsigned char lead = 0;  // last leading byte
-
-            while (i < size()) {
-                auto c = static_cast<unsigned char>(storage[i]);
-                // filter out disallowed ASCII control characters
-                if (!jh::meta::is_valid_char(static_cast<char>(c))) return false;
-                ///< constexpr, avoid using [[likely/unlikely]]
-                if (remaining == 0) {
-                    // --- leading byte ---
-                    if (c <= 0x7F) {
-                        // single-byte ASCII
-                        i++;
-                        continue;
-                    } else if (c >= 0xC2 && c <= 0xDF) {
-                        // 2-byte sequence
-                        remaining = 1;
-                        lead = c;
-                    } else if (c >= 0xE0 && c <= 0xEF) {
-                        // 3-byte sequence
-                        remaining = 2;
-                        lead = c;
-                    } else if (c >= 0xF0 && c <= 0xF4) {
-                        // 4-byte sequence
-                        remaining = 3;
-                        lead = c;
-                    } else {
-                        return false; // invalid leading byte
-                    }
-                } else {
-                    // --- continuation byte ---
-                    if ((c & 0xC0) != 0x80) return false;
-                    // special restrictions for the first continuation
-                    if (remaining == ((lead >= 0xE0 && lead <= 0xEF) ? 2 :
-                                      (lead >= 0xF0 && lead <= 0xF4) ? 3 : 1)) {
-                        if (lead == 0xE0 && (c < 0xA0 || c > 0xBF)) return false;
-                        if (lead == 0xED && (c < 0x80 || c > 0x9F)) return false;
-                        if (lead == 0xF0 && (c < 0x90 || c > 0xBF)) return false;
-                        if (lead == 0xF4 && (c < 0x80 || c > 0x8F)) return false;
-                    }
-                    remaining--;
-                }
-                i++;
-            }
-            return remaining == 0;
+            return pod_view().is_legal();
         }
 
         /**
@@ -430,10 +422,7 @@ namespace jh::meta {
          * @return true if valid hex string, false otherwise.
          */
         [[nodiscard]] constexpr bool is_hex() const noexcept {
-            if (size() % 2 != 0) return false;
-            for (std::uint64_t i = 0; i < size(); i++)
-                if (!jh::meta::is_hex_char(storage[i])) return false;
-            return true;
+            return pod_view().is_hex();
         }
 
         /**
@@ -442,7 +431,7 @@ namespace jh::meta {
          * @return true if valid Base64, false otherwise.
          */
         [[nodiscard]] constexpr bool is_base64() const noexcept {
-            return jh::detail::base64_common::is_base64(val(), size());
+            return pod_view().is_base64();
         }
 
         /**
@@ -451,7 +440,116 @@ namespace jh::meta {
          * @return true if valid Base64URL, false otherwise.
          */
         [[nodiscard]] constexpr bool is_base64url() const noexcept {
-            return jh::detail::base64_common::is_base64url(val(), size());
+            return pod_view().is_base64url();
+        }
+
+        /**
+         * @brief Validate a POSIX-style relative path at compile time.
+         *
+         * This function performs strict validation of a POSIX-style relative path.
+         * It is intended for project-internal path specifications and is designed
+         * to be evaluated at compile time.
+         *
+         * <h4>Core Constraints</h4>
+         * <ul>
+         *   <li>Length must be in range <code>[1, 128]</code>.</li>
+         *   <li>Must be a relative path (no leading <code>'/'</code>).</li>
+         *   <li>Only POSIX-style separators (<code>'/'</code>) are allowed.</li>
+         *   <li>No <code>"./"</code> segments.</li>
+         *   <li>
+         *     <code>".."</code> handling:
+         *     <ul>
+         *       <li>If <code>AllowParent == false</code> &rarr; any <code>".."</code> segment is rejected.</li>
+         *       <li>If <code>AllowParent == true</code> &rarr; leading <code>"../"</code> segments are allowed,
+         *           but:
+         *           <ul>
+         *             <li>The entire path cannot consist only of <code>"../"</code>.</li>
+         *             <li>No <code>".."</code> is permitted once normal path content begins.</li>
+         *           </ul>
+         *       </li>
+         *     </ul>
+         *   </li>
+         *   <li>Allowed characters: <code>[A-Za-z0-9_.-/]</code>.</li>
+         *   <li>Spaces and non-ASCII characters are forbidden.</li>
+         * </ul>
+         *
+         * <h4>Compile-Time Enforcement</h4>
+         * This function is intended to be used in constant evaluation contexts.
+         * It is typically combined with C++20 constraints:
+         *
+         * <p><b>Explicit form (disallow parent paths):</b></p>
+         * @code
+         * template&lt;jh::meta::TStr Path&gt;
+         *     requires(Path.template is_valid_relative_path&lt;false&gt;())
+         * struct Resource {};
+         * @endcode
+         *
+         * <p><b>Default form (equivalent to <code>&lt;false&gt;</code>):</b></p>
+         * @code
+         * template&lt;jh::meta::TStr Path&gt;
+         *     requires(Path.is_valid_relative_path())
+         * struct Resource {};
+         * @endcode
+         *
+         * Since <code>AllowParent</code> defaults to <code>false</code>,
+         * both forms are strictly equivalent.
+         *
+         * <h4>Design Rationale</h4>
+         * <ul>
+         *   <li>Only strict POSIX-style relative paths are accepted to ensure
+         *       deterministic, platform-neutral behavior.</li>
+         *   <li>Whitespace and non-ASCII characters are intentionally disallowed.
+         *       Project-internal relative paths must be explicitly and cleanly
+         *       designed, avoiding ambiguity and encoding issues.</li>
+         *   <li>This validator does not perform normalization or filesystem access.</li>
+         * </ul>
+         *
+         * <h4>Cross-Platform Note</h4>
+         * On Windows or other platforms, path composition should be performed
+         * using <code>std::filesystem</code> rather than embedding platform-specific
+         * separators:
+         *
+         * @code
+         * std::filesystem::path path =
+         *     std::filesystem::path(".") / Path.val();
+         * @endcode
+         *
+         * The validated string is treated purely as a logical POSIX-style
+         * relative path and may be combined with platform-native paths
+         * via <code>std::filesystem</code>.
+         *
+         * @tparam AllowParent Whether leading "../" segments are permitted.
+         * @return true if the path satisfies all constraints; otherwise false.
+         */
+        template<bool AllowParent = false>
+        [[nodiscard]] constexpr bool is_valid_relative_path() const noexcept {
+            if (size() < 1) return false;
+            if (size() > 128) return false;
+            if (val()[0] == '/') return false;   // absolute path forbidden
+
+            std::uint64_t i = 0;
+
+            if constexpr (AllowParent) {
+                // Allow leading "../" segments
+                while (i + 2 < size() &&
+                       val()[i] == '.' &&
+                       val()[i + 1] == '.' &&
+                       val()[i + 2] == '/') {
+                    i += 3;
+                }
+                if (i == size()) return false; // path cannot be only ../
+            }
+
+            for (; i < size(); ++i) {
+                if (!detail::is_path_char(val()[i]))
+                    return false;
+
+                // reject ".." appearing mid-path
+                if (val()[i] == '.' && i + 1 < size() && val()[i + 1] == '.')
+                    return false;
+            }
+
+            return true;
         }
 
     private:
@@ -507,8 +605,8 @@ namespace jh::meta {
          *       if <code>N != M</code>, the comparison does not even check characters.
          */
         template<std::uint16_t M>
-        constexpr bool operator==(const t_str<M> &) const noexcept
-        requires (M != N) { return false; }
+        constexpr bool operator==(const t_str<M> &) const
+        noexcept requires (M != N) { return false; }
 
         /**
          * @brief Equality comparison with another <code>t_str</code> of the same size.
@@ -555,7 +653,7 @@ namespace jh::meta {
             }
             return bytes;
         }
-        
+
         /**
          * @brief Convert to an immutable byte buffer.
          *
@@ -596,8 +694,13 @@ namespace jh::meta {
          *     <em>bytes</em> if converted back using <code>to_bytes()</code>.
          *   </li>
          * </ul>
+         * <b>Example Usage</b>:
+         * @code
+         * jh::meta::t_str&lt;bytes.size() + 1&gt;::from_bytes(bytes);
+         * // Use this form instead of an explicit size, especially when the byte array is deduced with auto.
+         * @endcode
          */
-        [[nodiscard]] static constexpr t_str from_bytes(const jh::pod::array<std::uint8_t, N - 1>& bytes) noexcept {
+        [[nodiscard]] static constexpr t_str from_bytes(const jh::pod::array<std::uint8_t, N - 1> &bytes) noexcept {
             jh::pod::array<char, N> arr{};
             if (std::is_constant_evaluated()) {
                 for (std::uint64_t i = 0; i < N - 1; ++i)

--- a/include/jh/metax/t_str.h
+++ b/include/jh/metax/t_str.h
@@ -84,6 +84,14 @@ namespace jh::meta {
                    (c >= '0' && c <= '9') ||
                    c == '_' || c == '-' || c == '.' || c == '/';
         }
+
+        template<std::uint16_t N, std::uint16_t Pos, std::uint16_t Count>
+        concept t_str_sub_legal =
+        (Pos <= N - 1) &&
+        (
+                Count == static_cast<std::uint16_t>(-1) ||
+                Count <= (N - 1 - Pos)
+        );
     } // namespace detail
 
     /**
@@ -271,6 +279,9 @@ namespace jh::meta {
             }.hash(hash_method);
         }
 
+        /// @brief Sentinel value representing "no position" or "until the end".
+        static constexpr auto npos = static_cast<std::uint16_t>(-1);
+
     private:
         /**
          * @brief Internal helper for string concatenation.
@@ -284,6 +295,56 @@ namespace jh::meta {
                     std::index_sequence<I...>, std::index_sequence<J...>) const noexcept {
             constexpr std::uint16_t NewSize = (N - 1) + (M - 1) + 1;
             jh::pod::array<char, NewSize> arr{{storage[I]..., other.storage[J]...}};
+            return t_str<NewSize>(arr);
+        }
+
+        /**
+         * @brief Internal helper for compile-time substring extraction.
+         *
+         * @tparam Pos         Starting position of the substring.
+         * @tparam ActualCount Number of characters to extract.
+         * @tparam I           Index sequence used to expand characters at compile time.
+         *
+         * @param Unused A compile-time index sequence used to unroll character access.
+         *
+         * @return A new <code>t_str&lt;ActualCount + 1&gt;</code> containing the selected
+         *         characters followed by a null terminator.
+         *
+         * @details
+         * This function performs substring construction entirely at compile time.
+         * It is invoked by <code>sub()</code>, which is responsible for validating
+         * bounds and computing the effective substring length (<code>ActualCount</code>).
+         *
+         * The implementation mirrors the design of <code>concat_impl()</code> and
+         * uses <code>std::index_sequence</code> to expand characters directly from
+         * the source storage:
+         *
+         * @code
+         * { storage[Pos + I]..., '\0' }
+         * @endcode
+         *
+         * This parameter-pack expansion generates a new null-terminated character
+         * array during compilation without loops or runtime operations.
+         *
+         * As a result, the returned <code>t_str</code> is fully constexpr and incurs
+         * zero runtime overhead.
+         *
+         * @note
+         * Bounds checking and the handling of the special substring sentinel
+         * (<code>Count == static_cast&lt;std::uint16_t&gt;(-1)</code>) are performed by
+         * the public <code>sub()</code> interface before calling this helper.
+         */
+        template<std::uint16_t Pos, std::uint16_t ActualCount, std::size_t... I>
+        [[nodiscard]] constexpr auto
+        sub_impl(std::index_sequence<I...>) const noexcept {
+
+            constexpr auto NewSize =
+                    static_cast<std::uint16_t>(ActualCount + 1);
+
+            jh::pod::array<char, NewSize> arr{
+                    {storage[Pos + I]..., '\0'}
+            };
+
             return t_str<NewSize>(arr);
         }
 
@@ -310,6 +371,133 @@ namespace jh::meta {
             return concat_impl(other,
                                std::make_index_sequence<N - 1>{},
                                std::make_index_sequence<M>{});
+        }
+
+        /**
+         * @brief Extract a substring at compile time.
+         *
+         * @tparam Pos   Starting position of the substring.
+         * @tparam Count Number of characters to extract.
+         *               If set to <code>jh::meta::t_str&lt;N&gt;::npos</code>,
+         *               the substring extends from <code>Pos</code> to the end of the string.
+         *
+         * @return A new <code>t_str</code> containing the selected characters followed
+         *         by a null terminator.
+         *
+         * @details
+         * <ul>
+         *   <li>Performs substring extraction entirely at compile time.</li>
+         *   <li>The resulting string size becomes <code>ActualCount + 1</code>
+         *       (including the null terminator).</li>
+         *   <li>The special value <code>Count = npos</code> acts as a sentinel
+         *       meaning "until the end of the string".</li>
+         *   <li>Bounds are validated using <code>t_str_sub_legal</code>.</li>
+         *   <li>No runtime allocation or loops are involved.</li>
+         * </ul>
+         *
+         * @note
+         * The returned object owns its storage, so any views obtained from it
+         * remain valid as long as the returned <code>t_str</code> object exists.
+         * <br>
+         * Use:
+         * @code
+         * constexpr auto sub_str = s.sub&lt;Pos, Count&gt;();
+         * auto v2 = sub_str.pod_view(); // same for std version .view()
+         * @endcode
+         * to ensure the substring's storage is preserved for the view.
+         * or use:
+         * @code
+         * auto v1 = s.sub_pod_view&lt;Pos, Count&gt;();
+         * // same for std version .sub_view&lt;Pos, Count&gt;();
+         * @endcode
+         * to get a view directly without creating a new <code>t_str</code> object.
+         * <br>
+         * Anything like:
+         * <br>
+         * <code>s.sub&lt;Pos, Count&gt;().pod_view()</code> is valid but creates a temporary
+         * <code>t_str</code> that may lead to dangling views if not used carefully.
+         */
+        template<std::uint16_t Pos, std::uint16_t Count = npos>
+        requires detail::t_str_sub_legal<N, Pos, Count>
+        [[nodiscard]] constexpr auto sub() const noexcept {
+
+            constexpr std::uint16_t ActualCount =
+                    Count == npos
+                    ? static_cast<std::uint16_t>((N - 1) - Pos)
+                    : Count;
+
+            return sub_impl<Pos, ActualCount>(
+                    std::make_index_sequence<ActualCount>{}
+            );
+        }
+
+        /**
+         * @brief Obtain a <code>std::string_view</code> over a substring.
+         *
+         * @tparam Pos   Starting position of the substring.
+         * @tparam Count Number of characters to expose.
+         *               If set to <code>jh::meta::t_str&lt;N&gt;::npos</code>,
+         *               the view extends from <code>Pos</code> to the end of the string.
+         *
+         * @return A <code>std::string_view</code> referencing the selected range.
+         *
+         * @details
+         * <ul>
+         *   <li>This function does not allocate or copy memory.</li>
+         *   <li>The returned view references the internal storage of this <code>t_str</code>.</li>
+         *   <li>The substring length is computed at compile time.</li>
+         *   <li>The special value <code>Count = npos</code> means "until end".</li>
+         * </ul>
+         *
+         * @warning
+         * The returned view is non-owning and becomes invalid if the source
+         * <code>t_str</code> object goes out of scope.
+         */
+        template<std::uint16_t Pos, std::uint16_t Count = npos>
+        requires detail::t_str_sub_legal<N, Pos, Count>
+        [[nodiscard]] constexpr std::string_view sub_view() const noexcept {
+
+            constexpr std::uint16_t ActualCount =
+                    Count == npos
+                    ? static_cast<std::uint16_t>((N - 1) - Pos)
+                    : Count;
+
+            return {storage.data + Pos, ActualCount};
+        }
+
+        /**
+         * @brief Obtain a <code>jh::pod::string_view</code> over a substring.
+         *
+         * @tparam Pos   Starting position of the substring.
+         * @tparam Count Number of characters to expose.
+         *               If set to <code>jh::meta::t_str&lt;N&gt;::npos</code>,
+         *               the view extends from <code>Pos</code> to the end of the string.
+         *
+         * @return A <code>jh::pod::string_view</code> referencing the selected range.
+         *
+         * @details
+         * <ul>
+         *   <li>Provides the same behavior as <code>sub_view()</code>, but returns a
+         *       POD-compatible view type.</li>
+         *   <li>No memory allocation or copying occurs.</li>
+         *   <li>The substring length is computed at compile time.</li>
+         *   <li>The special value <code>Count = npos</code> means "until end".</li>
+         * </ul>
+         *
+         * @note
+         * This function is primarily intended for interoperability with
+         * APIs expecting <code>jh::pod::string_view</code>.
+         */
+        template<std::uint16_t Pos, std::uint16_t Count = npos>
+        requires detail::t_str_sub_legal<N, Pos, Count>
+        [[nodiscard]] constexpr jh::pod::string_view sub_pod_view() const noexcept {
+
+            constexpr std::uint16_t ActualCount =
+                    Count == npos
+                    ? static_cast<std::uint16_t>((N - 1) - Pos)
+                    : Count;
+
+            return {storage.data + Pos, ActualCount};
         }
 
         /**
@@ -629,11 +817,12 @@ namespace jh::meta {
          * @details
          * This operator is <code>= default</code>, meaning comparison is delegated
          * to the underlying member <code>const jh::pod::array&lt;char, N&gt; storage</code>.
-         *
+         * <ul>
          *  <li>Semantically: it is equivalent to comparing all characters in the string one by one.</li>
          *  <li>Implementation-wise: since <code>storage</code> is a POD type,
          *   the compiler can optimize this into a direct <code>memcmp</code>-style comparison
          *   at compile time or runtime.</li>
+         * </ul>
          */
         constexpr bool operator==(const t_str &) const noexcept = default;
 
@@ -739,7 +928,7 @@ namespace jh::meta {
      * </ul>
      */
     template<std::uint16_t N>
-    using TStr [[maybe_unused]] = t_str<N>;
+    using TStr = t_str<N>;
 
     /**
      * @brief Stream output operator for <code>t_str&lt;N&gt;</code>.

--- a/include/jh/metax/t_str.h
+++ b/include/jh/metax/t_str.h
@@ -67,6 +67,7 @@
 #include "jh/pods/array.h"
 #include "jh/pods/string_view.h"
 #include "jh/metax/hash.h"
+#include "jh/macros/platform.h"
 
 namespace jh::meta {
     namespace detail {
@@ -446,6 +447,14 @@ namespace jh::meta {
         /**
          * @brief Validate a POSIX-style relative path at compile time.
          *
+         * @warning
+         * This implementation relies on correct C++20 constant evaluation
+         * behavior for NTTP-based string types. GCC 13 and earlier versions
+         * contain known constexpr/NTTP evaluation defects that may cause
+         * incorrect compilation failures.
+         * <br>
+         * GCC 14 or later is required. Clang is unaffected.
+         *
          * This function performs strict validation of a POSIX-style relative path.
          * It is intended for project-internal path specifications and is designed
          * to be evaluated at compile time.
@@ -523,6 +532,9 @@ namespace jh::meta {
          */
         template<bool AllowParent = false>
         [[nodiscard]] constexpr bool is_valid_relative_path() const noexcept {
+            static_assert(!JH_GCC_LE_13,
+                          "GCC 13 and earlier have known constexpr evaluation defects that may "
+                          "cause incorrect compilation failures. GCC 14 or later is required.");
             if (size() < 1) return false;
             if (size() > 128) return false;
             if (val()[0] == '/') return false;   // absolute path forbidden

--- a/include/jh/metax/t_str.h
+++ b/include/jh/metax/t_str.h
@@ -541,11 +541,11 @@ namespace jh::meta {
             }
 
             for (; i < size(); ++i) {
-                if (!detail::is_path_char(val()[i]))
+                if (!detail::is_path_char(storage[i]))
                     return false;
 
                 // reject ".." appearing mid-path
-                if (val()[i] == '.' && i + 1 < size() && val()[i + 1] == '.')
+                if (storage[i] == '.' && i + 1 < size() && storage[i + 1] == '.')
                     return false;
             }
 

--- a/include/jh/pods/bytes_view.h
+++ b/include/jh/pods/bytes_view.h
@@ -29,7 +29,7 @@
  *   <li>Fully POD (<code>const std::byte*</code> + <code>uint64_t</code>)</li>
  *   <li>No ownership, no destructor, no STL containers</li>
  *   <li>Support for reinterpretation (<code>at</code>, <code>fetch</code>)</li>
- *   <li>Stack-safe and heap-safe cloning (<code>clone</code>, <code>clone_new</code>)</li>
+ *   <li>Stack-safe and heap-safe cloning (<code>clone</code>)</li>
  *   <li>Works seamlessly with <code>pod_like</code> and <code>trivial_bytes</code> types</li>
  * </ul>
  *

--- a/include/jh/pods/span.h
+++ b/include/jh/pods/span.h
@@ -32,8 +32,6 @@
  *       contiguous memory. It does not support iterator ranges, polymorphic
  *       containers, or allocator-aware semantics.
  * @note Lifetime of underlying memory must be managed externally.
- * @note Functions rely on <code>reinterpret_cast</code> and therefore cannot
- *       be used in <code>consteval</code> contexts.
  */
 
 #pragma once

--- a/include/jh/pods/string_view.h
+++ b/include/jh/pods/string_view.h
@@ -180,23 +180,41 @@ namespace jh::pod {
             }
         }
 
+        /// @brief Sentinel value representing "no position" or "until the end".
+        static constexpr auto npos = static_cast<std::uint64_t>(-1);
+
         /**
          * @brief Returns a substring starting at <code>offset</code>, for <code>length</code> bytes.
          *
          * <ul>
-         *   <li>If <code>length == 0</code>, the view extends to the end.</li>
+         *   <li>If <code>length == jh::pod::string_view::npos</code>, the view extends to the end.</li>
+         *   <li>If <code>length == 0</code>, the result is an empty view.</li>
          *   <li>If <code>offset > len</code>, returns an empty view.</li>
          * </ul>
          *
          * @param offset Starting byte index (0-based).
-         * @param length Number of bytes (<code>0</code> = sentinel = to end).
+         * @param @param length Number of bytes. Use <code>jh::pod::string_view::npos</code>
+              to read until the end of the view.
          * @return A new <code>string_view</code> into the specified subrange.
+         *
+         * @note
+         * This behavior intentionally mirrors the semantics of
+         * <code>std::string_view::substr</code>, where
+         * <code>npos</code> represents "read until the end".
          */
-        [[nodiscard]] constexpr string_view sub(const std::uint64_t offset,
-                                                const std::uint64_t length = 0) const noexcept {
-            if (offset > len) return {nullptr, 0}; // out-of-range -> empty
+        [[nodiscard]] constexpr string_view
+        sub(std::uint64_t offset, std::uint64_t length = npos) const noexcept {
+
+            if (offset >= len)
+                return {nullptr, 0};
+
             const std::uint64_t remaining = len - offset;
-            const std::uint64_t real_len = length == 0 || length > remaining ? remaining : length;
+
+            const std::uint64_t real_len =
+                    (length == npos || length > remaining)
+                    ? remaining
+                    : length;
+
             return {data + offset, real_len};
         }
 

--- a/include/jh/pods/string_view.h
+++ b/include/jh/pods/string_view.h
@@ -50,6 +50,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <compare>
 #include <cstdint>
 #include <cstring>      // for memcmp, memcpy
@@ -57,7 +58,9 @@
 #include <type_traits>
 #include <cstddef>
 
+#include "jh/metax/char.h"
 #include "jh/pods/pod_like.h"
+#include "jh/detail/base64_common.h"
 #include "jh/metax/hash.h"
 
 namespace jh::pod {
@@ -300,6 +303,306 @@ namespace jh::pod {
         }
 
         /**
+         * @brief Check if all characters are decimal digits (0-9).
+         * @note This only checks that each character is a digit.
+         *       To validate if the whole string represents a number
+         *       (with optional sign, decimal point, or exponent),
+         *       use @c is_number() instead.
+         * @return true if all characters are digits, false otherwise.
+         */
+        [[nodiscard]] constexpr bool is_digit() const noexcept {
+            if (std::is_constant_evaluated()) {
+                for (std::uint64_t i = 0; i < size(); ++i) {
+                    if (!jh::meta::is_digit(data[i]))
+                        return false;
+                }
+                return true;
+            } else {
+                return std::all_of(
+                        begin(),
+                        end(),
+                        [](char c) {
+                            return jh::meta::is_digit(c);
+                        }
+                );
+            }
+        }
+
+        /**
+         * @brief Check if the string represents a valid decimal number.
+         *
+         * @return <code>true</code> if the string is a valid number, otherwise <code>false</code>.
+         *
+         * @details
+         * Grammar (simplified BNF):
+         * <pre>
+         *   [ '+' | '-' ] DIGIT+ [ '.' DIGIT+ ] [ ( 'e' | 'E' ) [ '+' | '-' ] DIGIT+ ]
+         * </pre>
+         *
+         * Equivalent regular expression:
+         * <pre>
+         *   ^[+-]?[0-9]+(&bsol;.[0-9]+)?([eE][+-]?[0-9]+)?$
+         * </pre>
+         *
+         * Rules:
+         * <ul>
+         *   <li>The first character may be <code>'+'</code> or <code>'-'</code>.</li>
+         *   <li>At least one digit must appear before optional '.' or 'e/E'.</li>
+         *   <li>If '.' appears, at least one digit must follow (either before or after '.').</li>
+         *   <li>If 'e' or 'E' appears, it must be followed by an optional sign and at least one digit.</li>
+         *   <li>Only decimal notation is supported (no hex, octal, binary, or locale-specific formats).</li>
+         * </ul>
+         */
+        [[nodiscard]] constexpr bool is_number() const noexcept {
+            const std::uint64_t n = size();
+            if (n == 0) return false;
+
+            std::uint64_t i = 0;
+            if (data[i] == '+' || data[i] == '-') {
+                ++i;
+            }
+
+            bool has_digit = false;
+            bool seen_dot = false;
+            bool seen_exp = false;
+
+            for (; i < n; ++i) {
+                const char c = data[i];
+
+                /// do NOT apply [[likely]] as this is constexpr
+                if (jh::meta::is_digit(c)) {
+                    has_digit = true;
+                    continue;
+                }
+
+                if (c == '.') {
+                    if (!has_digit || seen_dot || seen_exp) return false; // must have digit before '.'
+                    seen_dot = true;
+                    has_digit = false; // must see digit after '.'
+                    continue;
+                }
+
+                if (c == 'e' || c == 'E') {
+                    if (!has_digit || seen_exp) return false; // must have digit before 'e'
+                    seen_exp = true;
+                    has_digit = false; // must see digit after 'e'
+                    if (i + 1 < n && (data[i + 1] == '+' || data[i + 1] == '-')) {
+                        ++i; // skip optional sign after e/E
+                        // no leak risk, worst case reach '\0'
+                    }
+                    continue;
+                }
+                return false; // invalid character
+            }
+            return has_digit;
+        }
+
+        /**
+         * @brief Check if all characters are alphabetic (A-Z, a-z).
+         * @return true if all characters are alphabetic, false otherwise.
+         */
+        [[nodiscard]] constexpr bool is_alpha() const noexcept {
+            if (std::is_constant_evaluated()) {
+                for (std::uint64_t i = 0; i < size(); ++i) {
+                    if (!jh::meta::is_alpha(data[i]))
+                        return false;
+                }
+                return true;
+            } else {
+                return std::all_of(
+                        begin(),
+                        end(),
+                        [](char c) {
+                            return jh::meta::is_alpha(c);
+                        }
+                );
+            }
+        }
+
+        /**
+         * @brief Check if all characters are alphanumeric (letters or digits).
+         * @return true if all characters are alphanumeric, false otherwise.
+         */
+        [[nodiscard]] constexpr bool is_alnum() const noexcept {
+            if (std::is_constant_evaluated()) {
+                for (std::uint64_t i = 0; i < size(); ++i)
+                    if (!jh::meta::is_alnum(data[i]))
+                        return false;
+                return true;
+            } else {
+                return std::all_of(
+                        begin(),
+                        end(),
+                        [](char c) {
+                            return jh::meta::is_alnum(c);
+                        }
+                );
+            }
+        }
+
+        /**
+         * @brief Check if all characters are 7-bit ASCII.
+         * @return true if all characters are in range 0-127, false otherwise.
+         */
+        [[nodiscard]] constexpr bool is_ascii() const noexcept {
+            if (std::is_constant_evaluated()) {
+                for (std::uint64_t i = 0; i < size(); ++i)
+                    if (!jh::meta::is_ascii(data[i]))
+                        return false;
+                return true;
+            } else {
+                return std::all_of(
+                        begin(),
+                        end(),
+                        [](char c) {
+                            return jh::meta::is_ascii(c);
+                        }
+                );
+            }
+        }
+
+        /**
+         * @brief Check if all characters are printable 7-bit ASCII.
+         * @return true if all characters are in range 32-126, false otherwise.
+         *
+         * @details
+         * Verifies that every character lies within the printable
+         * 7-bit ASCII range (decimal 32-126).
+         *
+         * @note
+         * Printable ASCII is a strict subset of 7-bit ASCII.
+         * Therefore: <code>is_printable_ascii()</code> implies <code>is_ascii()</code>
+         * <br>
+         * If this function returns true, calling @c is_ascii()
+         * again is redundant. When used inside a @c requires clause,
+         * do not combine the two checks.
+         * <br>
+         * This function only permits ASCII characters.
+         * If the intention is to validate fully printable text
+         * including multi-byte UTF-8 sequences, use @c is_legal()
+         * instead.
+         * @note
+         * @c is_legal() performs:
+         * <ul>
+         *  <li>UTF-8 structural validation</li>
+         *  <li>rejection of invalid UTF-8 byte combinations</li>
+         *  <li>rejection of illegal ASCII control characters</li>
+         * </ul>
+         */
+        [[nodiscard]] constexpr bool is_printable_ascii() const noexcept {
+            if (std::is_constant_evaluated()) {
+                for (std::uint64_t i = 0; i < size(); ++i)
+                    if (!jh::meta::is_printable_ascii(data[i]))
+                        return false;
+                return true;
+            } else {
+                return std::all_of(
+                        begin(),
+                        end(),
+                        [](char c) {
+                            return jh::meta::is_printable_ascii(c);
+                        }
+                );
+            }
+        }
+
+        /**
+         * @brief Check if all characters are valid (printable ASCII or UTF-8).
+         * @return true if all characters are valid, false otherwise.
+         */
+        [[nodiscard]] constexpr bool is_legal() const noexcept {
+            std::uint64_t i = 0;
+            int remaining = 0;       // how many continuation bytes still expected
+            unsigned char lead = 0;  // last leading byte
+
+            while (i < size()) {
+                auto c = static_cast<unsigned char>(data[i]);
+                // filter out disallowed ASCII control characters
+                if (!jh::meta::is_valid_char(static_cast<char>(c))) return false;
+                ///< constexpr, avoid using [[likely/unlikely]]
+                if (remaining == 0) {
+                    // --- leading byte ---
+                    if (c <= 0x7F) {
+                        // single-byte ASCII
+                        i++;
+                        continue;
+                    } else if (c >= 0xC2 && c <= 0xDF) {
+                        // 2-byte sequence
+                        remaining = 1;
+                        lead = c;
+                    } else if (c >= 0xE0 && c <= 0xEF) {
+                        // 3-byte sequence
+                        remaining = 2;
+                        lead = c;
+                    } else if (c >= 0xF0 && c <= 0xF4) {
+                        // 4-byte sequence
+                        remaining = 3;
+                        lead = c;
+                    } else {
+                        return false; // invalid leading byte
+                    }
+                } else {
+                    // --- continuation byte ---
+                    if ((c & 0xC0) != 0x80) return false;
+                    // special restrictions for the first continuation
+                    if (remaining == ((lead >= 0xE0 && lead <= 0xEF) ? 2 :
+                                      (lead >= 0xF0 && lead <= 0xF4) ? 3 : 1)) {
+                        if (lead == 0xE0 && (c < 0xA0 || c > 0xBF)) return false;
+                        if (lead == 0xED && (c < 0x80 || c > 0x9F)) return false;
+                        if (lead == 0xF0 && (c < 0x90 || c > 0xBF)) return false;
+                        if (lead == 0xF4 && (c < 0x80 || c > 0x8F)) return false;
+                    }
+                    remaining--;
+                }
+                i++;
+            }
+            return remaining == 0;
+        }
+
+        /**
+         * @brief Check if the string is a valid hexadecimal sequence.
+         * @details Length must be even, and all characters must be hex digits.
+         * @return true if valid hex string, false otherwise.
+         */
+        [[nodiscard]] constexpr bool is_hex() const noexcept {
+            if (size() % 2 != 0)
+                return false;
+
+            if (std::is_constant_evaluated()) {
+                for (std::uint64_t i = 0; i < size(); ++i)
+                    if (!jh::meta::is_hex_char(data[i]))
+                        return false;
+                return true;
+            } else {
+                return std::all_of(
+                        begin(),
+                        end(),
+                        [](char c) {
+                            return jh::meta::is_hex_char(c);
+                        }
+                );
+            }
+        }
+
+        /**
+         * @brief Check if the string is valid Base64.
+         * @details Length must be a multiple of 4, padding ('=') allowed at the end.
+         * @return true if valid Base64, false otherwise.
+         */
+        [[nodiscard]] constexpr bool is_base64() const noexcept {
+            return jh::detail::base64_common::is_base64(data, size());
+        }
+
+        /**
+         * @brief Check if the string is valid Base64URL.
+         * @details '=' padding is optional. If present, length must be a multiple of 4.
+         * @return true if valid Base64URL, false otherwise.
+         */
+        [[nodiscard]] constexpr bool is_base64url() const noexcept {
+            return jh::detail::base64_common::is_base64url(data, size());
+        }
+
+        /**
          * @brief Copy the view into a C-style null-terminated buffer.
          *
          * @warning This is not POD-safe. Intended for debugging or interop only.
@@ -311,6 +614,71 @@ namespace jh::pod {
             const std::uint64_t n = len < max_len - 1 ? len : max_len - 1;
             std::memcpy(buffer, data, n);
             buffer[n] = '\0';
+        }
+
+        /**
+         * @brief Returns the semantic length of the UTF-8 string.
+         *
+         * Counts the number of Unicode code points represented in this view,
+         * rather than the number of raw bytes. This function assumes that the
+         * underlying data is valid UTF-8.
+         *
+         * <h4>Definition:</h4>
+         * <ul>
+         *   <li>A new code point is identified by a byte that is <b>not</b>
+         *       a UTF-8 continuation byte (<code>10xxxxxx</code>).</li>
+         *   <li>Continuation bytes are excluded from the count.</li>
+         * </ul>
+         *
+         * <h4>Evaluation Model:</h4>
+         * <ul>
+         *   <li>In constant-evaluated contexts, a fully <code>constexpr</code>
+         *       UTF-8 scan is performed.</li>
+         *   <li>At runtime, the implementation may delegate to optimized
+         *       standard library algorithms.</li>
+         * </ul>
+         *
+         * <h4>Important Notes:</h4>
+         * <ul>
+         *   <li>This function counts <b>Unicode code points</b>, not grapheme clusters.</li>
+         *   <li>Multi-code-point sequences (e.g. emoji ZWJ sequences or
+         *       combining characters) are counted individually.</li>
+         *   <li>No UTF-8 validation is performed.</li>
+         * </ul>
+         *
+         * @return Number of Unicode code points in the view,
+         *         or <code>0</code> if the view is empty.
+         *
+         * @note The computation of grapheme clusters will never be provided,
+         *       as it is evident that in software development, this is a front-end requirement
+         *       rather than a back-end one, and the systems upon which grapheme clusters depend
+         *       are excessively cumbersome.
+         */
+        [[nodiscard]] constexpr std::uint64_t semantic_len() const noexcept {
+            if (!data || len == 0)
+                return 0;
+
+            if (std::is_constant_evaluated()) {
+                // constexpr path: count non-continuation bytes
+                std::uint64_t count = 0;
+                for (std::uint64_t i = 0; i < len; ++i) {
+                    const auto c = static_cast<unsigned char>(data[i]);
+                    if ((c & 0b11000000) != 0b10000000)
+                        ++count;
+                }
+                return count;
+            } else {
+                // runtime path: use std::count_if for efficiency
+                return static_cast<std::uint64_t>(
+                        std::count_if(
+                                data,
+                                data + len,
+                                [](unsigned char c) {
+                                    return (c & 0b11000000) != 0b10000000;
+                                }
+                        )
+                );
+            }
         }
 
         /**

--- a/include/jh/pods/stringify.h
+++ b/include/jh/pods/stringify.h
@@ -44,14 +44,14 @@
  * Provides a minimal and consistent interface for encoding and decoding binary data.
  *
  * <ul>
- *   <li><code>std::string encode(const uint8_t *data, std::size_t len) noexcept;</code><br/>
+ *   <li><code>std::string encode(const std::uint8_t *data, std::size_t len) noexcept;</code><br/>
  *       Encode raw bytes into a Base64 string.</li>
  *
- *   <li><code>std::vector&lt;uint8_t&gt; decode(const std::string &input);</code><br/>
+ *   <li><code>std::vector&lt;std::uint8_t&gt; decode(const std::string &input);</code><br/>
  *       Decode a Base64 string into a new byte buffer.</li>
  *
- *   <li><code>jh::pod::bytes_view decode(const std::string &input, std::vector&lt;uint8_t&gt;& buffer);</code><br/>
- *       Decode into a provided <code>std::vector&lt;uint8_t&gt;</code> and return a
+ *   <li><code>jh::pod::bytes_view decode(const std::string &input, std::vector&lt;std::uint8_t&gt;& buffer);</code><br/>
+ *       Decode into a provided <code>std::vector&lt;std::uint8_t&gt;</code> and return a
  *       <code>bytes_view</code> pointing into it (useful for flat binary operations).</li>
  *
  *   <li><code>jh::pod::string_view decode(const std::string &input, std::string& buffer);</code><br/>
@@ -176,14 +176,14 @@ namespace jh::pod {
     !std::is_enum_v<T> &&
     !std::is_pointer_v<T>;
 
-    template<streamable T, uint16_t N>
+    template<streamable T, std::uint16_t N>
     requires(!std::is_same_v<T, char> && // forbid printing char arrays
              requires(std::ostream &os, T v) {
                  { os << v }; // T should be printable
              })
     inline std::ostream &operator<<(std::ostream &os, const jh::pod::array<T, N> &arr) {
         os << "[";
-        for (uint16_t i = 0; i < N; ++i) {
+        for (std::uint16_t i = 0; i < N; ++i) {
             if (i != 0)
                 os << ", ";
             os << arr[i];
@@ -192,10 +192,10 @@ namespace jh::pod {
         return os;
     }
 
-    template<uint16_t N>
+    template<std::uint16_t N>
     inline std::ostream &operator<<(std::ostream &os, const jh::pod::array<char, N> &str) {
         os << '"';  // start escaped JSON string
-        for (uint16_t i = 0; i < N && str[i] != '\0'; ++i) {
+        for (std::uint16_t i = 0; i < N && str[i] != '\0'; ++i) {
             char c = str[i];
             switch (c) {
                 case '\"':
@@ -282,9 +282,12 @@ namespace jh::pod {
     }
 
     inline std::ostream &operator<<(std::ostream &os, const jh::pod::bytes_view bv) {
+        // empty view should print as base64''
+        const auto *data = bv.fetch<std::uint8_t>(0);
         os << "base64'";
-        const auto encoded = jh::serio::base64::encode(reinterpret_cast<const uint8_t *>(bv.data), bv.len);
-        os << encoded;
+        if (data != nullptr) {
+            os << jh::serio::base64::encode(data, bv.len);
+        }
         os << "'";
         return os;
     }
@@ -309,7 +312,7 @@ namespace jh::pod {
     }
 
     template<streamable_pod Pod>
-    std::string to_string(const Pod& p) {
+    std::string to_string(const Pod &p) {
         std::ostringstream oss;
         oss << p;
         return oss.str();
@@ -338,7 +341,7 @@ namespace jh::pod {
     }
 } // namespace jh::pod
 
-namespace jh::typed{
+namespace jh::typed {
     inline std::ostream &operator<<(std::ostream &os, const jh::typed::monostate &) {
         os << "null";
         return os;

--- a/include/jh/pool
+++ b/include/jh/pool
@@ -14,6 +14,85 @@
  * Internally, it includes the user facing pool interfaces from
  * <code>jh/concurrent/&#42;.h</code> and exposes them collectively.
  * </p>
+ *
+ * <hr>
+ *
+ * <b>Platform Semantics</b>
+ * <br>
+ * All pool implementations in <code>&lt;jh/pool&gt;</code> are designed to be
+ * <b>data-race-free at the algorithmic level</b>.
+ *
+ * <ul>
+ *   <li>All shared mutable state is protected by explicit locks.</li>
+ *   <li>Reference counters and liveness indicators use atomics.</li>
+ *   <li>No intentional lock-free data races exist.</li>
+ * </ul>
+ *
+ * The concurrency design assumes a strong acquire/release synchronization
+ * contract between:
+ *
+ * <ul>
+ *   <li>lock/unlock operations, and</li>
+ *   <li>C++ atomic operations.</li>
+ * </ul>
+ *
+ * On POSIX platforms (Linux / Darwin), this assumption is satisfied by
+ * mature implementations built upon:
+ *
+ * <ul>
+ *   <li><code>pthread_rwlock</code></li>
+ *   <li><code>futex</code>-based primitives</li>
+ *   <li>well-integrated compiler/runtime memory semantics (GCC / Clang)</li>
+ * </ul>
+ *
+ * Under these environments, the synchronization graph forms a complete
+ * happens-before closure in practice. The pools are considered
+ * <b>engineering-grade well-formed</b> and have demonstrated stable
+ * high-concurrency behavior.
+ * <br>
+ * The design intentionally leverages these stronger implementation
+ * semantics. It does not restrict itself to the minimal guarantees of the
+ * ISO C++ abstract machine, as doing so would significantly reduce
+ * expressiveness or introduce prohibitive synchronization overhead.
+ *
+ * <hr>
+ * <b>Windows Support</b>
+ * <br>
+ * Windows is treated as a secondary platform.
+ * <br>
+ * While the code remains data-race-free at the C++ level, certain
+ * combinations of:
+ *
+ * <ul>
+ *   <li>MinGW (libstdc++)</li>
+ *   <li>Windows runtime libraries (MSVCRT / UCRT)</li>
+ *   <li>SRWLock-based synchronization paths</li>
+ * </ul>
+ *
+ * have been observed under extreme concurrency to exhibit rare
+ * visibility gaps or ordering jitter.
+ *
+ * These effects appear to stem from subtle differences in how
+ * C++ atomic semantics interact with Windows runtime synchronization
+ * primitives. In particular, control blocks associated with
+ * <code>weak_ptr</code>, <code>shared_ptr</code>, or atomic reference
+ * counters may not always participate in a fully closed visibility
+ * chain under high parallel pressure.
+ * <br>
+ * Additional fences are introduced on Windows builds to strengthen
+ * ordering, but they cannot eliminate all anomalies when interacting
+ * with certain runtime configurations.
+ * <br>
+ * Therefore:
+ *
+ * <ul>
+ *   <li>Full concurrency robustness is guaranteed only on POSIX.</li>
+ *   <li>Windows usage is recommended for single-threaded or
+ *       low-contention workloads.</li>
+ * </ul>
+ *
+ * The primary validation and release target of this toolkit remains
+ * POSIX systems (Linux + GCC/Clang, Darwin + Clang).
  */
 
 #pragma once

--- a/include/jh/serialize_io/base64.h
+++ b/include/jh/serialize_io/base64.h
@@ -39,12 +39,26 @@
  *
  * <h3>Usage</h3>
  * @code
- * std::vector&lt;uint8_t&gt; raw = {0x01, 0x02, 0x03};
+ * std::vector&lt;std::uint8_t&gt; raw = {0x01, 0x02, 0x03};
  * std::string encoded = jh::serio::base64::encode(raw.data(), raw.size());
  * auto decoded = jh::serio::base64::decode(encoded);
  * @endcode
  *
- * @version <pre>1.3.x</pre>
+ * @note
+ * This header participates in the <b>Dual-Mode Header</b> system of the
+ * JH Toolkit.
+ * <ul>
+ *   <li>Linked through <b>jh::jh-toolkit</b> &mdash; the module behaves
+ *       as a <b>header-only</b> implementation compiled in user
+ *       translation units.</li>
+ *   <li>Linked through <b>jh::jh-toolkit-static</b> &mdash; the module
+ *       uses a <b>precompiled implementation</b> built with aggressive
+ *       optimization (typically <code>-O3</code>).</li>
+ * </ul>
+ * This design allows fast incremental builds while preserving the
+ * option of using a fully optimized static implementation.
+ *
+ * @version <pre>1.4.1</pre>
  * @date <pre>2025</pre>
  */
 
@@ -58,7 +72,6 @@
 
 #include "jh/pods/string_view.h"
 #include "jh/pods/bytes_view.h"
-#include "jh/detail/base64_common.h"
 
 namespace jh::serio {
 
@@ -78,8 +91,6 @@ namespace jh::serio {
      */
     namespace base64 {
 
-        using namespace jh::detail::base64_common;
-
         /**
          * @brief Encode raw binary data into a Base64 string.
          *
@@ -91,20 +102,7 @@ namespace jh::serio {
          *
          * @note This function always produces a padded Base64 output.
          */
-        [[nodiscard]] inline std::string encode(const uint8_t *data, std::size_t len) {
-            if (data == nullptr && len > 0)
-                throw std::invalid_argument("encode(): null pointer with non-zero length");
-
-            const auto encoded_len = encoded_len_base64(len);
-            std::vector<char> buffer(encoded_len);
-
-            base64_encode_unchecked<false>(data, len, buffer.data(), true);
-
-            return {
-                    std::make_move_iterator(buffer.begin()),
-                    std::make_move_iterator(buffer.end())
-            };
-        }
+        [[nodiscard]] std::string encode(const std::uint8_t *data, std::size_t len);
 
         /**
          * @brief Decode a Base64 string into a byte vector.
@@ -114,21 +112,7 @@ namespace jh::serio {
          *
          * @throw std::runtime_error if input is not a valid Base64 string.
          */
-        [[nodiscard]] inline std::vector<uint8_t> decode(const std::string &input) {
-            const auto n = input.size();
-            if (n == 0)
-                return {};
-
-            const int pad = base64_check(input.data(), n);
-            if (pad == -1)
-                throw std::runtime_error("Invalid Base64: bad length, illegal characters, or bad padding");
-
-            const auto decoded_len = decoded_len_base64(n, static_cast<uint8_t>(pad));
-
-            std::vector<uint8_t> output(decoded_len);
-            base64_decode_unchecked(input.data(), n, output.data(), decoded_len);
-            return output;
-        }
+        [[nodiscard]] std::vector<std::uint8_t> decode(const std::string &input);
 
         /**
          * @brief Decode a Base64-encoded string into raw bytes.
@@ -154,13 +138,10 @@ namespace jh::serio {
          *   <li>These operations ensure POD-safe reinterpretation and provide zero-overhead access to binary data.</li>
          * </ul>
          */
-        inline jh::pod::bytes_view decode(
+        jh::pod::bytes_view decode(
                 const std::string &input,
-                std::vector<uint8_t> &output_buffer
-        ) {
-            output_buffer = decode(input);
-            return jh::pod::bytes_view::from(output_buffer.data(), output_buffer.size());
-        }
+                std::vector<std::uint8_t> &output_buffer
+        );
 
         /**
          * @brief Decode a Base64-encoded string into textual data.
@@ -191,17 +172,10 @@ namespace jh::serio {
          *       with the standard library and compile-time evaluation where applicable.</li>
          * </ul>
          */
-        inline jh::pod::string_view decode(
+        jh::pod::string_view decode(
                 const std::string &input,
                 std::string &output_buffer
-        ) {
-            auto temp = decode(input);
-            output_buffer = std::string(
-                    std::make_move_iterator(temp.begin()),
-                    std::make_move_iterator(temp.end())
-            );
-            return {output_buffer.data(), output_buffer.size()};
-        }
+        );
     } // namespace base64
 
 
@@ -221,8 +195,6 @@ namespace jh::serio {
      */
     namespace base64url {
 
-        using namespace jh::detail::base64_common;
-
         /**
          * @brief Encode raw binary data into a Base64URL string.
          *
@@ -235,23 +207,7 @@ namespace jh::serio {
          *
          * @note When @p pad = false, the output omits trailing '=' characters.
          */
-        [[nodiscard]] inline std::string encode(const uint8_t *data, std::size_t len, bool pad = false) {
-            if (data == nullptr && len > 0)
-                throw std::invalid_argument("encode(): null pointer with non-zero length");
-
-            const auto encoded_len = pad
-                                     ? encoded_len_base64(len)
-                                     : encoded_len_base64url_no_pad(len);
-
-            std::vector<char> buffer(encoded_len);
-
-            base64_encode_unchecked<true>(data, len, buffer.data(), pad);
-
-            return {
-                    std::make_move_iterator(buffer.begin()),
-                    std::make_move_iterator(buffer.end())
-            };
-        }
+        [[nodiscard]] std::string encode(const std::uint8_t *data, std::size_t len, bool pad = false);
 
         /**
          * @brief Decode a Base64URL string into a byte vector.
@@ -261,23 +217,7 @@ namespace jh::serio {
          *
          * @throw std::runtime_error if input is not valid Base64URL.
          */
-        [[nodiscard]] inline std::vector<uint8_t> decode(const std::string &input) {
-            const auto n = input.size();
-            if (n == 0)
-                return {};
-
-            const int pad = base64url_check(input.data(), n);
-            if (pad == -1)
-                throw std::runtime_error("Invalid Base64URL: bad length or illegal characters");
-
-            const auto decoded_len = (pad > 0)
-                                     ? decoded_len_base64(n, static_cast<uint8_t>(pad))
-                                     : decoded_len_base64url_no_pad(n);
-
-            std::vector<uint8_t> output(decoded_len);
-            base64_decode_unchecked(input.data(), n, output.data(), decoded_len);
-            return output;
-        }
+        [[nodiscard]] std::vector<std::uint8_t> decode(const std::string &input);
 
         /**
          * @brief Decode a Base64URL-encoded string into raw bytes.
@@ -303,13 +243,10 @@ namespace jh::serio {
          *   <li>These operations ensure POD-safe reinterpretation and provide zero-overhead access to binary data.</li>
          * </ul>
          */
-        inline jh::pod::bytes_view decode(
+        jh::pod::bytes_view decode(
                 const std::string &input,
-                std::vector<uint8_t> &output_buffer
-        ) {
-            output_buffer = decode(input);
-            return jh::pod::bytes_view::from(output_buffer.data(), output_buffer.size());
-        }
+                std::vector<std::uint8_t> &output_buffer
+        );
 
         /**
          * @brief Decode a Base64URL-encoded string into textual data.
@@ -340,7 +277,124 @@ namespace jh::serio {
          *       with the standard library and compile-time evaluation where applicable.</li>
          * </ul>
          */
-        inline jh::pod::string_view decode(
+        jh::pod::string_view decode(
+                const std::string &input,
+                std::string &output_buffer
+        );
+    } // namespace base64url
+
+} // namespace jh::serio
+
+
+#include "jh/macros/header_begin.h"
+
+#if JH_INTERNAL_SHOULD_DEFINE
+
+#include "jh/detail/base64_common.h"
+
+namespace jh::serio {
+
+    namespace base64 {
+
+        [[nodiscard]] JH_INLINE std::string encode(const std::uint8_t *data, std::size_t len) {
+            if (data == nullptr && len > 0)
+                throw std::invalid_argument("encode(): null pointer with non-zero length");
+
+            const auto encoded_len = jh::detail::base64_common::encoded_len_base64(len);
+            std::vector<char> buffer(encoded_len);
+
+            jh::detail::base64_common::base64_encode_unchecked<false>(data, len, buffer.data(), true);
+
+            return {
+                    std::make_move_iterator(buffer.begin()),
+                    std::make_move_iterator(buffer.end())
+            };
+        }
+
+        [[nodiscard]] JH_INLINE std::vector<std::uint8_t> decode(const std::string &input) {
+            const auto n = input.size();
+            if (n == 0)
+                return {};
+
+            const int pad = jh::detail::base64_common::base64_check(input.data(), n);
+            if (pad == -1)
+                throw std::runtime_error("Invalid Base64: bad length, illegal characters, or bad padding");
+
+            const auto decoded_len = jh::detail::base64_common::decoded_len_base64(n, static_cast<std::uint8_t>(pad));
+
+            std::vector<std::uint8_t> output(decoded_len);
+            jh::detail::base64_common::base64_decode_unchecked(input.data(), n, output.data(), decoded_len);
+            return output;
+        }
+
+        JH_INLINE jh::pod::bytes_view decode(
+                const std::string &input,
+                std::vector<std::uint8_t> &output_buffer
+        ) {
+            output_buffer = decode(input);
+            return jh::pod::bytes_view::from(output_buffer.data(), output_buffer.size());
+        }
+
+        JH_INLINE jh::pod::string_view decode(
+                const std::string &input,
+                std::string &output_buffer
+        ) {
+            auto temp = decode(input);
+            output_buffer = std::string(
+                    std::make_move_iterator(temp.begin()),
+                    std::make_move_iterator(temp.end())
+            );
+            return {output_buffer.data(), output_buffer.size()};
+        }
+    } // namespace base64
+
+    namespace base64url {
+
+        [[nodiscard]] JH_INLINE std::string encode(const std::uint8_t *data, std::size_t len, bool pad) {
+            if (data == nullptr && len > 0)
+                throw std::invalid_argument("encode(): null pointer with non-zero length");
+
+            const auto encoded_len = pad
+                                     ? jh::detail::base64_common::encoded_len_base64(len)
+                                     : jh::detail::base64_common::encoded_len_base64url_no_pad(len);
+
+            std::vector<char> buffer(encoded_len);
+
+            jh::detail::base64_common::base64_encode_unchecked<true>(data, len, buffer.data(), pad);
+
+            return {
+                    std::make_move_iterator(buffer.begin()),
+                    std::make_move_iterator(buffer.end())
+            };
+        }
+
+        [[nodiscard]] JH_INLINE std::vector<std::uint8_t> decode(const std::string &input) {
+            const auto n = input.size();
+            if (n == 0)
+                return {};
+
+            const int pad = jh::detail::base64_common::base64url_check(input.data(), n);
+            if (pad == -1)
+                throw std::runtime_error("Invalid Base64URL: bad length or illegal characters");
+
+            const auto decoded_len = (pad > 0)
+                                     ? jh::detail::base64_common::decoded_len_base64(n, static_cast<std::uint8_t>(pad))
+                                     : jh::detail::base64_common::decoded_len_base64url_no_pad(n);
+
+            std::vector<std::uint8_t> output(decoded_len);
+            jh::detail::base64_common::base64_decode_unchecked(input.data(), n, output.data(), decoded_len);
+            return output;
+        }
+
+        JH_INLINE jh::pod::bytes_view decode(
+                const std::string &input,
+                std::vector<std::uint8_t> &output_buffer
+        ) {
+            output_buffer = decode(input);
+            return jh::pod::bytes_view::from(output_buffer.data(), output_buffer.size());
+        }
+
+        JH_INLINE jh::pod::string_view decode(
                 const std::string &input,
                 std::string &output_buffer
         ) {
@@ -352,5 +406,8 @@ namespace jh::serio {
             return {output_buffer.data(), output_buffer.size()};
         }
     } // namespace base64url
-
 } // namespace jh::serio
+
+#endif // JH_INTERNAL_SHOULD_DEFINE
+
+#include "jh/macros/header_end.h"

--- a/include/jh/serialize_io/huffman.h
+++ b/include/jh/serialize_io/huffman.h
@@ -182,20 +182,21 @@
 #include "jh/metax/t_str.h"
 #include "jh/pods/array.h"
 #include "jh/pods/pair.h"
+#include "jh/pods/bytes_view.h"
 
 namespace jh::serio {
 
     namespace detail {
 
         /// @brief Provides empty canonical_decoder for non-canonical Huffman variants.
-        template<bool IsCanonical, size_t N>
+        template<bool IsCanonical, std::size_t N>
         struct canonical_decoder_selector final {
             struct type final {
             };
         };
 
         /// @brief Provides canonical_decoder only for canonical Huffman variants.
-        template<size_t N>
+        template<std::size_t N>
         struct canonical_decoder_selector<true, N> final {
             struct type final {
                 std::uint8_t code_len[N];      ///< Code length per symbol
@@ -253,7 +254,7 @@ namespace jh::serio {
                 Algo == huff_algo::huff128_canonical || Algo == huff_algo::huff256_canonical;
 
         /// @brief Number of symbols (128 or 256) determined by algorithm type.
-        static constexpr size_t table_size =
+        static constexpr std::size_t table_size =
                 ((Algo == huff_algo::huff128 || Algo == huff_algo::huff128_canonical)
                  ? 128 : 256);
 
@@ -315,7 +316,7 @@ namespace jh::serio {
          * @param pool  Output vector containing the built nodes.
          * @return Index of the root node (or -1 if empty input).
          */
-        static int build_tree(const std::vector<std::uint32_t> &freq,
+        static int build_tree(const jh::pod::array<std::uint32_t, table_size> &freq,
                               std::vector<node> &pool) {
             pool.clear();
             pool.reserve(table_size * 2);
@@ -559,9 +560,9 @@ namespace jh::serio {
 
             return out;
         }
-        
+
     public:
-        
+
         static void build_code_length(const std::vector<node> &pool,
                                       int root,
                                       jh::pod::array<std::uint8_t, table_size> &len_tbl
@@ -601,7 +602,7 @@ namespace jh::serio {
         static void compress(std::ostream &os, std::string_view input) {
             os.write(Signature.val(), Signature.size());
 
-            std::vector<std::uint32_t> freq(table_size);
+            jh::pod::array<std::uint32_t, table_size> freq{};
             for (unsigned char c: input) {
                 if constexpr (table_size == 128) {
                     if (c > 127)
@@ -612,8 +613,8 @@ namespace jh::serio {
             }
 
             if constexpr (!is_canonical) {
-                for (auto f: freq)
-                    os.write(reinterpret_cast<const char *>(&f), 4);
+                auto bv = jh::pod::bytes_view::from(freq);
+                os.write(bv.template fetch<char>(0), bv.size());
             }
 
             std::vector<node> pool;
@@ -634,7 +635,10 @@ namespace jh::serio {
                 for (unsigned char c: input)
                     total_bits += tbl[c].len;
 
-                os.write(reinterpret_cast<const char *>(&total_bits), 8);
+                {
+                    auto bv = jh::pod::bytes_view::from(total_bits);
+                    os.write(bv.fetch<char>(0), sizeof(total_bits));
+                }
 
                 std::uint8_t buf = 0;
                 int cnt = 0;
@@ -663,7 +667,10 @@ namespace jh::serio {
             for (unsigned char c: input)
                 total_bits += tbl[c].len;
 
-            os.write(reinterpret_cast<const char *>(&total_bits), 8);
+            {
+                auto bv = jh::pod::bytes_view::from(total_bits);
+                os.write(bv.fetch<char>(0), sizeof(total_bits));
+            }
 
             std::uint8_t buf = 0;
             int cnt = 0;
@@ -698,11 +705,11 @@ namespace jh::serio {
                 throw std::runtime_error("Bad signature");
 
             // ---------- Read freq for normal huffman ----------
-            std::vector<std::uint32_t> freq(table_size);
+            jh::pod::array<std::uint32_t, table_size> freq{};
 
             if constexpr (!is_canonical) {
-                for (size_t i = 0; i < table_size; i++)
-                    is.read(reinterpret_cast<char *>(&freq[i]), 4);
+                auto bv = jh::pod::bytes_view::from(freq);
+                is.read(const_cast<char *>(bv.template fetch<char>(0)), bv.size());
             }
 
             std::vector<node> pool;
@@ -724,7 +731,10 @@ namespace jh::serio {
                 build_canonical_decoder(len_tbl, dec);
 
                 std::uint64_t total_bits = 0;
-                is.read(reinterpret_cast<char *>(&total_bits), 8);
+                {
+                    auto bv = jh::pod::bytes_view::from(total_bits);
+                    is.read(const_cast<char *>(bv.fetch<char>(0)), sizeof(total_bits));
+                }
 
                 return canonical_decode(is, total_bits, dec);
             }
@@ -733,7 +743,10 @@ namespace jh::serio {
             root = build_tree(freq, pool);
 
             std::uint64_t total_bits = 0;
-            is.read(reinterpret_cast<char *>(&total_bits), 8);
+            {
+                auto bv = jh::pod::bytes_view::from(total_bits);
+                is.read(const_cast<char *>(bv.fetch<char>(0)), sizeof(total_bits));
+            }
 
             std::string out;
             out.reserve(total_bits / 3);
@@ -746,7 +759,8 @@ namespace jh::serio {
             int cnt = 0;
             std::uint64_t used = 0;
 
-            while (used < total_bits) {
+            while (used < total_bits) // NOLINT
+            {
                 if (cnt == 0) {
                     int b = is.get();
                     if (b == EOF) [[unlikely]]

--- a/include/jh/serialize_io/uri.h
+++ b/include/jh/serialize_io/uri.h
@@ -50,6 +50,20 @@
  * semantically UTF-8 strings, which should only be utilized within the runtime
  * serialization module <code>jh::serio</code>.
  *
+ * @note
+ * This header participates in the <b>Dual-Mode Header</b> system of the
+ * JH Toolkit.
+ * <ul>
+ *   <li>Linked through <b>jh::jh-toolkit</b> &mdash; the module behaves
+ *       as a <b>header-only</b> implementation compiled in user
+ *       translation units.</li>
+ *   <li>Linked through <b>jh::jh-toolkit-static</b> &mdash; the module
+ *       uses a <b>precompiled implementation</b> built with aggressive
+ *       optimization (typically <code>-O3</code>).</li>
+ * </ul>
+ * This design allows fast incremental builds while preserving the
+ * option of using a fully optimized static implementation.
+ *
  * @version <pre>1.4.1</pre>
  * @date <pre>2025</pre>
  */
@@ -59,10 +73,6 @@
 #include <string>
 #include <vector>
 #include <stdexcept>
-
-#include "jh/pods/string_view.h"
-#include "jh/detail/uri_common.h"
-#include "jh/metax/char.h"
 
 
 /**
@@ -126,22 +136,7 @@ namespace jh::serio::uri {
      *   <li>Use <code>encode_safe()</code> when input validation is required.</li>
      * </ul>
      */
-    [[nodiscard]] inline std::string encode(const std::string_view &input) {
-
-        std::uint64_t encoded_len =
-                jh::detail::uri_common::calculate_encoded_length(input.data(), input.size());
-
-        std::vector<std::uint8_t> buffer(encoded_len);
-
-        jh::detail::uri_common::uri_encode_unchecked(
-                input.data(),
-                input.size(),
-                buffer.data(),
-                encoded_len
-        );
-
-        return {buffer.begin(), buffer.end()};
-    }
+    [[nodiscard]] std::string encode(const std::string_view &input);
 
     /**
      * @brief Decode a percent-encoded URI string.
@@ -162,27 +157,7 @@ namespace jh::serio::uri {
      * @throw std::runtime_error
      * Thrown if the input contains malformed percent-encoding.
      */
-    [[nodiscard]] inline std::string decode(const std::string_view &input) {
-
-        std::uint64_t decoded_len =
-                jh::detail::uri_common::calculate_decoded_length(input.data(), input.size());
-
-        if (decoded_len == static_cast<std::uint64_t>(-1))
-            throw std::runtime_error(
-                    "Invalid URI: contains invalid percent-encoding."
-            );
-
-        std::vector<std::uint8_t> buffer(decoded_len);
-
-        jh::detail::uri_common::uri_decode_unchecked(
-                input.data(),
-                input.size(),
-                buffer.data(),
-                decoded_len
-        );
-
-        return {buffer.begin(), buffer.end()};
-    }
+    [[nodiscard]] std::string decode(const std::string_view &input);
 
     /**
      * @brief Encode a string into URI percent-encoded form with legality validation.
@@ -211,15 +186,7 @@ namespace jh::serio::uri {
      *   <li>Recommended for external or untrusted input.</li>
      * </ul>
      */
-    [[nodiscard]] inline std::string encode_safe(const std::string_view &input) {
-
-        if (!jh::pod::string_view{input.data(), input.size()}.is_legal())
-            throw std::runtime_error(
-                    "Invalid input: non-UTF-8 or contains control characters."
-            );
-
-        return encode(input);
-    }
+    [[nodiscard]] std::string encode_safe(const std::string_view &input);
 
     /**
      * @brief Decode a percent-encoded URI string with output validation.
@@ -247,7 +214,71 @@ namespace jh::serio::uri {
      * untrusted sources such as URLs, HTTP parameters, or
      * user input.
      */
-    [[nodiscard]] inline std::string decode_safe(const std::string_view &input) {
+    [[nodiscard]] std::string decode_safe(const std::string_view &input);
+
+} // namespace jh::serio::uri
+
+#include "jh/macros/header_begin.h"
+
+#if JH_INTERNAL_SHOULD_DEFINE
+
+#include "jh/pods/string_view.h"
+#include "jh/detail/uri_common.h"
+#include "jh/metax/char.h"
+
+namespace jh::serio::uri {
+
+
+    [[nodiscard]] JH_INLINE std::string encode(const std::string_view &input) {
+
+        std::uint64_t encoded_len =
+                jh::detail::uri_common::calculate_encoded_length(input.data(), input.size());
+
+        std::vector<std::uint8_t> buffer(encoded_len);
+
+        jh::detail::uri_common::uri_encode_unchecked(
+                input.data(),
+                input.size(),
+                buffer.data(),
+                encoded_len
+        );
+
+        return {buffer.begin(), buffer.end()};
+    }
+
+    [[nodiscard]] JH_INLINE std::string decode(const std::string_view &input) {
+
+        std::uint64_t decoded_len =
+                jh::detail::uri_common::calculate_decoded_length(input.data(), input.size());
+
+        if (decoded_len == static_cast<std::uint64_t>(-1))
+            throw std::runtime_error(
+                    "Invalid URI: contains invalid percent-encoding."
+            );
+
+        std::vector<std::uint8_t> buffer(decoded_len);
+
+        jh::detail::uri_common::uri_decode_unchecked(
+                input.data(),
+                input.size(),
+                buffer.data(),
+                decoded_len
+        );
+
+        return {buffer.begin(), buffer.end()};
+    }
+
+    [[nodiscard]] JH_INLINE std::string encode_safe(const std::string_view &input) {
+
+        if (!jh::pod::string_view{input.data(), input.size()}.is_legal())
+            throw std::runtime_error(
+                    "Invalid input: non-UTF-8 or contains control characters."
+            );
+
+        return encode(input);
+    }
+
+    [[nodiscard]] JH_INLINE std::string decode_safe(const std::string_view &input) {
 
         auto output = decode(input);
 
@@ -260,3 +291,7 @@ namespace jh::serio::uri {
     }
 
 } // namespace jh::serio::uri
+
+#endif // JH_INTERNAL_SHOULD_DEFINE
+
+#include "jh/macros/header_end.h"

--- a/include/jh/serialize_io/uri.h
+++ b/include/jh/serialize_io/uri.h
@@ -1,0 +1,262 @@
+/**
+ * @copyright
+ * Copyright 2025 JeongHan-Bae &lt;mastropseudo\@gmail.com&gt;
+ * <br>
+ * Licensed under the Apache License, Version 2.0 (the "License"); <br>
+ * you may not use this file except in compliance with the License.<br>
+ * You may obtain a copy of the License at<br>
+ * <br>
+ *     http://www.apache.org/licenses/LICENSE-2.0<br>
+ * <br>
+ * Unless required by applicable law or agreed to in writing, software<br>
+ * distributed under the License is distributed on an "AS IS" BASIS,<br>
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br>
+ * See the License for the specific language governing permissions and<br>
+ * limitations under the License.<br>
+ * <br>
+ * Full license: <a href="https://github.com/JeongHan-Bae/JH-Toolkit?tab=Apache-2.0-1-ov-file#readme">GitHub</a>
+ */
+/**
+ * @file uri.h
+ * @author JeongHan-Bae <a href="mailto:mastropseudo&#64;gmail.com">&lt;mastropseudo\@gmail.com&gt;</a>
+ * @brief High-level URI percent-encoding and decoding interface for the JH Toolkit.
+ *
+ * <p>
+ * This header provides a modern, safe, and portable implementation of
+ * <b>URI percent-encoding</b> and <b>percent-decoding</b>.
+ * It belongs to the <b>JH Toolkit Serialization I/O module</b>
+ * (<code>jh::serio</code>) and provides text-safe encoding utilities
+ * for URI and URL components.
+ * </p>
+ *
+ * <h3>Design overview</h3>
+ * <ul>
+ *   <li>Implements URI percent-encoding according to <b>RFC 3986</b>.</li>
+ *   <li>Provides both <b>unchecked</b> and <b>validated</b> encoding/decoding interfaces.</li>
+ *   <li>Supports fast encoding using precomputed character classification.</li>
+ *   <li>Validation-aware APIs ensure UTF-8 correctness and prevent control characters.</li>
+ *   <li>Fully portable and suitable for network, HTTP, and web serialization.</li>
+ * </ul>
+ *
+ * @note
+ * Unlike the <tt>base64</tt> module, although the <tt>uri</tt> module could theoretically
+ * support constexpr at the implementation level, it does not provide a compile-time solution
+ * like <code>jh::meta::base64</code>.
+ * <br>
+ * This is because, in practical use, <code>jh::meta::base64</code> enables embedding NTTP strings
+ * via macros and parsing them into binary resources.
+ * <br>
+ * However, URI processing does not require this capability. The data handled by URI is
+ * semantically UTF-8 strings, which should only be utilized within the runtime
+ * serialization module <code>jh::serio</code>.
+ *
+ * @version <pre>1.4.1</pre>
+ * @date <pre>2025</pre>
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <stdexcept>
+
+#include "jh/pods/string_view.h"
+#include "jh/detail/uri_common.h"
+#include "jh/metax/char.h"
+
+
+/**
+ * @brief Implements URI percent-encoding and decoding utilities.
+ *
+ * <p>
+ * URI percent-encoding converts unsafe characters into a textual
+ * representation using the <code>\%XX</code> hexadecimal format.
+ * This ensures that arbitrary data can be safely embedded within
+ * URI strings and transported through text-based protocols such
+ * as HTTP, REST APIs, or web forms.
+ * </p>
+ *
+ * <p>
+ * This namespace provides high-level wrappers built on top of the
+ * optimized primitives in <code>jh::detail::uri_common</code>.
+ * </p>
+ *
+ * <ul>
+ *   <li><b>Basic APIs</b> assume the user passes any arbitrary string,
+ *       allowing non-UTF-8 encoding or arbitrary binary data.</li>
+ *   <li><b>Safe APIs</b> assume that user input is always UTF-8 semantics
+ *       and throw errors when encountering control characters or malformed
+ *       UTF-8 concatenations.</li>
+ * </ul>
+ *
+ * Whether to use the unchecked version has no impact on performance.
+ * The additional checks in the <code>*_safe</code> functions are nearly
+ * equivalent to traversing a <code>string_view</code>.
+ *
+ * @note Although we support encoding and decoding for data representing arbitrary
+ *       binary and its precent-encoding, for this particular semantics, we
+ *       recommend base64 encoding from <code>jh::serio::base64</code> and
+ *       <code>jh::serio::base64url</code>.
+ *       URI percent-encoding is primarily intended for encoding textual data.
+ * @see jh::serio::base64
+ * @see jh::serio::base64url
+ */
+namespace jh::serio::uri {
+
+    /**
+     * @brief Encode a string into URI percent-encoded form.
+     *
+     * <p>
+     * Characters that are not part of the unreserved URI character set
+     * are converted into their percent-encoded representation
+     * (<code>\%XX</code>).
+     * </p>
+     *
+     * <p>
+     * This function performs <b>no input validation</b> and assumes that
+     * the input string is already legal UTF-8.
+     * </p>
+     *
+     * @param input Input string to encode.
+     * @return A percent-encoded URI string.
+     *
+     * @note
+     * <ul>
+     *   <li>This function assumes the source intentionally permits non-UTF-8 encoding.</li>
+     *   <li>Use <code>encode_safe()</code> when input validation is required.</li>
+     * </ul>
+     */
+    [[nodiscard]] inline std::string encode(const std::string_view &input) {
+
+        std::uint64_t encoded_len =
+                jh::detail::uri_common::calculate_encoded_length(input.data(), input.size());
+
+        std::vector<std::uint8_t> buffer(encoded_len);
+
+        jh::detail::uri_common::uri_encode_unchecked(
+                input.data(),
+                input.size(),
+                buffer.data(),
+                encoded_len
+        );
+
+        return {buffer.begin(), buffer.end()};
+    }
+
+    /**
+     * @brief Decode a percent-encoded URI string.
+     *
+     * <p>
+     * This function converts percent-encoded sequences (<code>\%XX</code>)
+     * back into their original byte representation.
+     * </p>
+     *
+     * <p>
+     * The input is validated to ensure that all percent-encoded
+     * sequences are syntactically correct.
+     * </p>
+     *
+     * @param input Percent-encoded URI string.
+     * @return Decoded URI string.
+     *
+     * @throw std::runtime_error
+     * Thrown if the input contains malformed percent-encoding.
+     */
+    [[nodiscard]] inline std::string decode(const std::string_view &input) {
+
+        std::uint64_t decoded_len =
+                jh::detail::uri_common::calculate_decoded_length(input.data(), input.size());
+
+        if (decoded_len == static_cast<std::uint64_t>(-1))
+            throw std::runtime_error(
+                    "Invalid URI: contains invalid percent-encoding."
+            );
+
+        std::vector<std::uint8_t> buffer(decoded_len);
+
+        jh::detail::uri_common::uri_decode_unchecked(
+                input.data(),
+                input.size(),
+                buffer.data(),
+                decoded_len
+        );
+
+        return {buffer.begin(), buffer.end()};
+    }
+
+    /**
+     * @brief Encode a string into URI percent-encoded form with legality validation.
+     *
+     * <p>
+     * This variant verifies that the input string represents a
+     * <b>legal textual payload</b> before performing the encoding.
+     * </p>
+     *
+     * <ul>
+     *   <li>The input must be valid UTF-8.</li>
+     *   <li>No control characters are permitted.</li>
+     * </ul>
+     *
+     * @param input Input string to encode.
+     * @return A percent-encoded URI string.
+     *
+     * @throw std::runtime_error
+     * Thrown if the input string contains invalid UTF-8 or control characters.
+     *
+     * @note
+     * Use this function when you want to ensure that the input is a well-formed UTF-8 string.
+     * <ul>
+     *   <li>This function provides a stronger safety guarantee than
+     *       <code>encode()</code>.</li>
+     *   <li>Recommended for external or untrusted input.</li>
+     * </ul>
+     */
+    [[nodiscard]] inline std::string encode_safe(const std::string_view &input) {
+
+        if (!jh::pod::string_view{input.data(), input.size()}.is_legal())
+            throw std::runtime_error(
+                    "Invalid input: non-UTF-8 or contains control characters."
+            );
+
+        return encode(input);
+    }
+
+    /**
+     * @brief Decode a percent-encoded URI string with output validation.
+     *
+     * <p>
+     * This function first performs percent-decoding and then verifies
+     * that the resulting string is a <b>legal textual representation</b>.
+     * </p>
+     *
+     * <ul>
+     *   <li>The decoded output must be valid UTF-8.</li>
+     *   <li>No control characters are permitted.</li>
+     * </ul>
+     *
+     * @param input Percent-encoded URI string.
+     * @return Decoded URI string.
+     *
+     * @throw std::runtime_error
+     * If the input contains malformed percent-encoding.
+     * <br>
+     * Or if the decoded result is not a legal UTF-8 string.
+     *
+     * @note
+     * This function should be used when decoding data from
+     * untrusted sources such as URLs, HTTP parameters, or
+     * user input.
+     */
+    [[nodiscard]] inline std::string decode_safe(const std::string_view &input) {
+
+        auto output = decode(input);
+
+        if (!jh::pod::string_view{output.data(), output.size()}.is_legal())
+            throw std::runtime_error(
+                    "Decoded output is not legal: non-UTF-8 or contains control characters."
+            );
+
+        return output;
+    }
+
+} // namespace jh::serio::uri

--- a/include/jh/serio
+++ b/include/jh/serio
@@ -33,6 +33,7 @@
 
 #include "jh/serialize_io/base64.h"
 #include "jh/serialize_io/huffman.h"
+#include "jh/serialize_io/uri.h"
 
 /**
  * @brief Aggregated entry point for serialization and codec utilities.

--- a/include/jh/sync
+++ b/include/jh/sync
@@ -28,6 +28,7 @@
 #include "jh/synchronous/ipc.h"
 #include "jh/synchronous/const_lock.h"
 #include "jh/synchronous/control_buf.h"
+#include "jh/synchronous/strong_lock.h"
 
 /**
  * @brief Aggregated entry point for synchronization and coordination facilities.

--- a/include/jh/synchronous/control_buf.h
+++ b/include/jh/synchronous/control_buf.h
@@ -55,7 +55,7 @@
  * <h3>Core Features</h3>
  * <ul>
  *   <li>Block-based allocation: memory grows by allocating fixed-sized blocks on demand.</li>
- *   <li><b>Block size:</b> each block contains <code>JH_FIXED_VEC_BLOCK_SIZE</code> elements
+ *   <li><b>Block size:</b> each block contains <code>JH_CTRL_BUFFER_BLOCK_SIZE</code> elements
  *       (default: 64). This can be configured via a preprocessor macro.</li>
  *   <li>Each element is <b>default-constructed in-place</b>; no relocation, no reordering.</li>
  *   <li><b>Strict type constraints</b>: relocation-disabled types only (e.g. <code>std::mutex</code>).</li>
@@ -88,8 +88,16 @@
 #include <type_traits>
 #include "jh/conceptual/container_traits.h"
 
-#ifndef JH_FIXED_VEC_BLOCK_SIZE
-#define JH_FIXED_VEC_BLOCK_SIZE 64
+/**
+ * @brief Specifies the number of elements allocated per block in
+ * jh::sync::control_buf (default: 64).
+ *
+ * This macro controls the fixed block size used for internal
+ * block-based allocation. Larger values reduce allocation frequency
+ * but increase per-block memory usage.
+ */
+#ifndef JH_CTRL_BUFFER_BLOCK_SIZE
+#define JH_CTRL_BUFFER_BLOCK_SIZE 64
 #endif
 
 
@@ -112,7 +120,7 @@ namespace jh::sync {
     class control_buf final {
     public:
         /// @brief Number of elements per allocation block.
-        static constexpr std::size_t BLOCK_SIZE = JH_FIXED_VEC_BLOCK_SIZE;
+        static constexpr std::size_t BLOCK_SIZE = JH_CTRL_BUFFER_BLOCK_SIZE;
 
         /// @brief Type of allocator used for element construction.
         using allocator_type = typename std::allocator_traits<Alloc>::template rebind_alloc<T>;

--- a/include/jh/synchronous/ipc/ipc_limits.h
+++ b/include/jh/synchronous/ipc/ipc_limits.h
@@ -70,10 +70,18 @@
 #include "jh/macros/platform.h"
 #include <cstdint>
 
+/**
+ * @brief Controls whether leading "../" segments are allowed in
+ * compile-time validated POSIX-style relative IPC paths.
+ */
 #ifndef JH_ALLOW_PARENT_PATH
 #define JH_ALLOW_PARENT_PATH 0
 #endif
 
+/**
+ * @brief Forces IPC object names to use the strict BSD length limit
+ * (30 characters) regardless of detected platform.
+ */
 #ifndef JH_FORCE_SHORT_SEM_NAME
 #define JH_FORCE_SHORT_SEM_NAME 0
 #endif

--- a/include/jh/synchronous/ipc/ipc_limits.h
+++ b/include/jh/synchronous/ipc/ipc_limits.h
@@ -74,8 +74,8 @@
  * @brief Controls whether leading "../" segments are allowed in
  * compile-time validated POSIX-style relative IPC paths.
  */
-#ifndef JH_ALLOW_PARENT_PATH
-#define JH_ALLOW_PARENT_PATH 0
+#ifndef JH_INTERPROCESS_ALLOW_PARENT_PATH
+#define JH_INTERPROCESS_ALLOW_PARENT_PATH 0
 #endif
 
 /**
@@ -114,13 +114,7 @@ namespace jh::sync::ipc::limits {
                    (c >= '0' && c <= '9') ||
                    c == '_' || c == '-' || c == '.';
         }
-        /// Check if a character is valid in a POSIX relative path.
-        consteval bool is_path_char(char c) noexcept {
-            return (c >= 'A' && c <= 'Z') ||
-                   (c >= 'a' && c <= 'z') ||
-                   (c >= '0' && c <= '9') ||
-                   c == '_' || c == '-' || c == '.' || c == '/';
-        }
+
     } // namespace detail
 
     /**
@@ -161,8 +155,8 @@ namespace jh::sync::ipc::limits {
      *   <li>No <code>"./"</code> segments.</li>
      *   <li><code>".."</code> segments:
      *     <ul>
-     *       <li>When <code>JH_ALLOW_PARENT_PATH == 0</code> &rarr; forbidden.</li>
-     *       <li>When <code>JH_ALLOW_PARENT_PATH == 1</code> &rarr; leading <code>"../"</code>
+     *       <li>When <code>JH_INTERPROCESS_ALLOW_PARENT_PATH == 0</code> &rarr; forbidden.</li>
+     *       <li>When <code>JH_INTERPROCESS_ALLOW_PARENT_PATH == 1</code> &rarr; leading <code>"../"</code>
      *       allowed but cannot occupy entire path, and no <code>".."</code> after content begins.</li>
      *     </ul>
      *   </li>
@@ -170,35 +164,12 @@ namespace jh::sync::ipc::limits {
      * </ul>
      */
     template<jh::meta::TStr S>
-    consteval bool valid_relative_path() {
-        if (S.size() < 1) return false;
-        if (S.size() > 128) return false;
-        if (S.val()[0] == '/') return false;   // absolute path forbidden
-
-        std::uint64_t i = 0;
-
-#if JH_ALLOW_PARENT_PATH
-        // Allow leading "../" segments
-        while (i + 2 < S.size() &&
-               S.val()[i] == '.' &&
-               S.val()[i + 1] == '.' &&
-               S.val()[i + 2] == '/')
-        {
-            i += 3;
-        }
-        if (i == S.size()) return false; // path cannot be only ../
+    consteval bool valid_relative_path() noexcept {
+#if JH_INTERPROCESS_ALLOW_PARENT_PATH
+        return S.template is_valid_relative_path<true>();
+#else
+        return S.template is_valid_relative_path<false>();
 #endif
-
-        for (; i < S.size(); ++i) {
-            if (!detail::is_path_char(S.val()[i]))
-                return false;
-
-            // reject ".." appearing mid-path
-            if (S.val()[i] == '.' && i + 1 < S.size() && S.val()[i + 1] == '.')
-                return false;
-        }
-
-        return true;
     }
 
 } // namespace jh::sync::ipc::limits

--- a/include/jh/synchronous/ipc/ipc_limits.h
+++ b/include/jh/synchronous/ipc/ipc_limits.h
@@ -165,11 +165,44 @@ namespace jh::sync::ipc::limits {
      */
     template<jh::meta::TStr S>
     consteval bool valid_relative_path() noexcept {
+#if JH_GCC_LE_13
+        // GCC13 is so flawed that it fails to properly
+        // derive certain constexpr functions related to the NTTP template.
+        // Occasionally, "this" fails to resolve, forcing us to implement workarounds.
+        if (S.size() < 1) return false;
+        if (S.size() > 128) return false;
+        if (S.val()[0] == '/') return false;   // absolute path forbidden
+
+        std::uint64_t i = 0;
+
+#if JH_INTERPROCESS_ALLOW_PARENT_PATH     // Allow leading "../" segments
+        while (i + 2 < S.size() &&
+               S.val()[i] == '.' &&
+               S.val()[i + 1] == '.' &&
+               S.val()[i + 2] == '/')
+        {
+            i += 3;
+        }
+        if (i == S.size()) return false; // path cannot be only ../
+#endif // JH_INTERPROCESS_ALLOW_PARENT_PATH
+
+        for (; i < S.size(); ++i) {
+            if (!jh::meta::detail::is_path_char(S.val()[i]))
+                return false;
+
+            // reject ".." appearing mid-path
+            if (S.val()[i] == '.' && i + 1 < S.size() && S.val()[i + 1] == '.')
+                return false;
+        }
+
+        return true;
+#else // JH_GCC_LE_13 == 0, normal implementation works
 #if JH_INTERPROCESS_ALLOW_PARENT_PATH
         return S.template is_valid_relative_path<true>();
-#else
+#else // JH_INTERPROCESS_ALLOW_PARENT_PATH == 0
         return S.template is_valid_relative_path<false>();
-#endif
+#endif // JH_INTERPROCESS_ALLOW_PARENT_PATH
+#endif // JH_GCC_LE_13
     }
 
 } // namespace jh::sync::ipc::limits

--- a/include/jh/synchronous/ipc/process_cond_var.h
+++ b/include/jh/synchronous/ipc/process_cond_var.h
@@ -111,6 +111,7 @@
 #if IS_WINDOWS
 #include <windows.h>
 #else
+
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -118,6 +119,7 @@
 #include <cerrno>
 #include <cstring>
 #include <pthread.h>
+
 #endif
 
 namespace jh::sync::ipc {
@@ -196,8 +198,7 @@ namespace jh::sync::ipc {
      *   <li>Windows implementation provides approximate equivalence, not strict parity.</li>
      * </ul>
      */
-    template <jh::meta::TStr S, bool HighPriv = false>
-    requires (limits::valid_object_name<S, limits::max_name_length>())
+    template<jh::meta::TStr S, bool HighPriv = false> requires (limits::valid_object_name<S, limits::max_name_length>())
     class process_cond_var final {
     private:
 #if IS_WINDOWS
@@ -214,7 +215,7 @@ namespace jh::sync::ipc {
         };
 
         int fd_ = -1;
-        cond_data* data_ = nullptr;
+        cond_data *data_ = nullptr;
 #endif
 
         process_cond_var() {
@@ -234,22 +235,23 @@ namespace jh::sync::ipc {
                 throw std::runtime_error("process_cond_var: shm_open failed (errno=" + std::to_string(errno) + ")");
 
             // 2. global init guard
-            auto& init_guard = process_mutex<S>::instance();
+            auto &init_guard = process_mutex<S>::instance();
             std::lock_guard lock(init_guard);
 
             // 3. ensure size
             struct stat st{};
             if (::fstat(fd_, &st) == -1)
                 throw std::runtime_error("process_cond_var: fstat failed (errno=" + std::to_string(errno) + ")");
-            if (st.st_size < sizeof(cond_data))
+            if (st.st_size < 0 || (static_cast<std::size_t>(st.st_size) < sizeof(cond_data)))
                 if (::ftruncate(fd_, sizeof(cond_data)) == -1)
-                    throw std::runtime_error("process_cond_var: ftruncate failed (errno=" + std::to_string(errno) + ")");
+                    throw std::runtime_error(
+                            "process_cond_var: ftruncate failed (errno=" + std::to_string(errno) + ")");
 
             // 4. mmap
-            void* ptr = ::mmap(nullptr, sizeof(cond_data), PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+            void *ptr = ::mmap(nullptr, sizeof(cond_data), PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
             if (ptr == MAP_FAILED)
                 throw std::runtime_error("process_cond_var: mmap failed (errno=" + std::to_string(errno) + ")");
-            data_ = static_cast<cond_data*>(ptr);
+            data_ = static_cast<cond_data *>(ptr);
             ::close(fd_);
 
             // 5. initialize once
@@ -282,13 +284,14 @@ namespace jh::sync::ipc {
         }
 
     public:
-        static process_cond_var& instance() {
+        static process_cond_var &instance() {
             static process_cond_var inst;
             return inst;
         }
 
-        process_cond_var(const process_cond_var&) = delete;
-        process_cond_var& operator=(const process_cond_var&) = delete;
+        process_cond_var(const process_cond_var &) = delete;
+
+        process_cond_var &operator=(const process_cond_var &) = delete;
 
         /**
          * @brief Wait until a signal or broadcast occurs.
@@ -323,8 +326,8 @@ namespace jh::sync::ipc {
          *
          * @return <code>true</code> if signaled before timeout, otherwise <code>false</code>.
          */
-        template <typename Clock, typename Duration>
-        bool wait_until(const std::chrono::time_point<Clock, Duration>& tp) noexcept {
+        template<typename Clock, typename Duration>
+        bool wait_until(const std::chrono::time_point<Clock, Duration> &tp) noexcept {
 #if IS_WINDOWS
             auto rel = std::chrono::duration_cast<std::chrono::milliseconds>(tp - Clock::now());
             DWORD timeout = (rel.count() > 0) ? static_cast<DWORD>(rel.count()) : 0;
@@ -336,7 +339,7 @@ namespace jh::sync::ipc {
             auto secs = std::chrono::time_point_cast<std::chrono::seconds>(tp);
             auto nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(tp - secs);
             timespec ts{};
-            ts.tv_sec  = static_cast<time_t>(secs.time_since_epoch().count());
+            ts.tv_sec = static_cast<time_t>(secs.time_since_epoch().count());
             ts.tv_nsec = static_cast<long>(nsec.count());
 
             pthread_mutex_lock(&data_->mutex);
@@ -388,6 +391,7 @@ namespace jh::sync::ipc {
             notify_all(32);
         }
 #else
+
         /**
          * @brief Wake multiple waiting processes (POSIX implementation).
          *
@@ -404,6 +408,7 @@ namespace jh::sync::ipc {
                 pthread_cond_signal(&data_->cond);
             pthread_mutex_unlock(&data_->mutex);
         }
+
 #endif
 
         /**

--- a/include/jh/synchronous/ipc/process_counter.h
+++ b/include/jh/synchronous/ipc/process_counter.h
@@ -96,10 +96,12 @@
 #if IS_WINDOWS
 #include <windows.h>
 #else
+
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+
 #endif
 
 namespace jh::sync::ipc {
@@ -183,15 +185,15 @@ namespace jh::sync::ipc {
      *       subsequent accesses reuse the same shared mapping.</li>
      * </ul>
      */
-    template <jh::meta::TStr S, bool HighPriv = false>
-    requires (limits::valid_object_name<S, limits::max_name_length - 4>())
+    template<jh::meta::TStr S, bool HighPriv = false> requires (limits::valid_object_name<S,
+            limits::max_name_length - 4>())
     class process_counter final {
     private:
 
 #if IS_WINDOWS
         static constexpr auto shm_name_  = jh::meta::TStr{"Global\\"} + S;
 #else
-        static constexpr auto shm_name_  = jh::meta::TStr{"/"} + S;
+        static constexpr auto shm_name_ = jh::meta::TStr{"/"} + S;
         static constexpr mode_t shm_mode = JH_PROCESS_MUTEX_SHARED ? 0666 : 0644;
 #endif
 
@@ -207,8 +209,8 @@ namespace jh::sync::ipc {
 #else
         int fd_ = -1;
 #endif
-        counter_data* data_ = nullptr;
-        lock_t& lock_;
+        counter_data *data_ = nullptr;
+        lock_t &lock_;
 
         process_counter() : lock_(lock_t::instance()) {
 #if IS_WINDOWS
@@ -229,17 +231,17 @@ namespace jh::sync::ipc {
             struct stat st{};
             if (::fstat(fd_, &st) == -1)
                 throw std::runtime_error("process_counter: fstat failed (errno=" + std::to_string(errno) + ")");
-            if (st.st_size < sizeof(counter_data))
+            if (st.st_size < 0 || (static_cast<std::size_t>(st.st_size) < sizeof(counter_data)))
                 if (::ftruncate(fd_, sizeof(counter_data)) == -1)
                     throw std::runtime_error("process_counter: ftruncate failed (errno=" + std::to_string(errno) + ")");
-            void* ptr = ::mmap(nullptr, sizeof(counter_data), PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+            void *ptr = ::mmap(nullptr, sizeof(counter_data), PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
             if (ptr == MAP_FAILED)
                 throw std::runtime_error("process_counter: mmap failed (errno=" + std::to_string(errno) + ")");
-            data_ = static_cast<counter_data*>(ptr);
+            data_ = static_cast<counter_data *>(ptr);
             ::close(fd_);
 #endif
             // initialization guard
-            auto& init_guard = process_mutex<S>::instance();
+            auto &init_guard = process_mutex<S>::instance();
             std::lock_guard global_lock(init_guard);
             std::lock_guard counter_lock(lock_);
             if (!data_->initialized) {
@@ -259,11 +261,12 @@ namespace jh::sync::ipc {
 
     public:
         // Disable copy
-        process_counter(const process_counter&) = delete;
-        process_counter& operator=(const process_counter&) = delete;
+        process_counter(const process_counter &) = delete;
+
+        process_counter &operator=(const process_counter &) = delete;
 
         /// @brief Singleton instance.
-        static process_counter& instance() {
+        static process_counter &instance() {
             static process_counter inst;
             return inst;
         }
@@ -386,10 +389,10 @@ namespace jh::sync::ipc {
          * @param func Transformation function.
          * @return The previous counter value before transformation.
          */
-        template <typename F>
+        template<typename F>
         requires std::invocable<F, std::uint64_t> &&
                  std::same_as<std::invoke_result_t<F, std::uint64_t>, std::uint64_t>
-        std::uint64_t fetch_apply(F&& func) noexcept(noexcept(std::invoke(std::forward<F>(func), std::uint64_t{}))) {
+        std::uint64_t fetch_apply(F &&func) noexcept(noexcept(std::invoke(std::forward<F>(func), std::uint64_t{}))) {
             std::lock_guard guard(lock_);
             auto old = data_->value;
             auto new_v = std::invoke(std::forward<F>(func), old);
@@ -435,6 +438,7 @@ namespace jh::sync::ipc {
             lock_t::unlink();
 #endif
         }
+
         /// Disabled if HighPriv == false. Non-privileged variants cannot call unlink().
         static void unlink() requires(!HighPriv) = delete;
     };

--- a/include/jh/synchronous/ipc/process_launcher.h
+++ b/include/jh/synchronous/ipc/process_launcher.h
@@ -196,8 +196,10 @@
 #if IS_WINDOWS
 #include <windows.h>  // STARTUPINFO, PROCESS_INFORMATION, CreateProcess, WaitForSingleObject, CloseHandle
 #elif IS_POSIX
+
 #include <unistd.h>   // fork, execl, _exit
 #include <sys/wait.h> // waitpid
+
 #endif
 
 
@@ -264,8 +266,7 @@ namespace jh::sync::ipc {
      * and parameter combination.
      * </p>
      */
-    template<jh::meta::TStr Path, bool IsBinary = true>
-    requires (limits::valid_relative_path<Path>())
+    template<jh::meta::TStr Path, bool IsBinary = true> requires (limits::valid_relative_path<Path>())
     class process_launcher final {
     public:
         process_launcher() = delete;                                    ///< Not constructible.

--- a/include/jh/synchronous/ipc/process_launcher.h
+++ b/include/jh/synchronous/ipc/process_launcher.h
@@ -75,8 +75,8 @@
  *       <li><code>"./"</code> segments are meaningless and rejected.</li>
  *       <li><code>".."</code> handling:
  *         <ul>
- *           <li>By default (<code>JH_ALLOW_PARENT_PATH == 0</code>): any <code>".."</code> is forbidden.</li>
- *           <li>If <code>JH_ALLOW_PARENT_PATH == 1</code>: leading <code>"../"</code> prefixes are permitted
+ *           <li>By default (<code>JH_INTERPROCESS_ALLOW_PARENT_PATH == 0</code>): any <code>".."</code> is forbidden.</li>
+ *           <li>If <code>JH_INTERPROCESS_ALLOW_PARENT_PATH == 1</code>: leading <code>"../"</code> prefixes are permitted
  *               (one or more), but:
  *             <ul>
  *               <li>The entire path cannot consist only of <code>"../"</code> segments.</li>
@@ -102,7 +102,7 @@
  *       <li>Absolute paths (<code>"/foo/bar"</code>) are forbidden by design.</li>
  *     </ul>
  *   </li>
- *   <li><strong>Parent path relaxation</strong> (<code>JH_ALLOW_PARENT_PATH</code>):
+ *   <li><strong>Parent path relaxation</strong> (<code>JH_INTERPROCESS_ALLOW_PARENT_PATH</code>):
  *     <ul>
  *       <li>Disabled (default = 0): any <code>".."</code> usage is an error.</li>
  *       <li>Enabled (= 1): only leading <code>"../"</code> prefixes are permitted;
@@ -181,8 +181,8 @@
 
 #pragma once
 
-#ifndef JH_ALLOW_PARENT_PATH
-#define JH_ALLOW_PARENT_PATH 0
+#ifndef JH_INTERPROCESS_ALLOW_PARENT_PATH
+#define JH_INTERPROCESS_ALLOW_PARENT_PATH 0
 #endif
 
 #include "jh/macros/platform.h"
@@ -214,8 +214,8 @@ namespace jh::sync::ipc {
      *             <li><code>"./"</code> segments are disallowed.</li>
      *             <li><code>".."</code> handling:
      *               <ul>
-     *                 <li>Default (<code>JH_ALLOW_PARENT_PATH == 0</code>): any <code>".."</code> is rejected.</li>
-     *                 <li>Relaxed (<code>JH_ALLOW_PARENT_PATH == 1</code>): only leading <code>"../"</code>
+     *                 <li>Default (<code>JH_INTERPROCESS_ALLOW_PARENT_PATH == 0</code>): any <code>".."</code> is rejected.</li>
+     *                 <li>Relaxed (<code>JH_INTERPROCESS_ALLOW_PARENT_PATH == 1</code>): only leading <code>"../"</code>
      *                     prefixes are allowed, and the path must contain additional content afterwards.</li>
      *                 <li>Once non-empty content has been appended, <code>".."</code> is forbidden.</li>
      *               </ul>
@@ -242,7 +242,7 @@ namespace jh::sync::ipc {
      *       <li>Absolute paths (<code>"/foo/bar"</code>) are forbidden.</li>
      *     </ul>
      *   </li>
-     *   <li><strong>Parent path relaxation</strong> (<code>JH_ALLOW_PARENT_PATH</code>):
+     *   <li><strong>Parent path relaxation</strong> (<code>JH_INTERPROCESS_ALLOW_PARENT_PATH</code>):
      *     <ul>
      *       <li>Disabled (default = 0): any <code>".."</code> usage is invalid.</li>
      *       <li>Enabled (= 1): leading <code>"../"</code> prefixes are allowed,
@@ -452,10 +452,10 @@ namespace jh::sync::ipc {
             }
             return handle{pi};
 #elif IS_POSIX
-            std::string exe = "./" + std::string(Path.val());
+            auto exe = jh::meta::TStr{"./"} + Path;
             pid_t pid = fork();
             if (pid == 0) {
-                execl(exe.c_str(), exe.c_str(), nullptr);
+                execl(exe.val(), exe.val(), nullptr);
                 // exec failed: safely terminate only the child process (avoid atexit/DTOR)
                 _exit(1);
             }

--- a/include/jh/synchronous/ipc/process_mutex.h
+++ b/include/jh/synchronous/ipc/process_mutex.h
@@ -140,12 +140,15 @@
 #if IS_WINDOWS
 #include <windows.h>
 #else
+
 #include <semaphore.h>
 #include <fcntl.h>
 #include <cerrno>
+
 #endif
 
 #if !IS_WINDOWS
+
 #include <sys/stat.h>
 
 namespace jh::sync::ipc::detail {

--- a/include/jh/synchronous/ipc/process_shm_obj.h
+++ b/include/jh/synchronous/ipc/process_shm_obj.h
@@ -338,7 +338,7 @@ namespace jh::sync::ipc {
 #else
             if (::shm_unlink(shm_name_.val()) == -1 && errno != ENOENT)
                 throw std::runtime_error(
-                        "shm_unlink failed for " + std::string{shm_name_.val()} +
+                        "shm_unlink failed for " + shm_name_.str() +
                         " (errno=" + std::to_string(errno) + ")");
             process_mutex<S, HighPriv>::unlink();
             lock_t::unlink();

--- a/include/jh/synchronous/ipc/process_shm_obj.h
+++ b/include/jh/synchronous/ipc/process_shm_obj.h
@@ -123,10 +123,12 @@
 #if IS_WINDOWS
 #include <windows.h>
 #else
+
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+
 #endif
 
 namespace jh::sync::ipc {
@@ -142,15 +144,15 @@ namespace jh::sync::ipc {
      * @tparam T POD-like type satisfying <code>cv_free_pod_like</code>.
      * @tparam HighPriv Enables privileged operations (e.g. <code>unlink()</code>).
      */
-    template <jh::meta::TStr S, jh::pod::cv_free_pod_like T, bool HighPriv = false>
-    requires (limits::valid_object_name<S, limits::max_name_length - 4>())
+    template<jh::meta::TStr S, jh::pod::cv_free_pod_like T, bool HighPriv = false> requires (limits::valid_object_name<S,
+            limits::max_name_length - 4>())
     class process_shm_obj final {
     private:
 
 #if IS_WINDOWS
         static constexpr auto shm_name_  = jh::meta::TStr{"Global\\"} + S;
 #else
-        static constexpr auto shm_name_  = jh::meta::TStr{"/"} + S;
+        static constexpr auto shm_name_ = jh::meta::TStr{"/"} + S;
         static constexpr mode_t shm_mode = JH_PROCESS_MUTEX_SHARED ? 0666 : 0644;
 #endif
 
@@ -166,8 +168,8 @@ namespace jh::sync::ipc {
 #else
         int fd_ = -1;
 #endif
-        shm_data* data_ = nullptr;
-        lock_t& lock_;
+        shm_data *data_ = nullptr;
+        lock_t &lock_;
 
         process_shm_obj() : lock_(lock_t::instance()) {
 #if IS_WINDOWS
@@ -188,17 +190,17 @@ namespace jh::sync::ipc {
             struct stat st{};
             if (::fstat(fd_, &st) == -1)
                 throw std::runtime_error("process_shm_obj: fstat failed (errno=" + std::to_string(errno) + ")");
-            if (st.st_size < sizeof(shm_data))
+            if (st.st_size < 0 || (static_cast<std::size_t>(st.st_size) < sizeof(shm_data)))
                 if (::ftruncate(fd_, sizeof(shm_data)) == -1)
                     throw std::runtime_error("process_shm_obj: ftruncate failed (errno=" + std::to_string(errno) + ")");
-            void* ptr = ::mmap(nullptr, sizeof(shm_data), PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+            void *ptr = ::mmap(nullptr, sizeof(shm_data), PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
             if (ptr == MAP_FAILED)
                 throw std::runtime_error("process_shm_obj: mmap failed (errno=" + std::to_string(errno) + ")");
-            data_ = static_cast<shm_data*>(ptr);
+            data_ = static_cast<shm_data *>(ptr);
             ::close(fd_);
 #endif
             // initialization guard
-            auto& init_guard = process_mutex<S>::instance();
+            auto &init_guard = process_mutex<S>::instance();
             std::lock_guard global_lock(init_guard);
             std::lock_guard counter_lock(lock_);
             if (!data_->initialized) {
@@ -218,11 +220,12 @@ namespace jh::sync::ipc {
 
     public:
         // Disable copy
-        process_shm_obj(const process_shm_obj&) = delete;
-        process_shm_obj& operator=(const process_shm_obj&) = delete;
+        process_shm_obj(const process_shm_obj &) = delete;
+
+        process_shm_obj &operator=(const process_shm_obj &) = delete;
 
         /// @brief Singleton accessor.
-        static process_shm_obj& instance() {
+        static process_shm_obj &instance() {
             static process_shm_obj inst;
             return inst;
         }
@@ -231,55 +234,55 @@ namespace jh::sync::ipc {
          * @brief Obtain non-const pointer to the shared object.
          * @return Pointer to the mapped shared instance of <code>T</code>.
          */
-        [[nodiscard]] T* ptr() noexcept { return std::launder(&data_->obj); }
+        [[nodiscard]] T *ptr() noexcept { return std::launder(&data_->obj); }
 
         /**
          * @brief Obtain const pointer to the shared object.
          * @return Const pointer to the mapped shared instance.
          */
-        [[nodiscard]] const T* ptr() const noexcept { return std::launder(&data_->obj); }
+        [[nodiscard]] const T *ptr() const noexcept { return std::launder(&data_->obj); }
 
         /**
          * @brief Obtain non-const reference to the shared object.
          * @return Reference to the shared instance.
          */
-        [[nodiscard]] T& ref() noexcept { return *std::launder(&data_->obj); }
+        [[nodiscard]] T &ref() noexcept { return *std::launder(&data_->obj); }
 
         /**
          * @brief Obtain const reference to the shared object.
          * @return Const reference to the shared instance.
          */
-        [[nodiscard]] const T& ref() const noexcept { return *std::launder(&data_->obj); }
+        [[nodiscard]] const T &ref() const noexcept { return *std::launder(&data_->obj); }
 
         /**
          * @brief Operator-> convenience accessor.
          * @return Pointer to the shared object.
          */
-        [[nodiscard]] T* operator->() noexcept { return ptr(); }
+        [[nodiscard]] T *operator->() noexcept { return ptr(); }
 
         /**
          * @brief Const Operator-> convenience accessor.
          * @return Const pointer to the shared object.
          */
-        [[nodiscard]] const T* operator->() const noexcept { return ptr(); }
+        [[nodiscard]] const T *operator->() const noexcept { return ptr(); }
 
         /**
          * @brief Operator* convenience accessor.
          * @return Reference to the shared object.
          */
-        [[nodiscard]] T& operator*() noexcept { return ref(); }
+        [[nodiscard]] T &operator*() noexcept { return ref(); }
 
         /**
          * @brief Const Operator* convenience accessor.
          * @return Const reference to the shared object.
          */
-        [[nodiscard]] const T& operator*() const noexcept { return ref(); }
+        [[nodiscard]] const T &operator*() const noexcept { return ref(); }
 
         /**
          * @brief Accessor for the inter-process mutex protecting this shared object.
          * @return Reference to the internal <code>process_mutex&lt;S + ".loc"&gt;</code>.
          */
-        [[nodiscard]] lock_t& lock() noexcept { return lock_; }
+        [[nodiscard]] lock_t &lock() noexcept { return lock_; }
 
         /**
          * @brief Acquire fence ensuring visibility of preceding writes by other processes.
@@ -344,6 +347,7 @@ namespace jh::sync::ipc {
             lock_t::unlink();
 #endif
         }
+
         /// Disabled if HighPriv == false. Non-privileged variants cannot call unlink().
         static void unlink() requires(!HighPriv) = delete;
     };

--- a/include/jh/synchronous/ipc/shared_process_mutex.h
+++ b/include/jh/synchronous/ipc/shared_process_mutex.h
@@ -460,7 +460,7 @@ namespace jh::sync::ipc {
 
             if (!got_excl) {
                 if (!prior_.try_lock()) {
-                    std::cerr << "[FATAL] concurrent upgrade detected in shared_process_mutex<" << S.val() << ">\n";
+                    std::cerr << "[FATAL] concurrent upgrade detected in shared_process_mutex<" + S.str() + ">\n";
                     try { unlink(); } catch (...) {}
                     std::terminate();
                 }

--- a/include/jh/synchronous/ipc/shared_process_mutex.h
+++ b/include/jh/synchronous/ipc/shared_process_mutex.h
@@ -145,8 +145,8 @@
 
 namespace jh::sync::ipc {
 
-    template <jh::meta::TStr S, bool HighPriv = false>
-    requires (limits::valid_object_name<S, limits::max_name_length - 8>())
+    template<jh::meta::TStr S, bool HighPriv = false> requires (limits::valid_object_name<S,
+            limits::max_name_length - 8>())
     class shared_process_mutex;
 
     /**
@@ -216,35 +216,31 @@ namespace jh::sync::ipc {
      *   <li>Unlink removes all associated IPC objects: <code>.exc</code>, <code>.cond</code>, <code>.cnt</code>, and <code>.pri</code>.</li>
      * </ul>
      */
-    template <jh::meta::TStr S, bool HighPriv>
-    requires (limits::valid_object_name<S, limits::max_name_length - 8>())
+    template<jh::meta::TStr S, bool HighPriv> requires (limits::valid_object_name<S, limits::max_name_length - 8>())
     class shared_process_mutex final {
     private:
-        using exc_t  = process_mutex<S + jh::meta::TStr{".exc"}, HighPriv>;
+        using exc_t = process_mutex<S + jh::meta::TStr{".exc"}, HighPriv>;
         using cond_t = process_cond_var<S + jh::meta::TStr{".cond"}, HighPriv>;
-        using cnt_t  = process_counter<S + jh::meta::TStr{".cnt"}, HighPriv>;
+        using cnt_t = process_counter<S + jh::meta::TStr{".cnt"}, HighPriv>;
         using pri_t = process_mutex<S + jh::meta::TStr{".pri"}, HighPriv>;
         thread_local static bool has_shared_lock_;
         thread_local static bool has_exclusive_lock_;
         thread_local static bool has_prior_lock_;
 
-        exc_t&  excl_;    ///< exclusive writer lock
-        cond_t& cond_;    ///< condition variable
-        cnt_t&  readers_; ///< reader counter
-        pri_t&  prior_;   ///< priority mutex to preempt writers during upgrade
+        exc_t &excl_;    ///< exclusive writer lock
+        cond_t &cond_;    ///< condition variable
+        cnt_t &readers_; ///< reader counter
+        pri_t &prior_;   ///< priority mutex to preempt writers during upgrade
 
     private:
         shared_process_mutex()
-                : excl_(exc_t::instance())
-                , cond_(cond_t::instance())
-                , readers_(cnt_t::instance())
-                , prior_(pri_t::instance())
-        {}
+                : excl_(exc_t::instance()), cond_(cond_t::instance()), readers_(cnt_t::instance()),
+                  prior_(pri_t::instance()) {}
 
         [[nodiscard]] inline bool is_writer() const noexcept {
             return has_exclusive_lock_ || has_prior_lock_;
         }
-        
+
     public:
 
         /**
@@ -254,14 +250,15 @@ namespace jh::sync::ipc {
 
         ~shared_process_mutex() = default;
 
-        shared_process_mutex(const shared_process_mutex&) = delete;
-        shared_process_mutex& operator=(const shared_process_mutex&) = delete;
+        shared_process_mutex(const shared_process_mutex &) = delete;
+
+        shared_process_mutex &operator=(const shared_process_mutex &) = delete;
 
         /**
          * @brief Access the process-wide singleton instance of this mutex.
          * @return A reference to the global synchronization object.
          */
-        static shared_process_mutex& instance() {
+        static shared_process_mutex &instance() {
             static shared_process_mutex inst;
             return inst;
         }
@@ -315,16 +312,16 @@ namespace jh::sync::ipc {
         /**
          * @brief Attempt to acquire exclusive access for a limited duration.
          */
-        template <typename Rep, typename Period>
-        bool try_lock_for(const std::chrono::duration<Rep, Period>& d) {
+        template<typename Rep, typename Period>
+        bool try_lock_for(const std::chrono::duration<Rep, Period> &d) {
             return try_lock_until(std::chrono::steady_clock::now() + d);
         }
 
         /**
          * @brief Attempt to acquire exclusive access until a specific time point.
          */
-        template <typename Clock, typename Duration>
-        bool try_lock_until(const std::chrono::time_point<Clock, Duration>& tp) {
+        template<typename Clock, typename Duration>
+        bool try_lock_until(const std::chrono::time_point<Clock, Duration> &tp) {
             if (is_writer())
                 return true; // already have exclusive lock
             if (!excl_.try_lock_until(tp))
@@ -399,16 +396,16 @@ namespace jh::sync::ipc {
         /**
          * @brief Attempt to acquire shared access for a limited duration.
          */
-        template <typename Rep, typename Period>
-        bool try_lock_shared_for(const std::chrono::duration<Rep, Period>& d) {
+        template<typename Rep, typename Period>
+        bool try_lock_shared_for(const std::chrono::duration<Rep, Period> &d) {
             return try_lock_shared_until(std::chrono::steady_clock::now() + d);
         }
 
         /**
          * @brief Attempt to acquire shared access until a time point.
          */
-        template <typename Clock, typename Duration>
-        bool try_lock_shared_until(const std::chrono::time_point<Clock, Duration>& tp) {
+        template<typename Clock, typename Duration>
+        bool try_lock_shared_until(const std::chrono::time_point<Clock, Duration> &tp) {
             if (has_shared_lock_) return true;
             if (!excl_.try_lock_until(tp))
                 return false;
@@ -449,7 +446,7 @@ namespace jh::sync::ipc {
          * This operation preserves global upgrade atomicity and ensures consistency across processes.
          * </p>
          */
-        void upgrade_lock() requires (HighPriv) {
+        void upgrade_lock() requires(HighPriv) {
             if (!has_shared_lock_)
                 throw std::logic_error("Cannot upgrade without shared lock");
             if (is_writer())
@@ -501,7 +498,7 @@ namespace jh::sync::ipc {
          * </ul>
          * </p>
          */
-        static void unlink() requires (HighPriv) {
+        static void unlink() requires(HighPriv) {
             exc_t::unlink();
             cond_t::unlink();
             cnt_t::unlink();
@@ -513,16 +510,13 @@ namespace jh::sync::ipc {
         static void unlink() requires (!HighPriv) = delete;
     };
 
-    template <jh::meta::TStr S, bool HighPriv>
-    requires (limits::valid_object_name<S, limits::max_name_length - 8>())
+    template<jh::meta::TStr S, bool HighPriv> requires (limits::valid_object_name<S, limits::max_name_length - 8>())
     thread_local bool shared_process_mutex<S, HighPriv>::has_shared_lock_ = false;
 
-    template <jh::meta::TStr S, bool HighPriv>
-    requires (limits::valid_object_name<S, limits::max_name_length - 8>())
+    template<jh::meta::TStr S, bool HighPriv> requires (limits::valid_object_name<S, limits::max_name_length - 8>())
     thread_local bool shared_process_mutex<S, HighPriv>::has_exclusive_lock_ = false;
 
-    template <jh::meta::TStr S, bool HighPriv>
-    requires (limits::valid_object_name<S, limits::max_name_length - 8>())
+    template<jh::meta::TStr S, bool HighPriv> requires (limits::valid_object_name<S, limits::max_name_length - 8>())
     thread_local bool shared_process_mutex<S, HighPriv>::has_prior_lock_ = false;
 
 } // namespace jh::sync::ipc

--- a/include/jh/synchronous/strong_lock.h
+++ b/include/jh/synchronous/strong_lock.h
@@ -60,7 +60,6 @@
  *       <code>jh::concepts::shared_lockable</code>.</li>
  * </ul>
  *
- *
  * <ul>
  *   <li>
  *     <code>strong_unique_lock</code> and <code>strong_shared_lock</code><br>
@@ -69,26 +68,23 @@
  *     immediately after acquisition and immediately before release.
  *   </li>
  *   <li>
- *     <code>posix_smtx_*_lock</code><br>
+ *     <code>posix_smtx_&#42;_lock</code><br>
  *     On Windows, aliases the strong variants to approximate POSIX-style
  *     behavior. On POSIX systems, aliases the standard library lock types.
  *   </li>
  * </ul>
  *
- *
- * <p>
- * Note: This facility does not address lifecycle inconsistencies
+ * @note
+ * This facility does not address lifecycle inconsistencies
  * introduced by test frameworks that intercept or wrap
  * <code>std::thread</code> handles.
  * Such issues originate from thread management semantics,
  * not from <code>std::shared_mutex</code> itself.
- * </p>
  *
- * <p>
+ * @note
  * The primary target platform remains POSIX.
  * The Windows strengthening path exists to provide a bounded,
  * practical approximation for cross-platform engineering scenarios.
- * </p>
  *
  * @version <pre>1.4.1</pre>
  * @date <pre>2026</pre>
@@ -197,6 +193,9 @@ namespace jh::sync {
      *
      * It should be regarded as a language-level strengthening adapter,
      * not a formal cross-platform equivalence guarantee.
+     *
+     * @note
+     * On POSIX systems, this alias uses std::unique_lock directly.
      */
     template<jh::concepts::basic_lockable Mtx>
     using posix_smtx_unique_lock = strong_unique_lock<Mtx>;
@@ -219,6 +218,9 @@ namespace jh::sync {
      *
      * This adapter provides a pragmatic mitigation strategy rather than
      * strict semantic equivalence.
+     *
+     * @note
+     * On POSIX systems, this alias uses std::shared_lock directly.
      */
     template<jh::concepts::shared_lockable Mtx>
     using posix_smtx_shared_lock = strong_shared_lock<Mtx>;
@@ -232,6 +234,10 @@ namespace jh::sync {
      * relying on the underlying pthread-based implementation.
      *
      * No additional language-level strengthening is applied.
+     *
+     * @note
+     * On Windows, this alias uses strong_unique_lock to approximate
+     * POSIX-style behavior.
      */
     template<jh::concepts::basic_lockable Mtx>
     using posix_smtx_unique_lock = std::unique_lock<Mtx>;
@@ -243,6 +249,10 @@ namespace jh::sync {
      * relying on the native pthread-backed shared mutex semantics.
      *
      * No additional language-level strengthening is applied.
+     *
+     * @note
+     * On Windows, this alias uses strong_shared_lock to approximate
+     * POSIX-style behavior.
      */
     template<jh::concepts::shared_lockable Mtx>
     using posix_smtx_shared_lock = std::shared_lock<Mtx>;

--- a/include/jh/synchronous/strong_mutex.h
+++ b/include/jh/synchronous/strong_mutex.h
@@ -1,0 +1,253 @@
+/**
+ * @copyright
+ * Copyright 2025 JeongHan-Bae &lt;mastropseudo\@gmail.com&gt;
+ * <br>
+ * Licensed under the Apache License, Version 2.0 (the "License"); <br>
+ * you may not use this file except in compliance with the License.<br>
+ * You may obtain a copy of the License at<br>
+ * <br>
+ *     http://www.apache.org/licenses/LICENSE-2.0<br>
+ * <br>
+ * Unless required by applicable law or agreed to in writing, software<br>
+ * distributed under the License is distributed on an "AS IS" BASIS,<br>
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br>
+ * See the License for the specific language governing permissions and<br>
+ * limitations under the License.<br>
+ * <br>
+ * Full license: <a href="https://github.com/JeongHan-Bae/JH-Toolkit?tab=Apache-2.0-1-ov-file#readme">GitHub</a>
+ */
+/**
+ * @file strong_lock.h
+ * @author JeongHan-Bae <a href="mailto:mastropseudo&#64;gmail.com">&lt;mastropseudo\@gmail.com&gt;</a>
+ * @brief Strong ordering adapters for read-write mutex-like synchronization primitives.
+ *
+ * <p>
+ * On POSIX platforms (e.g., Linux or Darwin),
+ * <code>std::shared_mutex</code> is commonly implemented on top of
+ * <code>pthread_rwlock</code> or futex-based primitives.
+ * In practice:
+ * </p>
+ *
+ * <ul>
+ *   <li><code>std::unique_lock&lt;std::shared_mutex&gt;</code>
+ *       behaves similarly to <code>pthread_rwlock_wrlock()</code> /
+ *       <code>pthread_rwlock_unlock()</code>.</li>
+ *   <li><code>std::shared_lock&lt;std::shared_mutex&gt;</code>
+ *       behaves similarly to <code>pthread_rwlock_rdlock()</code> /
+ *       <code>pthread_rwlock_unlock()</code>.</li>
+ * </ul>
+ *
+ * <p>
+ * However, ISO C++ does not strictly guarantee identical global ordering
+ * semantics compared to POSIX implementations.
+ * In particular, acquire-release semantics alone may be insufficient
+ * when locks and atomics are mixed under high concurrency.
+ * </p>
+ * <p>
+ * Even when atomics use <code>memory_order_seq_cst</code>,
+ * observable reordering may still occur under combinations of:
+ * high concurrency, debug builds, and intrusive test frameworks.
+ * The strong variants aim to reduce such cross-domain ordering anomalies.
+ * </p>
+ * <p>
+ * This header introduces two strengthening adapters:
+ * </p>
+ *
+ * <ul>
+ *   <li><code>strong_unique_lock</code> requires
+ *       <code>jh::concepts::basic_lockable</code>.</li>
+ *   <li><code>strong_shared_lock</code> requires
+ *       <code>jh::concepts::shared_lockable</code>.</li>
+ * </ul>
+ *
+ *
+ * <ul>
+ *   <li>
+ *     <code>strong_unique_lock</code> and <code>strong_shared_lock</code><br>
+ *     They enforce a global ordering barrier via
+ *     <code>std::atomic_thread_fence(std::memory_order_seq_cst)</code>
+ *     immediately after acquisition and immediately before release.
+ *   </li>
+ *   <li>
+ *     <code>posix_smtx_*_lock</code><br>
+ *     On Windows, aliases the strong variants to approximate POSIX-style
+ *     behavior. On POSIX systems, aliases the standard library lock types.
+ *   </li>
+ * </ul>
+ *
+ *
+ * <p>
+ * Note: This facility does not address lifecycle inconsistencies
+ * introduced by test frameworks that intercept or wrap
+ * <code>std::thread</code> handles.
+ * Such issues originate from thread management semantics,
+ * not from <code>std::shared_mutex</code> itself.
+ * </p>
+ *
+ * <p>
+ * The primary target platform remains POSIX.
+ * The Windows strengthening path exists to provide a bounded,
+ * practical approximation for cross-platform engineering scenarios.
+ * </p>
+ *
+ * @version <pre>1.4.1</pre>
+ * @date <pre>2026</pre>
+ */
+
+#pragma once
+
+#include <shared_mutex>
+#include <atomic>
+#include <jh/conceptual/mutex_like.h>
+#include "jh/macros/platform.h"
+
+namespace jh::sync {
+
+    /**
+     * @brief Strong exclusive lock adapter.
+     *
+     * Requires only exclusive locking capability.
+     * A sequentially-consistent fence is inserted
+     * after acquisition and before release.
+     */
+    template<jh::concepts::basic_lockable Mutex>
+    class strong_unique_lock final {
+    public:
+        explicit strong_unique_lock(Mutex &m)
+                : m_(&m), owns_(true) {
+            m_->lock();
+            std::atomic_thread_fence(std::memory_order_seq_cst);
+        }
+
+        ~strong_unique_lock() {
+            if (owns_) {
+                std::atomic_thread_fence(std::memory_order_seq_cst);
+                m_->unlock();
+            }
+        }
+
+        strong_unique_lock(const strong_unique_lock &) = delete;
+
+        strong_unique_lock &operator=(const strong_unique_lock &) = delete;
+
+    private:
+        Mutex *m_;
+        bool owns_;
+    };
+
+
+    /**
+     * @brief Strong shared (reader) lock adapter.
+     *
+     * Requires shared locking capability.
+     * A sequentially-consistent fence is inserted
+     * after acquisition and before release.
+     */
+    template<jh::concepts::shared_lockable Mutex>
+    class strong_shared_lock final {
+    public:
+        explicit strong_shared_lock(Mutex &m)
+                : m_(&m), owns_(true) {
+            m_->lock_shared();
+            std::atomic_thread_fence(std::memory_order_seq_cst);
+        }
+
+        ~strong_shared_lock() {
+            if (owns_) {
+                std::atomic_thread_fence(std::memory_order_seq_cst);
+                m_->unlock_shared();
+            }
+        }
+
+        strong_shared_lock(const strong_shared_lock &) = delete;
+
+        strong_shared_lock &operator=(const strong_shared_lock &) = delete;
+
+    private:
+        Mutex *m_;
+        bool owns_;
+    };
+
+
+#if IS_WINDOWS
+
+    /**
+     * @brief POSIX-style strong exclusive lock alias (Windows approximation).
+     *
+     * On Windows platforms this aliases strong_unique_lock in order to
+     * approximate the stronger global ordering behavior commonly observed
+     * on POSIX systems.
+     *
+     * This strengthening operates strictly at the ISO C++ memory model level
+     * by inserting sequentially-consistent fences around lock boundaries.
+     *
+     * <p>It does NOT:</p>
+     * <ul>
+     *   <li>Guarantee prevention of CPU-level reordering,</li>
+     *   <li>Provide a true hardware-enforced global total order,</li>
+     *   <li>Fully replicate POSIX rwlock implementation semantics.</li>
+     * </ul>
+     *
+     * <p>The effect is a bounded, practical mitigation that may:</p>
+     * <ul>
+     *   <li>Reduce cross-domain lock/atomic ordering anomalies,</li>
+     *   <li>Delay or raise the observable contention threshold on Windows,</li>
+     *   <li>Improve behavioral convergence under high concurrency.</li>
+     * </ul>
+     *
+     * It should be regarded as a language-level strengthening adapter,
+     * not a formal cross-platform equivalence guarantee.
+     */
+    template<jh::concepts::basic_lockable Mtx>
+    using posix_smtx_unique_lock = strong_unique_lock<Mtx>;
+
+    /**
+     * @brief POSIX-style strong shared lock alias (Windows approximation).
+     *
+     * On Windows platforms this aliases strong_shared_lock to approximate
+     * POSIX-style shared mutex ordering characteristics.
+     *
+     * The inserted seq_cst fences strengthen ordering only within the
+     * C++ abstract machine.
+     *
+     * <p>They do NOT:</p>
+     * <ul>
+     *   <li>Eliminate hardware-level reordering effects,</li>
+     *   <li>Establish a strict global total order equivalent to
+     *       typical pthread_rwlock behavior.</li>
+     * </ul>
+     *
+     * This adapter provides a pragmatic mitigation strategy rather than
+     * strict semantic equivalence.
+     */
+    template<jh::concepts::shared_lockable Mtx>
+    using posix_smtx_shared_lock = strong_shared_lock<Mtx>;
+
+#else
+
+    /**
+     * @brief POSIX native exclusive lock alias.
+     *
+     * On POSIX systems this aliases std::unique_lock directly,
+     * relying on the underlying pthread-based implementation.
+     *
+     * No additional language-level strengthening is applied.
+     */
+    template<jh::concepts::basic_lockable Mtx>
+    using posix_smtx_unique_lock = std::unique_lock<Mtx>;
+
+    /**
+     * @brief POSIX native shared lock alias.
+     *
+     * On POSIX systems this aliases std::shared_lock directly,
+     * relying on the native pthread-backed shared mutex semantics.
+     *
+     * No additional language-level strengthening is applied.
+     */
+    template<jh::concepts::shared_lockable Mtx>
+    using posix_smtx_shared_lock = std::shared_lock<Mtx>;
+
+#endif
+
+
+} // namespace jh::sync

--- a/src/immutable_str_tu.cpp
+++ b/src/immutable_str_tu.cpp
@@ -1,5 +1,5 @@
 /**
- * @file immutable_str.cpp
+ * @file immutable_str_tu.cpp
  * @brief Compilation unit for <code>jh::immutable_str</code>.
  *
  * <p>
@@ -10,5 +10,7 @@
  *
  * @see jh::immutable_str
  */
+
 #define JH_HEADER_IMPL_BUILD
+
 #include "jh/core/immutable_str.h"

--- a/src/runtime_arr_inst.cpp
+++ b/src/runtime_arr_inst.cpp
@@ -41,10 +41,13 @@
  * @see jh::runtime_arr
  * @see jh::runtime_arr_helper::bool_flat_alloc
  */
+
 #define JH_HEADER_IMPL_BUILD
+
 #include "jh/core/runtime_arr.h"
 
 // implicitly force static compilation of both conjugate forms
 namespace jh {
-    template class runtime_arr<bool, runtime_arr_helper::bool_flat_alloc>;
+    template
+    class runtime_arr<bool, runtime_arr_helper::bool_flat_alloc>;
 }

--- a/src/serio_tu.cpp
+++ b/src/serio_tu.cpp
@@ -1,0 +1,17 @@
+/**
+ * @file serio_tu.cpp
+ * @brief Compilation unit for <code>jh::serio</code>.
+ *
+ * <p>
+ * This file ensures that internal non-inline functions of
+ * <code>jh::serio</code> are compiled for the static build
+ * (<code>jh-toolkit-static</code>).
+ * </p>
+ *
+ * @see jh::serio
+ */
+
+#define JH_HEADER_IMPL_BUILD
+
+#include "jh/serialize_io/base64.h"
+#include "jh/serialize_io/uri.h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TESTS
         test_slot.cpp           jh-toolkit
         test_adt.cpp            jh-toolkit
         test_flat_multimap.cpp  jh-toolkit
+        test_uri.cpp            jh-toolkit
 )
 
 # Get total number of entries

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ set(TESTS
         test_runtime_arr.cpp    jh-toolkit-static
         test_ranges.cpp         jh-toolkit
         test_pod_sys.cpp        jh-toolkit
-        test_base64.cpp         jh-toolkit
+        test_base64.cpp         jh-toolkit-static
         test_t_str.cpp          jh-toolkit
         test_process_lock.cpp   jh-toolkit
         test_occ.cpp            jh-toolkit
@@ -37,7 +37,7 @@ set(TESTS
         test_slot.cpp           jh-toolkit
         test_adt.cpp            jh-toolkit
         test_flat_multimap.cpp  jh-toolkit
-        test_uri.cpp            jh-toolkit
+        test_uri.cpp            jh-toolkit-static
 )
 
 # Get total number of entries

--- a/tests/test_base64.cpp
+++ b/tests/test_base64.cpp
@@ -132,16 +132,16 @@ TEST_CASE("Base64 decode into user-provided buffer", "[base64][safety][buffer]")
     auto view = decode("Qm9i", out); // "Bob"
 
     REQUIRE(out == "Bob");
-    REQUIRE(view.len == out.size());
-    REQUIRE(std::string(view.data, view.len) == "Bob");
+    REQUIRE(view.size() == out.size());
+    REQUIRE(std::string(view.data, view.size()) == "Bob");
 
     view = decode("TWFu", out); // "Man"
     REQUIRE(out == "Man");
-    REQUIRE(std::string(view.data, view.len) == "Man");
+    REQUIRE(std::string(view.data, view.size()) == "Man");
 
     view = decode("QQ==", out); // "A"
     REQUIRE(out == "A");
-    REQUIRE(std::string(view.data, view.len) == "A");
+    REQUIRE(std::string(view.data, view.size()) == "A");
 }
 
 TEST_CASE("Base64URL decode into user-provided buffer", "[base64url][safety][buffer]") {
@@ -150,44 +150,44 @@ TEST_CASE("Base64URL decode into user-provided buffer", "[base64url][safety][buf
     std::string out;
     auto view = decode("SGVsbG8", out); // "Hello"
     REQUIRE(out == "Hello");
-    REQUIRE(std::string(view.data, view.len) == "Hello");
+    REQUIRE(std::string(view.data, view.size()) == "Hello");
 
     view = decode("QQ", out); // "A"
     REQUIRE(out == "A");
-    REQUIRE(std::string(view.data, view.len) == "A");
+    REQUIRE(std::string(view.data, view.size()) == "A");
 }
 
 TEST_CASE("Base64 decode into user-provided vector<uint8_t> buffer", "[base64][safety][buffer]") {
     using namespace jh::serio::base64;
 
-    std::vector<uint8_t> out;
+    std::vector<std::uint8_t> out;
     auto view = decode("Qm9i", out); // "Bob"
 
-    REQUIRE(out == std::vector<uint8_t>({'B', 'o', 'b'}));
-    REQUIRE(view.len == out.size());
-    REQUIRE(std::string(reinterpret_cast<const char *>(view.data), view.len) == "Bob");
+    REQUIRE(out == std::vector<std::uint8_t>({'B', 'o', 'b'}));
+    REQUIRE(view.size() == out.size());
+    REQUIRE(std::string(view.fetch<const char>(), view.size()) == "Bob");
 
     view = decode("TWFu", out); // "Man"
-    REQUIRE(out == std::vector<uint8_t>({'M', 'a', 'n'}));
-    REQUIRE(std::string(reinterpret_cast<const char *>(view.data), view.len) == "Man");
+    REQUIRE(out == std::vector<std::uint8_t>({'M', 'a', 'n'}));
+    REQUIRE(std::string(view.fetch<const char>(), view.size()) == "Man");
 
     view = decode("QQ==", out); // "A"
-    REQUIRE(out == std::vector<uint8_t>({'A'}));
-    REQUIRE(std::string(reinterpret_cast<const char *>(view.data), view.len) == "A");
+    REQUIRE(out == std::vector<std::uint8_t>({'A'}));
+    REQUIRE(std::string(view.fetch<const char>(), view.size()) == "A");
 }
 
 TEST_CASE("Base64URL decode into user-provided vector<uint8_t> buffer", "[base64url][safety][buffer]") {
     using namespace jh::serio::base64url;
 
-    std::vector<uint8_t> out;
+    std::vector<std::uint8_t> out;
     auto view = decode("SGVsbG8", out); // "Hello"
-    REQUIRE(out == std::vector<uint8_t>({'H', 'e', 'l', 'l', 'o'}));
-    REQUIRE(view.len == out.size());
-    REQUIRE(std::string(reinterpret_cast<const char *>(view.data), view.len) == "Hello");
+    REQUIRE(out == std::vector<std::uint8_t>({'H', 'e', 'l', 'l', 'o'}));
+    REQUIRE(view.size() == out.size());
+    REQUIRE(std::string(view.fetch<const char>(), view.size()) == "Hello");
 
     view = decode("QQ", out); // "A"
-    REQUIRE(out == std::vector<uint8_t>({'A'}));
-    REQUIRE(std::string(reinterpret_cast<const char *>(view.data), view.len) == "A");
+    REQUIRE(out == std::vector<std::uint8_t>({'A'}));
+    REQUIRE(std::string(view.fetch<const char>(), view.size()) == "A");
 }
 
 TEST_CASE("Compile-time Base64 / Base64URL correctness", "[constexpr][base64]") {
@@ -195,23 +195,23 @@ TEST_CASE("Compile-time Base64 / Base64URL correctness", "[constexpr][base64]") 
     SECTION("Base64 decode at compile time") {
         // "SGVsbG8=" -> "Hello"
         constexpr auto out = jh::jindallae::decode_base64<"SGVsbG8=">();
-        STATIC_REQUIRE(out == jh::pod::array<uint8_t, 5>{{'H', 'e', 'l', 'l', 'o'}});
+        STATIC_REQUIRE(out == jh::pod::array<std::uint8_t, 5>{{'H', 'e', 'l', 'l', 'o'}});
     }
 
     SECTION("Base64URL decode at compile time (with pad)") {
         // "SGVsbG8=" -> "Hello"
         constexpr auto out = jh::jindallae::decode_base64url<"SGVsbG8=">();
-        STATIC_REQUIRE(out == jh::pod::array<uint8_t, 5>{{'H', 'e', 'l', 'l', 'o'}});
+        STATIC_REQUIRE(out == jh::pod::array<std::uint8_t, 5>{{'H', 'e', 'l', 'l', 'o'}});
     }
 
     SECTION("Base64URL decode at compile time (no pad)") {
         // "SGVsbG8" -> "Hello"
         constexpr auto out = jh::jindallae::decode_base64url<"SGVsbG8">();
-        STATIC_REQUIRE(out == jh::pod::array<uint8_t, 5>{{'H', 'e', 'l', 'l', 'o'}});
+        STATIC_REQUIRE(out == jh::pod::array<std::uint8_t, 5>{{'H', 'e', 'l', 'l', 'o'}});
     }
 
     SECTION("Base64 encode at compile time") {
-        constexpr jh::pod::array<uint8_t, 3> raw{{'H', 'i', '!'}};
+        constexpr jh::pod::array<std::uint8_t, 3> raw{{'H', 'i', '!'}};
         constexpr auto enc = jh::jindallae::encode_base64(raw);
 
         // "Hi!" -> "SGkh"
@@ -219,14 +219,14 @@ TEST_CASE("Compile-time Base64 / Base64URL correctness", "[constexpr][base64]") 
     }
 
     SECTION("Base64URL encode (no pad) at compile time") {
-        constexpr jh::pod::array<uint8_t, 3> raw{{'H', 'i', '!'}};
+        constexpr jh::pod::array<std::uint8_t, 3> raw{{'H', 'i', '!'}};
         constexpr auto enc = jh::jindallae::encode_base64url(raw, std::false_type{});
 
         STATIC_REQUIRE(enc == jh::jindallae::t_str<5>("SGkh"));
     }
 
     SECTION("Base64URL encode (with pad) at compile time") {
-        constexpr jh::pod::array<uint8_t, 3> raw{{'H', 'i', '!'}};
+        constexpr jh::pod::array<std::uint8_t, 3> raw{{'H', 'i', '!'}};
         constexpr auto enc = jh::jindallae::encode_base64url(raw, std::true_type{});
 
         STATIC_REQUIRE(enc == jh::jindallae::t_str<5>("SGkh"));

--- a/tests/test_lookup_map.cpp
+++ b/tests/test_lookup_map.cpp
@@ -41,6 +41,7 @@ TEST_CASE("Compile-Time Construction with All make_lookup_map Versions") {
         STATIC_REQUIRE(m["red"_psv] == 1);
         STATIC_REQUIRE(m[jh::meta::TStr{"green"}] == 2);
         STATIC_REQUIRE(m["blue"sv] == 3);
+        REQUIRE(m[jh::immutable_str("blue")] == 3);
         STATIC_REQUIRE(m[std::string("purple")] == -1);
         STATIC_REQUIRE(m[string_view::from_literal("yellow")] == -1);
     }

--- a/tests/test_occ.cpp
+++ b/tests/test_occ.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_all.hpp>
 
 #include "jh/concurrency"
+#include "jh/macros/platform.h"
 #include <thread>
 #include <chrono>    // NOLINT force include for std::chrono_literals
 #include <vector>
@@ -122,6 +123,12 @@ TEST_CASE("occ_box concurrent writes", "[occ_box][thread]") {
     std::vector<std::thread> threads;
     threads.reserve(N);
 
+#if IS_CLANG
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-lambda-capture"
+#endif
+// Capture &N is necessary for GCC to allow usage inside the lambda, even though it's not modified.
+
     for (int i = 0; i < N; i++) {
         threads.emplace_back([&ITER, &box]() { // NOLINT for gcc
             for (int j = 0; j < ITER; j++) {
@@ -129,6 +136,11 @@ TEST_CASE("occ_box concurrent writes", "[occ_box][thread]") {
             }
         });
     }
+
+#if IS_CLANG
+#pragma clang diagnostic pop
+#endif
+
     for (auto &t: threads) t.join();
 
     int final = box.read([](const test::Counter &c) { return c.value; });
@@ -145,6 +157,12 @@ TEST_CASE("occ_box try_read retry statistics", "[occ_box][thread]") {
 
     int success_count = 0;
     int fail_count = 0;
+
+#if IS_CLANG
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-lambda-capture"
+#endif
+// Capture &N is necessary for GCC to allow usage inside the lambda, even though it's not modified.
 
     // Writer thread
     std::thread writer([&box, &stop, &WRITER_ITER]() { // NOLINT for gcc
@@ -168,6 +186,10 @@ TEST_CASE("occ_box try_read retry statistics", "[occ_box][thread]") {
             }
         }
     });
+
+#if IS_CLANG
+#pragma clang diagnostic pop
+#endif
 
     writer.join();
     reader.join();

--- a/tests/test_ordered_map.cpp
+++ b/tests/test_ordered_map.cpp
@@ -154,12 +154,13 @@ TEST_CASE("map emplace") {
     REQUIRE(ok3 == false);
     REQUIRE(it3->second == "one");
 
-    std::vector<std::pair<int,std::string>> v;
-    for (auto &kv : mp)
+    std::vector<std::pair<int, std::string>> v;
+    for (auto &kv: mp)
         v.emplace_back(kv.first, kv.second);
 
-    REQUIRE(v == std::vector<std::pair<int,std::string>>{
-            {1,"one"}, {2,"two"}
+    REQUIRE(v == std::vector<std::pair<int, std::string>>{
+            {1, "one"},
+            {2, "two"}
     });
 }
 
@@ -176,7 +177,7 @@ TEST_CASE("set emplace") {
     REQUIRE(ok3 == false);
 
     std::vector<int> v;
-    for (auto &x : s) v.push_back(x);
+    for (auto &x: s) v.push_back(x);
 
     REQUIRE(v == std::vector<int>{1, 3});
 }
@@ -195,17 +196,18 @@ TEST_CASE("map insert_or_assign") {
     REQUIRE(ok3 == false);
     REQUIRE(it3->second == 100);
 
-    std::vector<std::pair<int,int>> v;
-    for (auto &kv : mp)
+    std::vector<std::pair<int, int>> v;
+    for (auto &kv: mp)
         v.emplace_back(kv.first, kv.second);
 
-    REQUIRE(v == std::vector<std::pair<int,int>>{
-            {1, 100}, {2, 20}
+    REQUIRE(v == std::vector<std::pair<int, int>>{
+            {1, 100},
+            {2, 20}
     });
 }
 
 TEST_CASE("from_sorted basic ordering and lookup") {
-    for (int N = 1; N <= 200; N+=1) {
+    for (int N = 1; N <= 200; N += 1) {
 
         std::vector<int> sorted;
         sorted.reserve(N);
@@ -214,12 +216,12 @@ TEST_CASE("from_sorted basic ordering and lookup") {
 
         auto s = ordered_set<int>::from_sorted(sorted);
 
-        REQUIRE(s.size() == (size_t)N);
+        REQUIRE(s.size() == (size_t) N);
 
         {
             std::vector<int> vec;
             vec.reserve(N);
-            for (auto &x : s) vec.push_back(x);
+            for (auto &x: s) vec.push_back(x);
             REQUIRE(vec == sorted);
         }
 
@@ -229,7 +231,7 @@ TEST_CASE("from_sorted basic ordering and lookup") {
             REQUIRE(*it == i);
         }
         REQUIRE(s.find(-1) == s.end());
-        REQUIRE(s.find(N+1) == s.end());
+        REQUIRE(s.find(N + 1) == s.end());
 
         for (int i = 0; i < N; ++i) {
             auto it = s.lower_bound(i);
@@ -259,7 +261,7 @@ TEST_CASE("from_sorted basic ordering and lookup") {
 
         {
             int current = N - 1;
-            for (int it : std::ranges::reverse_view(s)) {
+            for (int it: std::ranges::reverse_view(s)) {
                 REQUIRE(it == current);
                 --current;
             }
@@ -272,7 +274,7 @@ TEST_CASE("from_sorted basic ordering and lookup") {
             REQUIRE(s.find(x) == s.end());
 
             std::vector<int> v2;
-            for (auto &x2 : s) v2.push_back(x2);
+            for (auto &x2: s) v2.push_back(x2);
 
             sorted.erase(sorted.begin() + x);
             REQUIRE(v2 == sorted);
@@ -325,15 +327,15 @@ TEST_CASE("map insert with various pair-like types") {
         REQUIRE(it->second == "five");
     }
     std::vector<std::pair<int, std::string>> v;
-    for (auto &kv : mp)
+    for (auto &kv: mp)
         v.emplace_back(kv.first, kv.second);
 
     REQUIRE(v == std::vector<std::pair<int, std::string>>{
-            {1,"one"},
-            {2,"two"},
-            {3,"three"},
-            {4,"four"},
-            {5,"five"}
+            {1, "one"},
+            {2, "two"},
+            {3, "three"},
+            {4, "four"},
+            {5, "five"}
     });
 }
 
@@ -348,11 +350,11 @@ TEST_CASE("map from_sorted with tuple<K,V> input") {
             {4, "ddd"}
     };
 
-    std::sort(vec.begin(), vec.end(), [](auto const& a, auto const& b) {
+    std::sort(vec.begin(), vec.end(), [](auto const &a, auto const &b) {
         return std::get<0>(a) < std::get<0>(b);
     });
 
-    vec.erase(std::unique(vec.begin(), vec.end(), [](auto const& a, auto const& b) {
+    vec.erase(std::unique(vec.begin(), vec.end(), [](auto const &a, auto const &b) {
         return std::get<0>(a) == std::get<0>(b);
     }), vec.end());
 
@@ -363,14 +365,14 @@ TEST_CASE("map from_sorted with tuple<K,V> input") {
     auto mp = ordered_map<int, std::string>::from_sorted(vec);
     REQUIRE(mp.size() == 4);
 
-    std::vector<std::pair<int,std::string>> out;
-    for (auto& kv : mp) out.emplace_back(kv.first, kv.second);
+    std::vector<std::pair<int, std::string>> out;
+    for (auto &kv: mp) out.emplace_back(kv.first, kv.second);
 
-    REQUIRE(out == std::vector<std::pair<int,std::string>>{
-            {1,"aaa"},
-            {2,"bbb"},
-            {3,"ccc"},
-            {4,"ddd"}
+    REQUIRE(out == std::vector<std::pair<int, std::string>>{
+            {1, "aaa"},
+            {2, "bbb"},
+            {3, "ccc"},
+            {4, "ddd"}
     });
 
     for (int i = 1; i <= 4; i++) {
@@ -428,8 +430,8 @@ TEST_CASE("container capacity-related utility functions") {
         REQUIRE(s.size() == 5);
 
         std::vector<int> v;
-        for (auto x : s) v.push_back(x);
-        REQUIRE(v == std::vector<int>{1,2,3,4,5});
+        for (auto x: s) v.push_back(x);
+        REQUIRE(v == std::vector<int>{1, 2, 3, 4, 5});
     }
 
     SECTION("reserve for map preserves elements") {
@@ -440,11 +442,13 @@ TEST_CASE("container capacity-related utility functions") {
 
         m.reserve(500);
 
-        std::vector<std::pair<int,int>> v;
-        for (auto& kv : m) v.emplace_back(kv.first, kv.second);
+        std::vector<std::pair<int, int>> v;
+        for (auto &kv: m) v.emplace_back(kv.first, kv.second);
 
-        REQUIRE(v == std::vector<std::pair<int,int>>{
-                {1,10},{2,20},{3,30}
+        REQUIRE(v == std::vector<std::pair<int, int>>{
+                {1, 10},
+                {2, 20},
+                {3, 30}
         });
     }
 
@@ -457,8 +461,8 @@ TEST_CASE("container capacity-related utility functions") {
         REQUIRE(s.size() == 5);
 
         std::vector<int> v;
-        for (auto x : s) v.push_back(x);
-        REQUIRE(v == std::vector<int>{10,20,30,40,50});
+        for (auto x: s) v.push_back(x);
+        REQUIRE(v == std::vector<int>{10, 20, 30, 40, 50});
     }
 
     SECTION("shrink_to_fit for map preserves structure") {
@@ -469,11 +473,79 @@ TEST_CASE("container capacity-related utility functions") {
 
         mp.shrink_to_fit();
 
-        std::vector<std::pair<int,std::string>> v;
-        for (auto& kv : mp) v.emplace_back(kv.first, kv.second);
+        std::vector<std::pair<int, std::string>> v;
+        for (auto &kv: mp)
+            v.emplace_back(kv.first, kv.second);
 
-        REQUIRE(v == std::vector<std::pair<int,std::string>>{
-                {1,"a"}, {2,"b"}, {3,"c"}
+        REQUIRE(v == std::vector<std::pair<int, std::string>>{
+                {1, "a"},
+                {2, "b"},
+                {3, "c"}
         });
     }
+}
+
+TEST_CASE("string ordered_map basic ordering and uniqueness") {
+    ordered_map<std::string, int> mp;
+
+    mp.emplace("banana", 1);
+    mp.emplace("apple", 2);
+    mp.emplace("date", 3);
+    mp.emplace("cherry", 4);
+
+    REQUIRE(mp.size() == 4);
+
+    std::vector<std::pair<std::string, int>> from_map;
+    for (const auto &[k, v]: mp)
+        from_map.emplace_back(k, v);
+
+    std::vector<std::pair<std::string, int>> expected = {
+            {"banana", 1},
+            {"apple",  2},
+            {"date",   3},
+            {"cherry", 4}
+    };
+
+    std::stable_sort(expected.begin(), expected.end(),
+                     [](const auto &a, const auto &b) {
+                         return a.first < b.first;
+                     });
+
+    REQUIRE(from_map == expected);
+}
+
+TEST_CASE("string-int map random stress vs std::map") {
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+
+    std::uniform_int_distribution<int> dist_val(0, 100000);
+    std::uniform_int_distribution<int> dist_key(0, 100000);
+
+    auto make_key = [](int x) {
+        return "key_" + std::to_string(x);
+    };
+
+    ordered_map<std::string, int> mp;
+    std::map<std::string, int> stdmp;
+
+    for (int i = 0; i < 20000; i++) {
+        auto k = make_key(dist_key(gen));
+        int v = dist_val(gen);
+
+        mp.insert_or_assign(k, v);
+        stdmp.insert_or_assign(k, v);
+
+        if (i % 10 == 0) {
+            auto k2 = make_key(dist_key(gen));
+            mp.erase(k2);
+            stdmp.erase(k2);
+        }
+    }
+
+    std::vector<std::pair<std::string, int>> a, b;
+
+    for (auto &kv: mp) a.emplace_back(kv.first, kv.second);
+    for (auto &kv: stdmp) b.emplace_back(kv.first, kv.second);
+
+    REQUIRE(a == b);
 }

--- a/tests/test_pod_sys.cpp
+++ b/tests/test_pod_sys.cpp
@@ -94,6 +94,14 @@ TEST_CASE("JH PODS Recognition And Static Checks") {
     STATIC_REQUIRE(a == c);
     STATIC_REQUIRE(a <= c);
     STATIC_REQUIRE(a >= c);
+    constexpr auto s1 = "hello"_psv;
+    static_assert(s1.semantic_len() == 5);
+
+    constexpr auto s2 = "\U00004F60\U0000597D"_psv;
+    static_assert(s2.semantic_len() == 2);
+
+    constexpr auto s3 = "\U0001F30D"_psv;
+    static_assert(s3.semantic_len() == 1);
 }
 
 TEST_CASE("JH_POD_STRUCT generated struct is pod_like") {
@@ -252,7 +260,7 @@ TEST_CASE("bytes_view basic reinterpret and comparison") {
         pod::array<int, 3> arr = {10, 20, 30};
         auto view = pod::bytes_view::from(arr.data, pod::array<int, 3>::size());
 
-        auto clone = view.clone<pod::array<int, 3> >();
+        auto clone = view.clone<pod::array<int, 3> >(); // NOLINT
         REQUIRE(clone[0] == 10);
         REQUIRE(clone[1] == 20);
         REQUIRE(clone[2] == 30);
@@ -278,7 +286,7 @@ TEST_CASE("bytes_view basic reinterpret and comparison") {
 
         std::array<std::byte, 2> too_small{};
         auto view = pod::bytes_view{too_small.data(), too_small.size()};
-        const auto [a, b] = view.clone<PodTest>();
+        const auto [a, b] = view.clone<PodTest>(); // NOLINT
 
         REQUIRE(a == 0);
         REQUIRE(b == 0.0f);
@@ -291,7 +299,7 @@ TEST_CASE("bytes_view clone from std::array to pod::array") {
     std::iota(original.begin(), original.end(), 100); // Fill with 100, 101, ..., 163
 
     const auto view = pod::bytes_view::from(original.data(), original.size());
-    auto cloned = view.clone<pod::array<std::uint32_t, N> >();
+    auto cloned = view.clone<pod::array<std::uint32_t, N> >(); // NOLINT
 
     REQUIRE(cloned.size() == N);
     for (std::size_t i = 0; i < N; ++i) {

--- a/tests/test_pool.cpp
+++ b/tests/test_pool.cpp
@@ -7,47 +7,73 @@
 #include <thread>
 
 /**
- * @file
- * @brief Tests for <code>jh::observe_pool</code> and <code>jh::conc::pointer_pool</code> including multithreading,
- *        expansion, shrinkage, and cleanup behavior.
+ * @brief Tests for pooling facilities:
+ *        <code>jh::observe_pool</code>,
+ *        <code>jh::conc::pointer_pool</code>,
+ *        <code>jh::resource_pool</code>,
+ *        and <code>jh::resource_pool_set</code>.
  *
  * @details
- * This test suite validates the behavior of <code>jh::observe_pool</code> and <code>jh::conc::pointer_pool</code> across
- * multiple usage patterns: basic acquisition, expansion and contraction, cleanup behavior,
- * move semantics, and multi-threaded correctness checks.
+ * This suite validates acquisition, reuse, cleanup, resizing,
+ * move semantics, and multi-threaded correctness.
  *
- * <b>Windows (MinGW) shared_ptr behavior</b><br>
- * MinGW-w64's <code>std::shared_ptr</code> implementation under libstdc++ has known concurrency-related
- * issues. In particular, reference count modifications are not reliably atomic on Windows when using
- * MinGW-w64. This may result in premature destruction of pooled objects during multi-threaded tests.
+ * <hr>
+ * <b>Windows / MinGW Concurrency Limitations</b>
  *
- * Consequently, on Windows (MinGW) platforms, this test suite does not perform strict validation of
- * conditions such as:
+ * On Windows (MinGW-w64 + libstdc++), rare ordering anomalies may occur
+ * under high concurrency. This affects not only
+ * <code>observe_pool</code>, but all pool variants.
  *
- * <pre><code>
- * pool.size() == OBJECTS_PER_THREAD * THREADS
- * </code></pre>
+ * Even when atomics use <code>memory_order_seq_cst</code>,
+ * global ordering is not reliably preserved in stress conditions.
  *
- * because MinGW may spuriously drop reference counts during contention, causing the size reported by
- * the pool to be smaller than the number of shared pointers that should still be alive.
+ * Contributing factors include:
  *
- * <p><b>UCRT Debug Allocator Behavior</b></p>
- * The Microsoft UCRT debug allocator introduces further inconsistencies during validation, including
- * false positives for memory misuse that do not occur on other platforms. To avoid allocator-related
- * interference, the Windows test configuration is executed in release mode.
+ * <ul>
+ *   <li>atomic operations (including shared_ptr reference counting)</li>
+ *   <li>shared_mutex implementations</li>
+ *   <li>thread scheduling behavior</li>
+ *   <li>test framework interception of std::thread</li>
+ * </ul>
  *
- * Earlier attempts to disable the UCRT debug allocator through injection were found to be unreliable
- * and have been fully removed. The current approach is stable and prevents platform-specific allocator
- * diagnostics from corrupting test results.
+ * <hr>
+ * <b>posix_smtx_* Strengthening</b>
  *
- * @note
- * These Windows-specific limitations do not indicate any logical or correctness issues in
- * <code>jh::observe_pool</code> or <code>jh::conc::pointer_pool</code>. All strict checks continue to apply on
- * non-Windows platforms.
+ * Newer versions introduce:
  *
- * @warning
- * The behavior described above is specific to MinGW-w64 and its interaction with libstdc++ on Windows.
- * It does not affect Linux or macOS.
+ * <ul>
+ *   <li><code>jh::sync::posix_smtx_unique_lock</code></li>
+ *   <li><code>jh::sync::posix_smtx_shared_lock</code></li>
+ * </ul>
+ *
+ * On Windows, these insert sequentially-consistent fences around
+ * lock boundaries to approximate POSIX ordering.
+ *
+ * This mitigates shared_mutex-related reordering,
+ * but cannot fully stabilize cross-domain interactions.
+ *
+ * <hr>
+ * <b>Test Policy</b>
+ *
+ * Due to CI resource constraints and platform-level ordering variance,
+ * high-concurrency stress tests are disabled on Windows.
+ *
+ * Windows builds are supported for:
+ *
+ * <ul>
+ *   <li>single-threaded usage</li>
+ *   <li>low-pressure multi-threaded scenarios</li>
+ * </ul>
+ *
+ * Full concurrency validation is guaranteed on POSIX
+ * platforms (Linux / Darwin), which remain the primary target.
+ *
+ * <hr>
+ * <b>Design Note</b>
+ *
+ * The pool modules rely on POSIX-style synchronization semantics.
+ * Restricting the design strictly to ISO minimal guarantees would
+ * significantly limit concurrency robustness and design flexibility.
  */
 
 namespace test {
@@ -518,6 +544,8 @@ TEST_CASE("resource_pool single-thread key-value") {
     REQUIRE(check1 == false);
 }
 
+#if !IS_WINDOWS
+
 TEST_CASE("resource_pool_set multithreading without storing ptr") {
     jh::resource_pool_set<int> pool;
     constexpr int total_tests = 128;
@@ -735,3 +763,4 @@ TEST_CASE("pmr resource_pool multithreading with duplicated keys") {
         }
     }
 }
+#endif

--- a/tests/test_pool.cpp
+++ b/tests/test_pool.cpp
@@ -18,62 +18,71 @@
  * move semantics, and multi-threaded correctness.
  *
  * <hr>
- * <b>Windows / MinGW Concurrency Limitations</b>
+ * <b>Concurrency Guarantees</b>
  *
- * On Windows (MinGW-w64 + libstdc++), rare ordering anomalies may occur
- * under high concurrency. This affects not only
- * <code>observe_pool</code>, but all pool variants.
+ * All pool implementations in this module are algorithmically
+ * data-race-free (DRF) and do not rely on undefined behavior under
+ * the ISO C++ memory model.
  *
- * Even when atomics use <code>memory_order_seq_cst</code>,
- * global ordering is not reliably preserved in stress conditions.
+ * Additional strengthening is applied on Windows builds via
+ * <code>std::atomic_thread_fence(std::memory_order_seq_cst)</code>
+ * around lock boundaries. This eliminates ISO-level UB risks and
+ * preserves correctness within the C++ abstract machine.
  *
- * Contributing factors include:
+ * <hr>
+ * <b>Windows / MinGW Runtime Characteristics</b>
  *
- * <ul>
- *   <li>atomic operations (including shared_ptr reference counting)</li>
- *   <li>shared_mutex implementations</li>
- *   <li>thread scheduling behavior</li>
- *   <li>test framework interception of std::thread</li>
- * </ul>
+ * On certain Windows configurations (e.g., MinGW-w64 with libstdc++
+ * and UCRT/MSVCRT), system-level synchronization primitives may not
+ * provide POSIX-equivalent global ordering behavior.
+ *
+ * Under extreme multi-core contention, rare visibility or reordering
+ * effects may be observed. These effects arise from platform runtime
+ * and kernel-level synchronization characteristics rather than from
+ * violations of the C++ standard.
+ *
+ * Such behavior does not indicate undefined behavior or data races
+ * within the pool implementations.
  *
  * <hr>
  * <b>posix_smtx_* Strengthening</b>
  *
- * Newer versions introduce:
+ * The following wrappers are used to approximate POSIX-style ordering:
  *
  * <ul>
  *   <li><code>jh::sync::posix_smtx_unique_lock</code></li>
  *   <li><code>jh::sync::posix_smtx_shared_lock</code></li>
  * </ul>
  *
- * On Windows, these insert sequentially-consistent fences around
- * lock boundaries to approximate POSIX ordering.
+ * On Windows, these introduce sequentially-consistent fences at
+ * lock boundaries to strengthen ordering at the language level.
  *
- * This mitigates shared_mutex-related reordering,
- * but cannot fully stabilize cross-domain interactions.
+ * While this improves practical stability, it cannot fully enforce
+ * hardware-level global ordering beyond what the platform provides.
  *
  * <hr>
  * <b>Test Policy</b>
  *
- * Due to CI resource constraints and platform-level ordering variance,
- * high-concurrency stress tests are disabled on Windows.
+ * Due to platform-level ordering variance and CI constraints,
+ * extreme high-concurrency stress tests are disabled on Windows.
  *
- * Windows builds are supported for:
+ * Windows builds are validated for:
  *
  * <ul>
  *   <li>single-threaded usage</li>
- *   <li>low-pressure multi-threaded scenarios</li>
+ *   <li>moderate multi-threaded workloads</li>
  * </ul>
  *
- * Full concurrency validation is guaranteed on POSIX
- * platforms (Linux / Darwin), which remain the primary target.
+ * Full high-pressure concurrency validation is performed on POSIX
+ * platforms (Linux / Darwin), which remain the primary reference
+ * environments.
  *
  * <hr>
  * <b>Design Note</b>
  *
- * The pool modules rely on POSIX-style synchronization semantics.
- * Restricting the design strictly to ISO minimal guarantees would
- * significantly limit concurrency robustness and design flexibility.
+ * The pool modules are engineered to be DRF and standards-compliant.
+ * Observed high-contention behavior differences stem from platform
+ * synchronization semantics rather than from algorithmic defects.
  */
 
 namespace test {
@@ -537,8 +546,8 @@ TEST_CASE("resource_pool single-thread key-value") {
     auto p4 = pool.acquire(3, std::forward_as_tuple("new"));
     REQUIRE(*p4->second == "new");
 
-    auto check0 = (pool.find(3) != nullptr);
-    auto check1 = (pool.find(1) != nullptr);
+    auto check0 = static_cast<bool>(pool.find(3));
+    auto check1 = static_cast<bool>(pool.find(1));
 
     REQUIRE(check0);
     REQUIRE(check1 == false);

--- a/tests/test_proc_cond.cpp
+++ b/tests/test_proc_cond.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch_all.hpp>
 
-#define JH_ALLOW_PARENT_PATH 1
+#define JH_INTERPROCESS_ALLOW_PARENT_PATH 1
 
 #include "jh/synchronous/ipc/process_cond_var.h"
 #include "jh/synchronous/ipc/process_launcher.h"

--- a/tests/test_proc_mapping.cpp
+++ b/tests/test_proc_mapping.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch_all.hpp>
 
-#define JH_ALLOW_PARENT_PATH 1
+#define JH_INTERPROCESS_ALLOW_PARENT_PATH 1
 
 #include "jh/synchronous/ipc/process_counter.h"
 #include "jh/synchronous/ipc/process_shm_obj.h"

--- a/tests/test_process_lock.cpp
+++ b/tests/test_process_lock.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch_all.hpp>
 
-#define JH_ALLOW_PARENT_PATH 1
+#define JH_INTERPROCESS_ALLOW_PARENT_PATH 1
 
 #include "jh/synchronous/ipc/process_mutex.h"
 #include "jh/synchronous/ipc/process_launcher.h"

--- a/tests/test_runtime_arr.cpp
+++ b/tests/test_runtime_arr.cpp
@@ -448,6 +448,12 @@ TEST_CASE("runtime_arr (bit-packed) vs (byte-based)") {
     std::vector<unsigned char> ref(N);
     for (auto &b: ref) { b = static_cast<unsigned char>(dist(gen) & 1); }
 
+#if IS_CLANG
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-lambda-capture"
+#endif
+// Capture &N is necessary for GCC to allow usage inside the lambda, even though it's not modified.
+
     BENCHMARK_ADVANCED("bit-packed set() loop (1M bits)")() {
             runtime_arr<bool> bits(N); // Prepare phase
             return [bits = std::move(bits), &ref, &N]() mutable {
@@ -489,6 +495,10 @@ TEST_CASE("runtime_arr (bit-packed) vs (byte-based)") {
                 (void) sum;
             };
         };
+
+#if IS_CLANG
+#pragma clang diagnostic pop
+#endif
 
     BENCHMARK_ADVANCED("bit-packed reset_all()")() {
             runtime_arr<bool> bits(N);

--- a/tests/test_runtime_arr.cpp
+++ b/tests/test_runtime_arr.cpp
@@ -630,3 +630,83 @@ TEST_CASE("runtime_arr<int, std::allocator<double>> rebind behavior", "[alloc][r
         REQUIRE(vec[3] == 8);
     }
 }
+
+TEST_CASE("runtime_arr allocator-aware constructors from vector and iterators", "[alloc][vector][iterator]") {
+
+    SECTION("vector with different allocator -> runtime_arr with custom allocator") {
+
+        using VecAlloc = std::allocator<int>;
+        using ArrAlloc = test_allocator<int>;
+
+        std::vector<int, VecAlloc> vec{1,2,3,4,5};
+
+        runtime_arr<int, ArrAlloc> arr(std::move(vec), ArrAlloc{});
+
+        REQUIRE(arr.size() == 5);
+        for (int i = 0; i < 5; ++i)
+            REQUIRE(arr[i] == i + 1);
+    }
+
+    SECTION("vector with pmr allocator -> runtime_arr with std::allocator") {
+
+        std::pmr::monotonic_buffer_resource res;
+
+        std::vector<int, std::pmr::polymorphic_allocator<int>> vec(
+                {10,20,30,40},
+                std::pmr::polymorphic_allocator<int>(&res)
+        );
+
+        runtime_arr<int, std::allocator<int>> arr(std::move(vec), std::allocator<int>{});
+
+        REQUIRE(arr.size() == 4);
+        REQUIRE(arr[0] == 10);
+        REQUIRE(arr[3] == 40);
+    }
+
+    SECTION("vector<T, Alloc> constructor using vec.get_allocator()") {
+
+        std::pmr::monotonic_buffer_resource res;
+
+        std::vector<int, std::pmr::polymorphic_allocator<int>> vec(
+                {7,8,9},
+                std::pmr::polymorphic_allocator<int>(&res)
+        );
+
+        runtime_arr<int, std::pmr::polymorphic_allocator<int>> arr(std::move(vec));
+
+        REQUIRE(arr.size() == 3);
+        REQUIRE(arr[0] == 7);
+        REQUIRE(arr[2] == 9);
+    }
+
+    SECTION("iterator + allocator constructor") {
+
+        std::vector<int> src{11,22,33,44};
+
+        runtime_arr<int, test_allocator<int>> arr(
+                src.begin(),
+                src.end(),
+                test_allocator<int>{}
+        );
+
+        REQUIRE(arr.size() == 4);
+        REQUIRE(arr[0] == 11);
+        REQUIRE(arr[3] == 44);
+    }
+
+    SECTION("iterator + allocator reset_all behavior") {
+
+        std::vector<int> src{5,6,7};
+
+        runtime_arr<int, test_allocator<int>> arr(
+                src.begin(),
+                src.end(),
+                test_allocator<int>{}
+        );
+
+        arr.reset_all();
+
+        for (int i : arr)
+            REQUIRE(i == 0);
+    }
+}

--- a/tests/test_runtime_arr.cpp
+++ b/tests/test_runtime_arr.cpp
@@ -3,6 +3,7 @@
 #include <memory_resource>
 #include <ranges>
 #include "jh/runtime_arr"
+#include "jh/macros/platform.h"
 #include <tuple>
 #include <memory>
 #include <vector>
@@ -368,6 +369,12 @@ TEST_CASE("Advanced Benchmark: runtime_arr vs std::vector<MyPod> (1024x)") {
         int_vals.emplace_back(id_dist(gen));
     }
 
+#if IS_CLANG
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-lambda-capture"
+#endif
+// Capture &N is necessary for GCC to allow usage inside the lambda, even though it's not modified.
+
     BENCHMARK_ADVANCED("std::vector<MyPod> by construction (1024x)")() {
             std::vector<MyPod> buffer(N);
             return [buffer = std::move(buffer), &inputs, &N]() mutable {
@@ -426,6 +433,11 @@ TEST_CASE("Advanced Benchmark: runtime_arr vs std::vector<MyPod> (1024x)") {
                 }
             };
         };
+
+#if IS_CLANG
+#pragma clang diagnostic pop
+#endif
+
 }
 
 TEST_CASE("runtime_arr (bit-packed) vs (byte-based)") {
@@ -531,7 +543,8 @@ TEST_CASE("runtime_arr initializer_list construction", "[initlist]") {
 
     SECTION("flat bool version (byte-based allocator)") {
         using jh::runtime_arr_helper::bool_flat_alloc;
-        runtime_arr<bool, bool_flat_alloc> arr{{true, false, false, true}, {}};
+        runtime_arr<bool, bool_flat_alloc> arr{{true, false, false, true},
+                                               {}};
         REQUIRE(arr.size() == 4);
         REQUIRE(arr[0]);
         REQUIRE_FALSE(arr[1]);

--- a/tests/test_t_str.cpp
+++ b/tests/test_t_str.cpp
@@ -6,7 +6,8 @@ using namespace jh::meta;
 
 namespace test {
     template<TStr S>
-    struct tag {};
+    struct tag {
+    };
 }
 
 /**
@@ -141,7 +142,7 @@ TEST_CASE("t_str hex/base64/base64url checks") {
 TEST_CASE("t_str NTTP type identity") {
     using Foo1 = test::tag<"foo">;
     using Foo2 = test::tag<"foo">;
-    using Bar  = test::tag<"bar">;
+    using Bar = test::tag<"bar">;
 
     STATIC_REQUIRE(std::is_same_v<Foo1, Foo2>);
     STATIC_REQUIRE_FALSE(std::is_same_v<Foo1, Bar>);
@@ -258,5 +259,211 @@ TEST_CASE("t_str to_bytes/from_bytes conversion") {
         auto modified = t_str<6>::from_bytes(bytes);
         REQUIRE(modified.view() == "Abcde");
         REQUIRE(modified != s);
+    }
+}
+/**
+ * @test Substring operations: sub / sub_view / sub_pod_view.
+ *
+ * <ul>
+ *   <li>Compile-time substring extraction using <code>sub</code>.</li>
+ *   <li>Default Count (-1) meaning "to end".</li>
+ *   <li>Verify <code>sub_view()</code> and <code>sub_pod_view().to_std()</code> equivalence.</li>
+ *   <li>Ensure <code>sub()</code> is usable in NTTP contexts.</li>
+ * </ul>
+ */
+TEST_CASE("t_str substring operations") {
+
+    constexpr t_str s("hello_world");
+
+    /**
+     * Compile-time substring checks using sub()
+     */
+    {
+        constexpr auto sub = s.sub<0, 5>();
+        STATIC_REQUIRE(sub == "hello");
+        STATIC_REQUIRE(sub.size() == 5);
+    }
+
+    {
+        constexpr auto sub = s.sub<6, 5>();
+        STATIC_REQUIRE(sub == "world");
+        STATIC_REQUIRE(sub.size() == 5);
+    }
+
+    /**
+     * Default Count = -1 (substring until end)
+     */
+    {
+        constexpr auto sub = s.sub<6>();
+        STATIC_REQUIRE(sub == "world");
+    }
+
+    {
+        constexpr auto sub = s.sub<0>();
+        STATIC_REQUIRE(sub == "hello_world");
+    }
+
+    /**
+     * Runtime view validation
+     */
+    {
+        auto v = s.sub_view<0, 5>();
+        REQUIRE(v == "hello");
+    }
+
+    {
+        auto v = s.sub_view<6>();
+        REQUIRE(v == "world");
+    }
+
+    /**
+     * sub_view vs sub_pod_view equivalence
+     */
+    {
+        auto v1 = s.sub_view<0, 5>();
+        auto v2 = s.sub_pod_view<0, 5>().to_std();
+
+        REQUIRE(v1 == v2);
+        REQUIRE(v1 == "hello");
+    }
+
+    {
+        auto v1 = s.sub_view<6>();
+        auto v2 = s.sub_pod_view<6>().to_std();
+
+        REQUIRE(v1 == v2);
+        REQUIRE(v1 == "world");
+    }
+
+    /**
+     * NTTP usage of sub()
+     */
+    {
+        using HelloTag = test::tag<s.sub<0, 5>()>;
+        using HelloTag2 = test::tag<"hello">;
+
+        STATIC_REQUIRE(std::is_same_v<HelloTag, HelloTag2>);
+    }
+
+    /**
+     * Runtime substring check
+     */
+    {
+        t_str runtime("run_time");
+
+        auto sub = runtime.sub<4, 4>();
+        REQUIRE(sub.view() == "time");
+
+        auto v1 = runtime.sub_view<4, 4>();
+        auto v2 = runtime.sub_pod_view<4, 4>().to_std();
+
+        REQUIRE(v1 == "time");
+        REQUIRE(v1 == v2);
+    }
+}
+
+/**
+ * @test Boundary conditions for substring extraction.
+ *
+ * <ul>
+ *   <li>Zero-length substring.</li>
+ *   <li>Substring at last character.</li>
+ *   <li>Full-string extraction.</li>
+ * </ul>
+ */
+TEST_CASE("t_str substring boundary cases") {
+
+    constexpr t_str s("hello_world");
+
+    /**
+     * sub<0,0>() → empty string
+     */
+    {
+        constexpr auto sub = s.sub<0, 0>();
+        STATIC_REQUIRE(sub.size() == 0);
+        STATIC_REQUIRE(sub == "");
+    }
+
+    /**
+     * sub<N-1,0>() → empty at end
+     */
+    {
+        constexpr auto sub = s.sub<11, 0>();
+        STATIC_REQUIRE(sub.size() == 0);
+        STATIC_REQUIRE(sub == "");
+    }
+
+    /**
+     * last character
+     */
+    {
+        constexpr auto sub = s.sub<10, 1>();
+        STATIC_REQUIRE(sub == "d");
+    }
+
+    /**
+     * full string extraction
+     */
+    {
+        constexpr auto sub = s.sub<0, 11>();
+        STATIC_REQUIRE(sub == "hello_world");
+    }
+
+    /**
+     * view consistency
+     */
+    {
+        auto v1 = s.sub_view<0, 11>();
+        constexpr auto substring = s.sub<0, 11>();
+        auto v2 = substring.view();
+
+        REQUIRE(v1 == v2);
+    }
+}
+
+/**
+ * @test Verify that Count=-1 and default Count behave identically.
+ */
+TEST_CASE("t_str substring default count equals -1") {
+
+    constexpr t_str s("hello_world");
+
+    {
+        constexpr auto a = s.sub<0>();
+        constexpr auto b = s.sub<0, static_cast<std::uint16_t>(-1)>();
+
+        STATIC_REQUIRE(a == b);
+        STATIC_REQUIRE(a == "hello_world");
+    }
+
+    {
+        constexpr auto a = s.sub<6>();
+        constexpr auto b = s.sub<6, static_cast<std::uint16_t>(-1)>();
+
+        STATIC_REQUIRE(a == b);
+        STATIC_REQUIRE(a == "world");
+    }
+
+    /**
+     * runtime view check
+     */
+    {
+        auto v1 = s.sub_view<6>();
+        auto v2 = s.sub_view<6, static_cast<std::uint16_t>(-1)>();
+
+        REQUIRE(v1 == v2);
+        REQUIRE(v1 == "world");
+    }
+
+    /**
+     * pod_view equivalence
+     */
+    {
+        using namespace jh::pod::literals;
+        auto p1 = s.sub_pod_view<6>();
+        auto p2 = s.sub_pod_view<6, static_cast<std::uint16_t>(-1)>();
+
+        REQUIRE(p1 == p2);
+        REQUIRE(p1 == "world"_psv);
     }
 }

--- a/tests/test_uri.cpp
+++ b/tests/test_uri.cpp
@@ -24,7 +24,9 @@ TEST_CASE("URI Encode/Decode Roundtrip", "[uri]") {
             for (auto &b : input)
                 b = byte_dist(gen);
 
-            std::string raw(reinterpret_cast<char*>(input.data()), input.size());
+            const auto bv = jh::pod::bytes_view::from(input);
+
+            std::string raw(bv.fetch<const char>(), bv.size());
 
             const std::string encoded = jh::serio::uri::encode(raw);
             const std::string decoded = jh::serio::uri::decode(encoded);

--- a/tests/test_uri.cpp
+++ b/tests/test_uri.cpp
@@ -1,0 +1,154 @@
+#include <random>
+#include <catch2/catch_all.hpp>
+
+#include "jh/serio"
+
+TEST_CASE("URI Encode/Decode Roundtrip", "[uri]") {
+
+    std::random_device rd;
+    std::mt19937 gen(rd());
+
+    std::uniform_int_distribution<uint8_t> byte_dist(0, 255);
+    std::uniform_int_distribution<size_t> len_dist(1, 256);
+
+    constexpr int total_tests = 256;
+
+    for (int i = 0; i < total_tests; ++i) {
+
+        SECTION("Randomized URI Test " + std::to_string(i + 1)) {
+
+            const std::size_t len = len_dist(gen);
+
+            std::vector<uint8_t> input(len);
+
+            for (auto &b : input)
+                b = byte_dist(gen);
+
+            std::string raw(reinterpret_cast<char*>(input.data()), input.size());
+
+            const std::string encoded = jh::serio::uri::encode(raw);
+            const std::string decoded = jh::serio::uri::decode(encoded);
+
+            REQUIRE(decoded == raw);
+        }
+    }
+}
+
+TEST_CASE("URI Encode/Decode Known Pairs", "[uri]") {
+
+    struct Pair {
+        std::string raw;
+        std::string encoded;
+    };
+
+    const std::vector<Pair> pairs = {
+
+            {"", ""},
+
+            {"abc", "abc"},
+
+            {"Hello World", "Hello%20World"},
+
+            {"Hello+World", "Hello%2BWorld"},
+
+            {"a/b?c=d&e=f", "a%2Fb%3Fc%3Dd%26e%3Df"},
+
+            {"100%", "100%25"},
+
+            {"#fragment", "%23fragment"},
+
+            {"A B C", "A%20B%20C"},
+    };
+
+    for (const auto &p : pairs) {
+
+        SECTION("Encode matches expected: " + p.raw) {
+            REQUIRE(jh::serio::uri::encode(p.raw) == p.encoded);
+        }
+
+        SECTION("Decode roundtrip: " + p.raw) {
+            REQUIRE(jh::serio::uri::decode(p.encoded) == p.raw);
+        }
+    }
+}
+
+TEST_CASE("URI Invalid Percent Encoding Detection", "[uri][error]") {
+
+    using namespace jh::serio::uri;
+
+    SECTION("Incomplete percent encoding") {
+        REQUIRE_THROWS_AS(decode("%"), std::runtime_error);
+        REQUIRE_THROWS_AS(decode("%A"), std::runtime_error);
+        REQUIRE_THROWS_AS(decode("abc%"), std::runtime_error);
+    }
+
+    SECTION("Invalid hex digits") {
+        REQUIRE_THROWS_AS(decode("%GG"), std::runtime_error);
+        REQUIRE_THROWS_AS(decode("%1G"), std::runtime_error);
+        REQUIRE_THROWS_AS(decode("%G1"), std::runtime_error);
+    }
+
+    SECTION("Invalid URI characters") {
+        std::string bad = "abc";
+        bad.push_back('\x01');
+        bad += "def";
+
+        REQUIRE_THROWS_AS(decode(bad), std::runtime_error);
+    }
+}
+
+TEST_CASE("URI URL-safe Encode legality checks", "[uri][url]") {
+
+    using namespace jh::serio::uri;
+
+    SECTION("Valid UTF-8 passes") {
+
+        std::string input = "Hello World";
+
+        const auto encoded = encode_safe(input);
+        const auto decoded = decode_safe(encoded);
+
+        REQUIRE(decoded == input);
+    }
+
+    SECTION("Control characters rejected") {
+
+        std::string bad = "abc";
+        bad.push_back('\x01');
+
+        REQUIRE_THROWS_AS(encode_safe(bad), std::runtime_error);
+    }
+
+    SECTION("Illegal UTF-8 rejected") {
+
+        std::string bad;
+        bad.push_back(char(0xC3));
+        bad.push_back(char(0x28)); // invalid UTF-8 sequence
+
+        REQUIRE_THROWS_AS(encode_safe(bad), std::runtime_error);
+    }
+}
+
+TEST_CASE("URI decode handles lowercase hex", "[uri]") {
+
+    using namespace jh::serio::uri;
+
+    REQUIRE(decode("Hello%20World") == "Hello World");
+    REQUIRE(decode("Hello%20world") == "Hello world");
+
+    REQUIRE(decode("%2f") == "/");
+    REQUIRE(decode("%2F") == "/");
+}
+
+TEST_CASE("URI decode with embedded nulls", "[uri][edge]") {
+
+    using namespace jh::serio::uri;
+
+    std::string raw = std::string("A\0B",3);
+
+    const auto encoded = encode(raw);
+    const auto decoded = decode(encoded);
+
+    REQUIRE(decoded.size() == raw.size());
+    REQUIRE(decoded == raw);
+}

--- a/version_badge.json
+++ b/version_badge.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "label": "JH-Toolkit",
-  "message": "1.4.0",
+  "message": "1.4.1",
   "labelColor": "#555555",
   "namedLogo": "github",
   "color": "#559900",


### PR DESCRIPTION
### What problem does this PR solve / What is new in this PR?

This PR performs an early merge from `1.4.1-dev` into `main` to deliver a critical hotfix identified by @waltonR1.

The issue affects `jh::ordered_map` when using non-trivial key types (e.g., `std::string`). During insertion, comparisons could be performed on moved-from objects, leading to inconsistent iteration results and incorrect ordering.

This PR includes:

* Fix for comparison semantics in `ordered_map` insertion logic
* Regression tests contributed by @waltonR1
* New usage example: `examples/example_ordered_map.cpp`

In addition, previously validated 1.4.1 changes (examples, `jh::serio::url`, tests, and documentation) are included as part of the branch state and will be introduced into `main` through this merge. These changes are not the focus of this PR and will be formally documented during the 1.4.1 release.

---

### Is the PR backed by CI tests?

Yes.

* All existing tests pass
* New regression tests from @waltonR1 are included and passing
* Behavior verified against `std::map` under stress scenarios

---

### Any breaking changes?

No.

This fix restores expected behavior and aligns implementation with documented semantics without introducing API or behavioral breaking changes.

---

### Notes

* This is a hotfix-driven early merge from `1.4.1-dev` into `main`
* The 1.4.1 release is still in progress and not finalized
* Full feature documentation and release notes will be provided with the official 1.4.1 release

Closes #30